### PR TITLE
Local user management API enhancements

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/users/interfaces/GroupResource.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/users/interfaces/GroupResource.java
@@ -21,6 +21,7 @@ package com.tle.web.api.users.interfaces;
 import com.tle.web.api.interfaces.beans.SearchBean;
 import com.tle.web.api.interfaces.beans.UserBean;
 import com.tle.web.api.users.interfaces.beans.GroupBean;
+import com.tle.web.api.users.interfaces.beans.UsersAndGroupsBean;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -69,4 +70,12 @@ public interface GroupResource {
   @Path("/")
   @ApiOperation("Add a group")
   public Response addGroup(@ApiParam GroupBean group);
+
+  @POST
+  @Path("/assign")
+  @ApiOperation("Add users to groups")
+  public Response assignGroups(
+      @ApiParam UsersAndGroupsBean group,
+      @ApiParam("Remove the users from their other groups") @QueryParam("removeOthers")
+          boolean removeOthers);
 }

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/users/interfaces/UserResource.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/users/interfaces/UserResource.java
@@ -76,6 +76,7 @@ public interface UserResource {
       @Context UriInfo uriInfo,
       @ApiParam(required = false) @QueryParam("q") String query,
       @ApiParam(required = false) @QueryParam("group") String parentGroupId,
+      @ApiParam(required = false) @QueryParam("length") Integer length,
       @ApiParam(
               value = "Search the specified group's child groups as well",
               required = false,

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/users/interfaces/beans/UsersAndGroupsBean.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/users/interfaces/beans/UsersAndGroupsBean.java
@@ -16,29 +16,28 @@
  * limitations under the License.
  */
 
-package com.tle.core.remoting;
+package com.tle.web.api.users.interfaces.beans;
 
-import com.tle.beans.user.TLEUser;
-import java.util.List;
+import java.util.Set;
 
-public interface RemoteTLEUserService {
-  String add(TLEUser newUser);
+public class UsersAndGroupsBean {
 
-  String add(TLEUser newUser, boolean passwordNotHashed);
+  private Set<String> users;
+  private Set<String> groups;
 
-  String add(TLEUser newUser, List<String> groups);
+  public void setGroups(Set<String> groups) {
+    this.groups = groups;
+  }
 
-  String add(String username, List<String> groups);
+  public void setUsers(Set<String> users) {
+    this.users = users;
+  }
 
-  TLEUser get(String id);
+  public Set<String> getGroups() {
+    return groups;
+  }
 
-  TLEUser getByUsername(String username);
-
-  String edit(TLEUser user, boolean passwordNotHashed);
-
-  void delete(String uuid);
-
-  List<TLEUser> searchUsers(String query, String parentGroupID, boolean recursive);
-
-  List<TLEUser> searchUsers(String query, String parentGroupID, int max, boolean recursive);
+  public Set<String> getUsers() {
+    return users;
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -4510,3 +4510,4 @@ activation.access.denied.percent=You must have the COPYRIGHT_OVERRIDE privilege 
 activation.access.denied.message=Potential copyright breach. You must supply a overrideMessage parameter
 course.edit.validation.codeinuse=Course with code ''{0}'' already exists.
 impexp.entities=Additional Entities
+userapi.differentid=If you supply an id, it must match the id in the url path

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/dao/TLEUserDao.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/dao/TLEUserDao.java
@@ -29,7 +29,8 @@ public interface TLEUserDao extends GenericDao<TLEUser, Long> {
 
   List<TLEUser> listAllUsers();
 
-  List<TLEUser> searchUsersInGroup(String likeQuery, String parentGroupID, boolean recurse);
+  List<TLEUser> searchUsersInGroup(
+      String likeQuery, String parentGroupID, int max, boolean recurse);
 
   void deleteAll();
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/dao/impl/TLEUserDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/dao/impl/TLEUserDaoImpl.java
@@ -69,7 +69,7 @@ public class TLEUserDaoImpl extends GenericDaoImpl<TLEUser, Long> implements TLE
   @Override
   @SuppressWarnings("unchecked")
   public List<TLEUser> searchUsersInGroup(
-      String userQuery, final String parentGroupID, boolean recurse) {
+      String userQuery, final String parentGroupID, int max, boolean recurse) {
     // Prep the query by converting all *'s to %'s and lowercase it.
     userQuery = userQuery.replace('*', '%').toLowerCase();
 
@@ -124,6 +124,7 @@ public class TLEUserDaoImpl extends GenericDaoImpl<TLEUser, Long> implements TLE
                 if (!Check.isEmpty(parentGroupID)) {
                   query.setParameter("groupID", parentGroupID);
                 }
+                query.setMaxResults(max);
 
                 return query.list();
               }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/service/TLEGroupService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/service/TLEGroupService.java
@@ -20,6 +20,7 @@ package com.tle.core.usermanagement.standard.service;
 
 import com.tle.beans.user.TLEGroup;
 import com.tle.core.remoting.RemoteTLEGroupService;
+import java.util.Collection;
 import java.util.List;
 
 public interface TLEGroupService extends RemoteTLEGroupService {
@@ -38,4 +39,7 @@ public interface TLEGroupService extends RemoteTLEGroupService {
   void removeAllUsersFromGroup(String groupUuid);
 
   String prepareQuery(String searchString);
+
+  void assignUsersToGroups(
+      Collection<String> groups, Collection<String> users, boolean removeExisting);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/service/impl/TLEGroupServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/service/impl/TLEGroupServiceImpl.java
@@ -419,4 +419,18 @@ public class TLEGroupServiceImpl
 
     return searchString;
   }
+
+  @Override
+  @Transactional
+  @RequiresPrivilege(priv = "EDIT_USER_MANAGEMENT")
+  public void assignUsersToGroups(
+      Collection<String> groups, Collection<String> users, boolean removeOthers) {
+    if (removeOthers) {
+      users.forEach(u -> dao.getGroupsContainingUser(u).forEach(g -> g.getUsers().remove(u)));
+    }
+    List<TLEGroup> groupsToEdit = dao.getInformationForGroups(groups);
+    for (TLEGroup group : groupsToEdit) {
+      group.getUsers().addAll(users);
+    }
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/service/impl/TLEUserServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/service/impl/TLEUserServiceImpl.java
@@ -28,7 +28,6 @@ import com.tle.common.beans.exception.InvalidDataException;
 import com.tle.common.beans.exception.NotFoundException;
 import com.tle.common.beans.exception.ValidationError;
 import com.tle.common.hash.Hash;
-import com.tle.common.i18n.CurrentLocale;
 import com.tle.common.institution.CurrentInstitution;
 import com.tle.common.security.SecurityConstants;
 import com.tle.common.security.SecurityConstants.Recipient;
@@ -44,6 +43,7 @@ import com.tle.core.events.listeners.GroupChangedListener;
 import com.tle.core.events.listeners.UserChangeListener;
 import com.tle.core.events.services.EventService;
 import com.tle.core.guice.Bind;
+import com.tle.core.i18n.CoreStrings;
 import com.tle.core.security.impl.RequiresPrivilege;
 import com.tle.core.services.ValidationHelper;
 import com.tle.core.services.user.UserService;
@@ -141,9 +141,14 @@ public class TLEUserServiceImpl
   }
 
   @Override
-  @Transactional
   public List<TLEUser> searchUsers(String query, String parentGroupID, boolean recursive) {
-    return dao.searchUsersInGroup(query, parentGroupID, recursive);
+    return searchUsers(query, parentGroupID, Integer.MAX_VALUE, recursive);
+  }
+
+  @Override
+  @Transactional
+  public List<TLEUser> searchUsers(String query, String parentGroupID, int max, boolean recursive) {
+    return dao.searchUsersInGroup(query, parentGroupID, max, recursive);
   }
 
   @Override
@@ -276,9 +281,7 @@ public class TLEUserServiceImpl
     // Make sure we have a valid email address
     if (!Check.isEmpty(user.getEmailAddress())
         && !emailService.isValidAddress(user.getEmailAddress())) {
-      errors.add(
-          new ValidationError(
-              "email", CurrentLocale.get("com.tle.web.userdetails.common.invalidemail")));
+      errors.add(new ValidationError("email", CoreStrings.text("common.invalidemail")));
     }
 
     validatePassword(user.getPassword(), passwordNotHashed, errors);
@@ -307,9 +310,7 @@ public class TLEUserServiceImpl
     if (passwordNotHashed) {
       int len = password == null ? 0 : password.length();
       if (len < PASSWORD_MIN_LENGTH) {
-        errors.add(
-            new ValidationError(
-                "password", CurrentLocale.get("com.tle.web.userdetails.common.passwordtooshort")));
+        errors.add(new ValidationError("password", CoreStrings.text("common.passwordtooshort")));
       }
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/usermanagement/GroupManagementResourceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/usermanagement/GroupManagementResourceImpl.java
@@ -31,6 +31,7 @@ import com.tle.exceptions.AccessDeniedException;
 import com.tle.web.api.interfaces.beans.SearchBean;
 import com.tle.web.api.interfaces.beans.UserBean;
 import com.tle.web.api.users.interfaces.beans.GroupBean;
+import com.tle.web.api.users.interfaces.beans.UsersAndGroupsBean;
 import com.tle.web.remoting.rest.service.RestImportExportHelper;
 import com.tle.web.remoting.rest.service.UrlLinkService;
 import io.swagger.annotations.ApiOperation;
@@ -302,5 +303,11 @@ public class GroupManagementResourceImpl implements EquellaGroupResource {
     return urlLinkService
         .getMethodUriBuilder(EquellaGroupResource.class, "getGroup")
         .build(userUuid);
+  }
+
+  @Override
+  public Response assignGroups(UsersAndGroupsBean group, boolean removeOthers) {
+    tleGroupService.assignUsersToGroups(group.getGroups(), group.getUsers(), removeOthers);
+    return Response.noContent().build();
   }
 }


### PR DESCRIPTION
Just some minor enhancements to the API to make it possible for a basic local user management interface outside of the Admin console.

* Support a maximum limit on users returned from search
* Return the failed validation data as JSON for create/edit of users
* Support setting passwords that aren't pre-hashed
* New group API for assigning a list of users to a list of groups
* Return the UUID of a created user in an X-UUID header (this header is used elsewhere in openEQUELLA)
