### PR TITLE
Fix ECS registration token issue

### DIFF
--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/impl/ReplicatedCacheServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/impl/ReplicatedCacheServiceImpl.java
@@ -144,7 +144,9 @@ public class ReplicatedCacheServiceImpl
     @Override
     public synchronized Optional<V> get(@NonNull String key) {
       checkNotNull(key);
-      cache.refresh(CurrentInstitution.get());
+      if (zookeeperService.isCluster()) {
+        cache.refresh(CurrentInstitution.get());
+      }
 
       LoadingCache<String, Optional<ExpiringValue<V>>> c =
           cache.getIfPresent(CurrentInstitution.get());

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/impl/ReplicatedCacheServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/impl/ReplicatedCacheServiceImpl.java
@@ -144,6 +144,7 @@ public class ReplicatedCacheServiceImpl
     @Override
     public synchronized Optional<V> get(@NonNull String key) {
       checkNotNull(key);
+      cache.refresh(CurrentInstitution.get());
 
       LoadingCache<String, Optional<ExpiringValue<V>>> c =
           cache.getIfPresent(CurrentInstitution.get());


### PR DESCRIPTION
1. In clustering environment, the ECS registration token is stored in the database, and the token will be deleted from the database once it is used.
2. Say node1 generates a token, then the only way that node 2 and 3 can know this token is to grab the token from the database, because oEQ uses Guava cache which does not support being shared among instances.
3. According to [the guava cache api](https://guava.dev/releases/19.0/api/docs/com/google/common/cache/LoadingCache.html#refresh(K)), refreshing the cache will call the CacheLoader's load method, and this method is where reading the token from the database was implemented before. Therefore, each node is able to know the token is the token is available