### PR TITLE
Fix incorrectly prerendering styles.css in new layout

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
@@ -181,9 +181,9 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
 		}
 
 		PreRenderContext precontext = context.getPreRenderContext();
-		precontext.preRender(STYLES_CSS);
         if (oldLayout) {
 			model.getBody().setPostmarkup(template.getNamedResult(context, "postmarkup"));
+			precontext.preRender(STYLES_CSS);
 			precontext.preRender(CUSTOMER_CSS);
 			return selectLayout(context, template);
         }

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,7 @@ env:
     KALTURA_BRANCH: master
     # for this build we still need Oracle JDK for JNLP support
     JAVA_HOME: /opt/oracle-jdk/jdk1.8.0_202
+    AUTOTEST_BRANCH: stable-6.6
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
Fixed an issue with https://github.com/openequella/openEQUELLA/pull/878 in which the styles.css was wrongly moved out of the oldLayout, causing graphical issues. Tested that it still works in IE11.