### PR TITLE
Bugfix/drag and drop update duplicate msg

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
@@ -5,15 +5,16 @@ exports.updateCtrlErrorText = function(ctrlId, text) {
   contElem.querySelector("P.ctrlinvalidmessage").textContent = text;
 };
 
-exports.updateDuplicateMessage = function(display) {
+exports.updateDuplicateMessage = function(id, display) {
   var duplicateMessageDiv = document.querySelector(
-    ".attachment-duplicate-message"
+    "#" + id + "_duplicateWarningMessage"
   );
-  console.log(display);
-  if (display) {
-    duplicateMessageDiv.setAttribute("style", "color:red; display:inline");
-  } else {
-    duplicateMessageDiv.setAttribute("style", "color:red; display:none");
+  if (duplicateMessageDiv != null) {
+    if (display) {
+      duplicateMessageDiv.setAttribute("style", "color:red; display:inline");
+    } else {
+      duplicateMessageDiv.setAttribute("style", "color:red; display:none");
+    }
   }
 };
 

--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
@@ -5,6 +5,18 @@ exports.updateCtrlErrorText = function(ctrlId, text) {
   contElem.querySelector("P.ctrlinvalidmessage").textContent = text;
 };
 
+exports.updateDuplicateMessage = function(display) {
+  var duplicateMessageDiv = document.querySelector(
+    ".attachment-duplicate-message"
+  );
+  console.log(display);
+  if (display) {
+    duplicateMessageDiv.setAttribute("style", "color:red; display:inline");
+  } else {
+    duplicateMessageDiv.setAttribute("style", "color:red; display:none");
+  }
+};
+
 exports.simpleFormat = function(format) {
   return function(args) {
     return format.replace(/{(\d+)}/g, function(match, number) {

--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
@@ -6,6 +6,8 @@ exports.updateCtrlErrorText = function(ctrlId, text) {
 };
 
 exports.updateDuplicateMessage = function(id, display) {
+  // The div id of all duplicate warning message automatically follow
+  // this format: its parent div id concatenating "_duplicateWarningMessage"
   var duplicateMessageDiv = document.querySelector(
     "#" + id + "_duplicateWarningMessage"
   );

--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.js
@@ -6,8 +6,8 @@ exports.updateCtrlErrorText = function(ctrlId, text) {
 };
 
 exports.updateDuplicateMessage = function(id, display) {
-  // The div id of all duplicate warning message automatically follow
-  // this format: its parent div id concatenating "_duplicateWarningMessage"
+  // The div id of all duplicate warning messages automatically follows
+  // this format: its parent div id concatenated with "_duplicateWarningMessage"
   var duplicateMessageDiv = document.querySelector(
     "#" + id + "_duplicateWarningMessage"
   );

--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.purs
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.purs
@@ -79,7 +79,10 @@ inlineUploadClass = component "InlineUpload" $ \this -> do
       let oldError = ctrlError oldEntries
           newError = ctrlError entries
       if oldError /= newError then runEffectFn2 updateCtrlErrorText ctrlId newError else pure unit
+      -- Must unwrap the attachmentDuplicateInfo extracted from State
+      -- so that it will become a normal record
       let unwrappedInfo = unwrap attachmentDuplicateInfo
+      -- use runEffectFn2 to execute updateDuplicateMessage because it needs two parameters
       runEffectFn2 updateDuplicateMessage unwrappedInfo.warningMessageWebId unwrappedInfo.displayWarningMessage
 
     ctrlError entries = if compareMax (>) entries 

--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadModel.purs
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadModel.purs
@@ -31,8 +31,9 @@ import Web.File.File (File, name, size)
 
 type EntryId = String
 
+-- Create a newtype to store attachment duplicate information
 newtype AttachmentDuplicateInfo =  AttachmentDuplicateInfo{ displayWarningMessage :: Boolean, warningMessageWebId :: String}
-derive instance duplicateInfo :: Newtype AttachmentDuplicateInfo _
+derive instance unwrappedAttachmentDuplicateInfo :: Newtype AttachmentDuplicateInfo _
 defaultDuplicateInfo :: AttachmentDuplicateInfo
 defaultDuplicateInfo = AttachmentDuplicateInfo {displayWarningMessage:false, warningMessageWebId:""}
 
@@ -92,6 +93,7 @@ instance decodeFE :: DecodeJson FileElement where
     preview <- o .? "preview"
     pure $ FileElement {id,name,link,preview,editable,children}
 
+-- decode the attachment duplicate Json data, which is required in line 117 and 121
 instance decodeJsonAttachmentDuplicateInfo :: DecodeJson AttachmentDuplicateInfo where
   decodeJson json = do
     x <- decodeJson json

--- a/Source/Plugins/Core/com.equella.core/resources/view/universalattachmentlist.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/universalattachmentlist.ftl
@@ -9,7 +9,6 @@
 <#else >
   <#assign visibility = "none">
 </#if>
-<!-- Control the visibility of duplicateWarningMessage via CSS so that Purescript can control it consistently -->
   <@link section=s.duplicateWarningMessage style="color:red; display: ${visibility}" class="attachment-duplicate-message"/>
 
 <@render m.divTag />

--- a/Source/Plugins/Core/com.equella.core/resources/view/universalattachmentlist.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/universalattachmentlist.ftl
@@ -5,6 +5,11 @@
 
 <@css "universalresource.css" />
 <#if m.displayDuplicateWarning>
-  <@link section=s.duplicateWarningMessage style="color:red"/>
+  <#assign visibility = "inline">
+<#else >
+  <#assign visibility = "none">
 </#if>
+<!-- Control the visibility of duplicateWarningMessage via CSS so that Purescript can control it consistently -->
+  <@link section=s.duplicateWarningMessage style="color:red; display: ${visibility}" class="attachment-duplicate-message"/>
+
 <@render m.divTag />

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/UniversalWebControlNew.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/UniversalWebControlNew.scala
@@ -343,7 +343,7 @@ class UniversalWebControlNew extends AbstractWebControl[UniversalWebControlModel
                     children)
     }
 
-    // Return if any attachment in this control has duplicate information found
+    // Returns true if any attachment in this control has duplicate information found
     def duplicatesFound: Boolean = {
       val duplicateData = repo.getState.getDuplicateData
       val attachments   = dialog.getAttachments.asScala

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/FileUploadHandlerNew.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/FileUploadHandlerNew.scala
@@ -701,19 +701,20 @@ class FileUploadHandlerNew extends AbstractAttachmentHandler[FileUploadHandlerMo
               .getOrElse {
                 WebFileUploads.writeStream(uf, this, request.getInputStream) match {
                   case Successful(fileInfo) =>
+                    System.out.println("121212")
                     validateContent(info, this, uf.uploadPath) match {
                       case Left(ifr) =>
                         illegal(ifr)
                       case Right(detected) =>
                         val v = ValidatedUpload(uf.success(fileInfo), detected)
                         (v,
-                         UpdateEntry(
-                           AjaxFileEntry(uploadId.toString,
-                                         uf.originalFilename,
-                                         "",
-                                         true,
-                                         false,
-                                         Iterable.empty)))
+                         UpdateEntry(AjaxFileEntry(uploadId.toString,
+                                                   uf.originalFilename,
+                                                   "",
+                                                   true,
+                                                   false,
+                                                   Iterable.empty),
+                                     None))
                     }
                   case IllegalFile(reason) => illegal(reason)
                   case e @ Errored(t) =>
@@ -737,7 +738,7 @@ class FileUploadHandlerNew extends AbstractAttachmentHandler[FileUploadHandlerMo
           decode[AjaxUploadCommand](jsonSource).fold(throw _, identity) match {
             case Delete(uploadId) =>
               stopOrCancel(info, UUID.fromString(uploadId))
-              RemoveEntries(Iterable(uploadId))
+              RemoveEntries(Iterable(uploadId), None)
             case NewUpload(filename, size) =>
               val uploadId   = UUID.randomUUID()
               val uniqueName = WebFileUploads.uniqueName(filename, replaceFilename, uploadId, this)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/FileUploadHandlerNew.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/FileUploadHandlerNew.scala
@@ -707,6 +707,7 @@ class FileUploadHandlerNew extends AbstractAttachmentHandler[FileUploadHandlerMo
                       case Right(detected) =>
                         val v = ValidatedUpload(uf.success(fileInfo), detected)
                         (v,
+                         // Normal file uploader doesn't need attachmentDuplicateInfo, so pass None
                          UpdateEntry(AjaxFileEntry(uploadId.toString,
                                                    uf.originalFilename,
                                                    "",

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/FileUploadHandlerNew.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/FileUploadHandlerNew.scala
@@ -701,7 +701,6 @@ class FileUploadHandlerNew extends AbstractAttachmentHandler[FileUploadHandlerMo
               .getOrElse {
                 WebFileUploads.writeStream(uf, this, request.getInputStream) match {
                   case Successful(fileInfo) =>
-                    System.out.println("121212")
                     validateContent(info, this, uf.uploadPath) match {
                       case Left(ifr) =>
                         illegal(ifr)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/sections/equella/ajaxupload/AjaxUpload.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/sections/equella/ajaxupload/AjaxUpload.scala
@@ -65,8 +65,10 @@ sealed trait AjaxUploadResponse
 case class NewUploadResponse(uploadUrl: String, id: String, name: String) extends AjaxUploadResponse
 case class UploadFailed(reason: String)                                   extends AjaxUploadResponse
 case class AddEntries(entries: Iterable[AjaxFileEntry])                   extends AjaxUploadResponse
-case class UpdateEntry(entry: AjaxFileEntry)                              extends AjaxUploadResponse
-case class RemoveEntries(ids: Iterable[String])                           extends AjaxUploadResponse
+case class UpdateEntry(entry: AjaxFileEntry, hasAttachmentDuplicate: Option[Boolean])
+    extends AjaxUploadResponse
+case class RemoveEntries(ids: Iterable[String], hasAttachmentDuplicate: Option[Boolean])
+    extends AjaxUploadResponse
 
 object AjaxUploadCommand {
   implicit val config = Configuration.default

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/sections/equella/ajaxupload/AjaxUpload.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/sections/equella/ajaxupload/AjaxUpload.scala
@@ -72,6 +72,7 @@ case class RemoveEntries(ids: Iterable[String],
                          attachmentDuplicateInfo: Option[AttachmentDuplicateInfo])
     extends AjaxUploadResponse
 
+// This class as part of AjaxResponse includes if duplicates are found and the attachment control's parent id
 case class AttachmentDuplicateInfo(displayWarningMessage: Boolean, warningMessageWebId: String) {}
 
 object AttachmentDuplicateInfo {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/sections/equella/ajaxupload/AjaxUpload.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/sections/equella/ajaxupload/AjaxUpload.scala
@@ -65,10 +65,19 @@ sealed trait AjaxUploadResponse
 case class NewUploadResponse(uploadUrl: String, id: String, name: String) extends AjaxUploadResponse
 case class UploadFailed(reason: String)                                   extends AjaxUploadResponse
 case class AddEntries(entries: Iterable[AjaxFileEntry])                   extends AjaxUploadResponse
-case class UpdateEntry(entry: AjaxFileEntry, hasAttachmentDuplicate: Option[Boolean])
+case class UpdateEntry(entry: AjaxFileEntry,
+                       attachmentDuplicateInfo: Option[AttachmentDuplicateInfo])
     extends AjaxUploadResponse
-case class RemoveEntries(ids: Iterable[String], hasAttachmentDuplicate: Option[Boolean])
+case class RemoveEntries(ids: Iterable[String],
+                         attachmentDuplicateInfo: Option[AttachmentDuplicateInfo])
     extends AjaxUploadResponse
+
+case class AttachmentDuplicateInfo(displayWarningMessage: Boolean, warningMessageWebId: String) {}
+
+object AttachmentDuplicateInfo {
+  implicit val config                                                       = Configuration.default
+  implicit val attachmentDuplicateEncoder: Encoder[AttachmentDuplicateInfo] = deriveEncoder
+}
 
 object AjaxUploadCommand {
   implicit val config = Configuration.default


### PR DESCRIPTION
Modify Drag and Drop to update attachment duplicate warning message
* If a collection has multiple attachment controls, each attachment control has a warning message
* Only update the warning message of an attachment control which has attachments changed
