### PR TITLE
Add NoCache to wizard state update api

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -45,6 +45,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.Response.{ResponseBuilder, Status}
 import javax.ws.rs.core.{Context, Response, StreamingOutput, UriInfo}
+import org.jboss.resteasy.annotations.cache.NoCache
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits
@@ -82,6 +83,7 @@ class WizardApi {
   }
 
   @GET
+  @NoCache
   @Path("state")
   def getState(@PathParam("wizid") wizid: String, @Context req: HttpServletRequest): ItemState = {
     withWizardState(wizid, req, false) { wsi =>


### PR DESCRIPTION
In IE11, this GET request is getting incorrectly cached, which breaks cloud controls (since without a wizard state update, cloud controls cannot react to file uploads on the same page as them without a refresh) and could potentially affect non-ECS areas too, since this API is regularly called by wizards. I've seen this happen in a non-cloud control collection, although since the collection did not need to react directly to the file upload, it had no (visible) effect on the functionality.

Modern browsers never cache GET requests, and so this will simply match what happens in other browsers in IE11.

#1218 