### PR TITLE
Add NoCache to wizard state provider api

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -184,6 +184,7 @@ class WizardApi {
 
   }
 
+  @NoCache
   @GET
   @Path("provider/{providerId}/{serviceId}")
   def proxyGET(@PathParam("wizid") wizid: String,


### PR DESCRIPTION
Another roadblock caused by IE11's caching. related to #1218 