### PR TITLE
Display editbox's title rather than the name of schema node in the duplicate data page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/WizardService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/WizardService.java
@@ -87,6 +87,13 @@ public interface WizardService extends ScriptEvaluator {
 
   void checkLinkAttachmentDuplicate(WizardState state, String url, String linkUuid);
 
+  boolean checkEditboxDuplicate(
+      WizardState state,
+      String xpath,
+      Collection<String> values,
+      boolean canAccept,
+      String fieldName);
+
   ScriptContext createScriptContext(
       WizardState state, WizardPage page, HTMLControl control, Map<String, Object> attributes);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/CEditBox.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/CEditBox.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.tle.common.Check;
 import com.tle.core.wizard.controls.WizardPage;
 import com.tle.web.sections.result.util.KeyLabel;
+import com.tle.web.wizard.impl.WebRepository;
 import java.util.ArrayList;
 
 /**
@@ -88,9 +89,10 @@ public class CEditBox extends EditableCtrl {
   private void checkDuplicate(ImmutableCollection<String> list) {
     // We need to inform the wizard to check for uniqueness every time,
     // no matter what
+    WebRepository repository = editBoxSection.getWebRepository();
     isUnique =
-        getRepository().checkDataUniqueness(getFirstTarget().getXoqlPath(), list, !forceUnique);
-
+        repository.checkEditboxDuplicate(
+            getFirstTarget().getXoqlPath(), list, !forceUnique, getTitle());
     setInvalid(
         forceUnique && !isUnique && !isInvalid(),
         new KeyLabel("wizard.controls.editbox.uniqueerror"));

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WebRepository.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WebRepository.java
@@ -381,6 +381,11 @@ public class WebRepository implements LERepository {
     wizardService.checkDuplicateUrls(state, urls);
   }
 
+  public boolean checkEditboxDuplicate(
+      String xpath, ImmutableCollection<String> values, boolean canAccept, String fieldName) {
+    return wizardService.checkEditboxDuplicate(state, xpath, values, canAccept, fieldName);
+  }
+
   @Override
   public FileInfo unzipFile(String zipfile, String targetFolder, boolean ignoreZipError) {
     try {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
@@ -697,15 +697,19 @@ public class WizardServiceImpl
   @Override
   public boolean checkDuplicateXpathValue(
       WizardState state, String xpath, Collection<String> values, boolean canAccept) {
+    return checkEditboxDuplicate(state, xpath, values, canAccept, null);
+  }
+
+  @Override
+  public boolean checkEditboxDuplicate(
+      WizardState state,
+      String xpath,
+      Collection<String> values,
+      boolean canAccept,
+      String fieldName) {
     final String prefix = xpath + '$';
     clearDuplicatesWithPrefix(state, prefix);
     final String uuid = state.getItem().getUuid();
-    // Extract the title of an Editbox from a specific xpath of an item's XML
-    PropBagEx wizardControlXmlNode = state.getItemxml().getSubtree(xpath);
-    String wizardControlTitle = "";
-    if (wizardControlXmlNode != null) {
-      wizardControlTitle = wizardControlXmlNode.getNodeName();
-    }
     boolean isUnique = true;
     for (String value : values) {
       if (!Check.isEmpty(value)) {
@@ -718,7 +722,7 @@ public class WizardServiceImpl
                 freeTextService.getKeysForNodeValue(uuid, state.getItemDefinition(), xpath, value),
                 canAccept,
                 false,
-                wizardControlTitle);
+                fieldName);
       }
     }
     return isUnique;


### PR DESCRIPTION
Charlie's testing for the Duplicate data page found one problem about showing the title of each editbox that has duplicates. 

At the moment, the name of the schema node is being displayed on the Duplicate data page rather than each editbox's title. For example, in the below image, 'duplicatesinhere' is the node name, not the editbox's name.

So this PR fixes this problem.

![image](https://user-images.githubusercontent.com/47203811/65402554-75e17c00-de12-11e9-8d70-12f19a26f678.png)
