### PR TITLE
Extend the wait on checking database status for Travis builds

### DIFF
--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/migration/impl/MigrationGlobalTask.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/migration/impl/MigrationGlobalTask.java
@@ -447,6 +447,9 @@ public class MigrationGlobalTask extends AlwaysRunningTask<SimpleMessage> {
             hibernateMigrationService.checkSchemaForMigrations(dataSource, false);
         String uniqueId = hibernateMigrationService.getUniqueId(dataSource);
         return new CheckResult(toRun, uniqueId);
+      } catch (RuntimeException e) {
+        LOGGER.error("MigrationGlobalTask error: " + e.getMessage());
+        return null;
       } finally {
         migDataSource.close();
         postMessage(new SimpleMessage(null, new SchemaMessage(Type.CHECKED, schemaId)));

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/institution/DatabaseRow.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/institution/DatabaseRow.java
@@ -52,7 +52,7 @@ public class DatabaseRow extends AbstractPage<DatabaseRow> {
   }
 
   public void waitForCheck() {
-    waiter.until(
+    longWaiter.until(
         new Function<WebDriver, Boolean>() {
           @Override
           public Boolean apply(WebDriver driver) {


### PR DESCRIPTION
Recently, Travis CI builds have failed more frequently due to the timeouts when doing the `InstallFirstTime`. This brought more and more manual restart work.  (Github issue #1247)
So this PR attempts to fix this by using `longWaiter` to extend the timeout from 30s to 60s.