### PR TITLE
Fix the bug that the file attachment check treats the file itself as a duplicate

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/AttachmentDao.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/AttachmentDao.java
@@ -27,7 +27,10 @@ import java.util.List;
 
 public interface AttachmentDao extends GenericDao<Attachment, Long> {
   List<Attachment> findByMd5Sum(
-      String md5Sum, ItemDefinition collection, boolean ignoreDeletedRejectedSuspenedItems);
+      String md5Sum,
+      ItemDefinition collection,
+      boolean ignoreDeletedRejectedSuspenedItems,
+      String excludedItemUuid);
 
   List<FileAttachment> findFilesWithNoMD5Sum();
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/quickupload/service/impl/QuickUploadServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/quickupload/service/impl/QuickUploadServiceImpl.java
@@ -102,7 +102,7 @@ public class QuickUploadServiceImpl implements QuickUploadService {
       try {
         FileInfo fileInfo = fileSystemService.write(staging, filename, inputStream, false, true);
         List<Attachment> attachs =
-            attachmentDao.findByMd5Sum(fileInfo.getMd5CheckSum(), collection, true);
+            attachmentDao.findByMd5Sum(fileInfo.getMd5CheckSum(), collection, true, null);
         Pair<ItemId, Attachment> attInfo;
 
         if (!attachs.isEmpty()) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
@@ -766,11 +766,10 @@ public class WizardServiceImpl
   @Override
   public void checkFileAttachmentDuplicate(WizardState state, String fileName, String fileUuid) {
     try {
-      String md5 = fileSystemService.getMD5Checksum(state.getFileHandle(), fileName);
+      final String md5 = fileSystemService.getMD5Checksum(state.getFileHandle(), fileName);
+      final String excludeItemUuid = state.getItemId().getUuid();
       List<Attachment> duplicateFileAttachments =
-          attachmentDao.findByMd5Sum(md5, state.getItemDefinition(), true);
-      // Exclude the file itself if it has been published.
-      duplicateFileAttachments.removeIf(attachment -> attachment.getUuid().equals(fileUuid));
+          attachmentDao.findByMd5Sum(md5, state.getItemDefinition(), true, excludeItemUuid);
       if (duplicateFileAttachments.size() > 0) {
         List<ItemId> list =
             duplicateFileAttachments.stream()

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
@@ -769,6 +769,8 @@ public class WizardServiceImpl
       String md5 = fileSystemService.getMD5Checksum(state.getFileHandle(), fileName);
       List<Attachment> duplicateFileAttachments =
           attachmentDao.findByMd5Sum(md5, state.getItemDefinition(), true);
+      // Exclude the file itself if it has been published.
+      duplicateFileAttachments.removeIf(attachment -> attachment.getUuid().equals(fileUuid));
       if (duplicateFileAttachments.size() > 0) {
         List<ItemId> list =
             duplicateFileAttachments.stream()


### PR DESCRIPTION
At the moment, if a file attachment has been published and then when editing this file, the duplicate warning appears despite no duplicates being really found. This is because duplicates are found by the file MD5 and the file itself is in the result list. So the duplicate check treats the file itself as a duplicate. 

So this PR aims to fix this issue by excluding the file itself if it has been published.

