### PR TITLE
Fix Selenium tests which frequently fail to pass Travis build checks

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/viewing/ItemSummaryTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/viewing/ItemSummaryTest.java
@@ -59,6 +59,7 @@ public class ItemSummaryTest extends AbstractCleanupTest {
     assertEquals(search.getSelectedWithin(), COLLECTION);
     assertFalse(search.exactQuery(dontFindItem).isResultsAvailable());
     assertTrue(search.exactQuery(summaryItem).isResultsAvailable());
+    logout(context);
   }
 
   @Test

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalEditPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalEditPage.java
@@ -56,6 +56,7 @@ public abstract class AbstractPortalEditPage<T extends AbstractPortalEditPage<T>
     WebElement saveButton = getSave();
     waiter.until(ExpectedConditions.elementToBeClickable(saveButton));
     saveButton.click();
+    waiter.until(ExpectedConditions.visibilityOf(page.getLoadedElement()));
     return page.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalEditPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalEditPage.java
@@ -53,7 +53,9 @@ public abstract class AbstractPortalEditPage<T extends AbstractPortalEditPage<T>
   }
 
   public <P extends AbstractPage<P>> P save(P page) {
-    getSave().click();
+    WebElement saveButton = getSave();
+    waiter.until(ExpectedConditions.elementToBeClickable(saveButton));
+    saveButton.click();
     return page.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalEditPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalEditPage.java
@@ -55,8 +55,11 @@ public abstract class AbstractPortalEditPage<T extends AbstractPortalEditPage<T>
   public <P extends AbstractPage<P>> P save(P page) {
     WebElement saveButton = getSave();
     waiter.until(ExpectedConditions.elementToBeClickable(saveButton));
-    saveButton.click();
-    waiter.until(ExpectedConditions.visibilityOf(page.getLoadedElement()));
+    int retry = 3;
+    while (!page.isLoaded() && retry > 0) {
+      saveButton.click();
+      retry--;
+    }
     return page.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
     extends AbstractPage<T> {
@@ -74,7 +75,10 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     showButtons();
-    getBoxHead().findElement(By.className("box_edit")).click();
+    By boxEditButtonBy = By.className("box_edit");
+    waiter.until(ExpectedConditions.elementToBeClickable(boxEditButtonBy));
+    WebElement boxEditButton = getBoxHead().findElement(boxEditButtonBy);
+    boxEditButton.click();
     return portal.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -8,7 +8,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
     extends AbstractPage<T> {
@@ -74,9 +73,14 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
   }
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
-    showButtons();
     WebElement boxEditButton = getBoxHead().findElement(By.className("box_edit"));
-    waiter.until(ExpectedConditions.elementToBeClickable(boxEditButton));
+    // 'showButtons' not working very well on Travis when the New UI is enable
+    // So retry three times at most
+    int retry = 3;
+    while (!boxEditButton.isDisplayed() && retry > 0) {
+      showButtons();
+      retry--;
+    }
     boxEditButton.click();
     return portal.get();
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -75,9 +75,8 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     showButtons();
-    By boxEditButtonBy = By.className("box_edit");
-    waiter.until(ExpectedConditions.elementToBeClickable(boxEditButtonBy));
-    WebElement boxEditButton = getBoxHead().findElement(boxEditButtonBy);
+    WebElement boxEditButton = getBoxHead().findElement(By.className("box_edit"));
+    waiter.until(ExpectedConditions.elementToBeClickable(boxEditButton));
     boxEditButton.click();
     return portal.get();
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
     extends AbstractPage<T> {
@@ -74,13 +75,8 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     WebElement boxEditButton = getBoxHead().findElement(By.className("box_edit"));
-    // 'showButtons' not working very well on Travis when the New UI is enable
-    // So retry three times at most
-    int retry = 3;
-    while (!boxEditButton.isDisplayed() && retry > 0) {
-      showButtons();
-      retry--;
-    }
+    showButtons();
+    waiter.until(ExpectedConditions.visibilityOf(boxEditButton));
     boxEditButton.click();
     return portal.get();
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/tasklist/ModerationView.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/tasklist/ModerationView.java
@@ -11,6 +11,7 @@ import com.tle.webtests.pageobject.wizard.RejectMessagePage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class ModerationView extends AbstractPage<ModerationView> {
   @FindBy(className = "moderate-reject")
@@ -48,6 +49,7 @@ public class ModerationView extends AbstractPage<ModerationView> {
   }
 
   public ModerationMessagePage acceptToMessagePage() {
+    waiter.until(ExpectedConditions.elementToBeClickable(approveButton));
     approveButton.click();
     return new ApproveMessagePage(context).get();
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/AbstractWizardControlPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/AbstractWizardControlPage.java
@@ -345,11 +345,10 @@ public abstract class AbstractWizardControlPage<T extends AbstractWizardControlP
   }
 
   public String getErrorMessage(int ctrlNum) {
-    return driver
-        .findElement(
-            By.xpath(
-                "id(" + quoteXPath(getControlId(ctrlNum)) + ")/div/p[@class='ctrlinvalidmessage']"))
-        .getText()
-        .trim();
+    By errorMessageXpath =
+        By.xpath(
+            "id(" + quoteXPath(getControlId(ctrlNum)) + ")/div/p[@class='ctrlinvalidmessage']");
+    waiter.until(ExpectedConditions.presenceOfElementLocated(errorMessageXpath));
+    return driver.findElement(errorMessageXpath).getText().trim();
   }
 }


### PR DESCRIPTION
Three Selenium tests listed below have failed to pass Travis build checks frequently since when we enabled tests working on the new UI. This PR aims to fix them so hopefully we no longer need to restart Travis jobs which run these three tests again and again.

They are : 
com.tle.webtests.test.dashboard.PortalsTest
com.tle.webtests.test.contribute.controls.MaxAttachmentsTest
com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByContributorRoleTest