### PR TITLE
Display last owner's details in the ownership change page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/content/ChangeOwnershipContentSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/content/ChangeOwnershipContentSection.java
@@ -21,6 +21,7 @@ package com.tle.web.viewitem.summary.content;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
+import com.rometools.utils.Strings;
 import com.tle.beans.item.Item;
 import com.tle.common.Format;
 import com.tle.common.usermanagement.user.valuebean.UserBean;
@@ -296,7 +297,11 @@ public class ChangeOwnershipContentSection
     protected List<String> getSourceList(SectionInfo info) {
       final ItemSectionInfo iinfo = ParentViewItemSectionUtils.getItemInfo(info);
       final Item item = iinfo.getItem();
-      return Collections.singletonList(item.getOwner());
+      String itemOwner = item.getOwner();
+      if (Strings.isEmpty(itemOwner)) {
+        itemOwner = item.getLastOwner();
+      }
+      return Collections.singletonList(itemOwner);
     }
 
     @Override
@@ -306,7 +311,8 @@ public class ChangeOwnershipContentSection
         String userId,
         List<SectionRenderable> actions,
         int index) {
-      selection.setViewAction(new LinkRenderer(userLinkSection.createLink(info, userId)));
+      selection.setViewAction(
+          new LinkRenderer(userLinkSection.createLink(info, userId, null, true)));
       actions.add(makeAction(OWNER_CHANGE, new OverrideHandler(ownerSelect.getOpenFunction())));
     }
   }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] screenshots are included showing significant UI changes

##### Description of change
This feature was previously done in the `Item summary` and `Moderation history` pages. We also want the last owner's details displayed instead of 'unknown user' in the `ownership change` page.
 
#726  

![image](https://user-images.githubusercontent.com/47203811/67722718-0886c380-fa2e-11e9-9f32-3e5f24567996.png)

