### PR TITLE
Replace max-age with Etag checksum check to fix attachment preview caching

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
@@ -141,7 +141,7 @@ public class ItemFilestoreServlet extends HttpServlet {
       if (itemId != null) {
         auditor.audit(request, new ViewAuditEntry("file:" + mimeType, path), itemId, attachment);
       }
-      contentStreamWriter.outputStream(request, response, filteredStream);
+      contentStreamWriter.outputStream(request, response, filteredStream, true);
     } catch (AccessDeniedException ade) {
       if (CurrentUser.isGuest()) {
         LogonSection.forwardToLogon(
@@ -195,7 +195,7 @@ public class ItemFilestoreServlet extends HttpServlet {
       // proxy cache) must always revalidate before releasing their copy
       // to ensure we're not returning a resource to a user who doesn't
       // have access.
-      return "max-age=86400, s-maxage=0, must-revalidate";
+      return "must-revalidate";
     }
 
     @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
@@ -185,16 +185,7 @@ public class ItemFilestoreServlet extends HttpServlet {
     @SuppressWarnings("nls")
     @Override
     public String getCacheControl() {
-      // Before changing anything, read http://www.mnot.net/cache_docs/
-      //
-      // The following settings mean that all caches will be able to keep
-      // a copy of the resource - the age values only specify how long
-      // before the cache must *revalidate* their copy. With these
-      // settings, browser caches can serve their copy for a whole day
-      // without needing to talk to the server. Shared caches (eg, a Squid
-      // proxy cache) must always revalidate before releasing their copy
-      // to ensure we're not returning a resource to a user who doesn't
-      // have access.
+      // this is to ensure that the etag is checked when attempting to pull down attachments
       return "must-revalidate";
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] documentation is changed or added (in-code documentation)

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Solves #1181. The original method for file attachment cache validation was to use a max age parameter, which meant that modifying a file but maintaining its filename would cause stale preview images. Using a checksum instead forces the invalidation should the file content change. 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
