### PR TITLE
Fix the alert dialog bug when publishing items

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -111,11 +111,21 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
 
   def isClientPath(relUrl: RelativeUrl): Boolean = relUrl.path.parts match {
     case Vector("logon.do") => false
-    case p                  => p.last.endsWith(".do")
+    case p                  => p.last.endsWith(".do") || isItemSummaryUrl(relUrl.toString())
   }
 
   def internalRoute(uri: String): Option[String] = {
     relativeURI(uri).filter(isClientPath).map(r => "/" + r.toString())
+  }
+
+  def isItemSummaryUrl(path: String): Boolean = {
+    // This regex matches the relative Url of the Item Summary page
+    // For example, items/2f2b2b72-8a71-465d-bdcd-107de3ec8696/1/
+    val itemSummaryUrlPattern = "items\\/.+-.+-.+-.+-.+\\/\\d+\\/".r
+    path match {
+      case itemSummaryUrlPattern() => true
+      case _                       => false
+    }
   }
 
   override lazy val getExceptionHandlers: util.Collection[ExceptionHandlerMatch] = {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement is signed
- [x] commit message follows [commit guidelines]

##### Description of change
#1313 
According to my investigation, this bug is caused because the the route to the Item Summary page is considered as an external route due to the new function `isClientPath` in LegacyContentApi. 

This function  only marks Urls which end with '.do' as internal routes, excluding 'logon.do'. However, routes to the Item Summary page (e.g. http://localhost:8080/charlie/items/802798b4-5bf8-4b70-b7d5-4c91d366386a/1/)  should also be internal ones.

So the proposed (and maybe the safest) fix is to let `isClientPath` mark the Urls of  Item Summary page as internal routes.

Lastly, in terms of why this bug only happens in one page collection, the answer could be found from line 88 - 99 of `index.tsx` .
