### PR TITLE
Run the npm test in a subshell so it does not change the directory

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,7 +17,7 @@ phases:
       - service postgresql start
   build:
     commands:
-      - cd Source/Plugins/Core/com.equella.core/js && npm install && npm test; cd -
+      - (cd Source/Plugins/Core/com.equella.core/js && npm install && npm test)
       - sbt -no-colors -Dconfig.file=${HOME}/build.conf test installerZip writeLanguagePack writeScriptingJavadoc
       - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
       - (cd import-export-tool && ./gradlew build); cd -


### PR DESCRIPTION
##### Checklist


- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]


##### Description of change

Previous work of oEQ version checking adds a new build command to run 'npm test' in the `Buildspec.yml` file.
This command however causes a problem that the directory where `publishBuildResult` gets running is wrong. 

So need to slightly change the new build command,making it gets running in a subshell.