### PR TITLE
Enable docker-compose to specify oEQ installer version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -ms /bin/bash equella \
 # Install openEQUELLA
 FROM baseequella as installer
 
-ARG OEQ_INSTALL_FILE=equella-installer-2019.1.zip
+ARG OEQ_INSTALL_FILE=equella-installer-2019.2.0.zip
 
 COPY ["$OEQ_INSTALL_FILE","defaults.xml", "./"]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.6"
 
 services:
   oeq:
-    build: .
+    build:
+      context: .
+      args:
+        - OEQ_INSTALL_FILE=equella-installer-2019.2.0.zip
     networks:
       - oeq-cluster
     links:


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]

##### Description of change
Previous work was done to set up a clustered environment of oEQ. However to use a different version of oEQ requires manually changing the argument `OEQ_INSTALL_FILE`  in the Dockerfile, which is not what we want.

Instead, it is good to specify the installer file name in the `docker-compose.yml` file.

