### PR TITLE
Ensure advanced search controls added to tree when editing params

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
@@ -759,7 +759,7 @@ public class SearchQuerySection
       } catch (Exception e) {
         Throwables.propagate(e);
       }
-      powerPage.ensureTreeAdded(info, isSubmitWizard());
+      powerPage.ensureTreeAdded(info, isEditQuery() || isSubmitWizard());
 
       if (isSubmitWizard()) {
         info.queueEvent(
@@ -886,8 +886,8 @@ public class SearchQuerySection
   @DirectEvent(priority = SectionEvent.PRIORITY_AFTER_EVENTS)
   public void ensurePowerPage(SectionInfo info) {
     SearchQueryModel model = getModel(info);
-    if (model.isSubmitWizard()) {
-      model.loadPowerPage();
+    if (model.isSubmitWizard() || model.isEditQuery()) {
+      model.ensurePowerPage();
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/Tree.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/Tree.java
@@ -23,14 +23,12 @@ import com.tle.annotation.Nullable;
 import com.tle.web.sections.Bookmark;
 import com.tle.web.sections.SectionId;
 import com.tle.web.sections.SectionInfo;
-import com.tle.web.sections.SectionTree;
 import com.tle.web.sections.ajax.AjaxGenerator;
 import com.tle.web.sections.ajax.AjaxRenderContext;
 import com.tle.web.sections.ajax.JSONResponseCallback;
 import com.tle.web.sections.ajax.handler.AjaxFactory;
 import com.tle.web.sections.ajax.handler.AjaxMethod;
 import com.tle.web.sections.events.RenderContext;
-import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.render.SectionRenderable;
 import com.tle.web.sections.standard.model.HtmlComponentState;
 import com.tle.web.sections.standard.model.HtmlTreeModel;
@@ -47,32 +45,18 @@ public class Tree extends AbstractDisablerComponent<Tree.TreeModel> implements H
   private boolean allowMultipleOpenBranches;
 
   @AjaxFactory private AjaxGenerator ajaxMethods;
-  private JSCallable ajaxFunction;
 
   public Tree() {
     super(RendererConstants.TREE);
   }
 
   @Override
-  public void registered(String id, SectionTree tree) {
-    super.registered(id, tree);
-    if (lazyLoad) {
-      ajaxFunction = ajaxMethods.getAjaxFunction("getTreeNodes"); // $NON-NLS-1$
-    }
-  }
-
-  @Override
-  public JSCallable getAjaxFunctionForNode(SectionInfo info, String nodeId) {
-    return ajaxFunction;
-  }
-
-  @Override
   public Bookmark getAjaxUrlForNode(SectionInfo info, String nodeId) {
-    return ajaxMethods.getAjaxUrl(info, "getTreeNodes", nodeId); // $NON-NLS-1$
+    return ajaxMethods.getAjaxUrl(info, "getTreeNodes");
   }
 
   @AjaxMethod
-  public JSONResponseCallback getTreeNodes(AjaxRenderContext context, String nodeId) {
+  public JSONResponseCallback getTreeNodes(AjaxRenderContext context) {
     context.setModalId(displayTree.getSectionId());
     return getTreeRenderer(context).getJSONResponse();
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/model/HtmlTreeServer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/model/HtmlTreeServer.java
@@ -21,11 +21,8 @@ package com.tle.web.sections.standard.model;
 import com.tle.annotation.NonNullByDefault;
 import com.tle.web.sections.Bookmark;
 import com.tle.web.sections.SectionInfo;
-import com.tle.web.sections.js.JSCallable;
 
 @NonNullByDefault
 public interface HtmlTreeServer {
   Bookmark getAjaxUrlForNode(SectionInfo info, String nodeId);
-
-  JSCallable getAjaxFunctionForNode(SectionInfo info, String nodeId);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/page/WizardPage.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/page/WizardPage.java
@@ -37,8 +37,6 @@ public interface WizardPage {
 
   void createPage() throws WizardPageException;
 
-  void ensureTreeAdded(SectionInfo info, boolean submitWizard);
-
   void loadFromDocument(SectionInfo info);
 
   void saveToDocument(SectionInfo info) throws Exception;
@@ -63,6 +61,8 @@ public interface WizardPage {
   void init();
 
   void ensureTreeAdded(SectionInfo info);
+
+  void ensureTreeAdded(SectionInfo info, boolean processParams);
 
   void setSubmitted(boolean submitted);
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included

##### Description of change

The controls of the advanced search were only being added at render time, missing the all the event handler code.  The change ensures that the controls are added earlier on in the process.

Some dead code was also removed in Tree.java

#1309

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
