### PR TITLE
Disable the browser's cache for attachments

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
@@ -185,16 +185,9 @@ public class ItemFilestoreServlet extends HttpServlet {
     @SuppressWarnings("nls")
     @Override
     public String getCacheControl() {
-      // Before changing anything, read http://www.mnot.net/cache_docs/
-      //
-      // The following settings mean that all caches will be able to keep
-      // a copy of the resource - the age values only specify how long
-      // before the cache must *revalidate* their copy. With these
-      // settings, browser caches can serve their copy for a whole day
-      // without needing to talk to the server. Shared caches (eg, a Squid
-      // proxy cache) must always revalidate before releasing their copy
-      // to ensure we're not returning a resource to a user who doesn't
-      // have access.
+      // Set 'max-age' to 0 so that the content of cache is always stale.
+      // Hence, the browser sends every request to the the Equella server which will then
+      // re-validate the content.
       return "max-age=0, s-maxage=0, must-revalidate";
     }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
@@ -195,7 +195,7 @@ public class ItemFilestoreServlet extends HttpServlet {
       // proxy cache) must always revalidate before releasing their copy
       // to ensure we're not returning a resource to a user who doesn't
       // have access.
-      return "max-age=86400, s-maxage=0, must-revalidate";
+      return "max-age=0, s-maxage=0, must-revalidate";
     }
 
     @Override


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]


##### Description of change

Set the value of `max-age` to 0 so that the browser will send a request to server all the time. Then the server will check `Last-Modified` of the attachment, which does not cost too many resources.

#1181

