### PR TITLE
Add meta tags for discoverability into the HTML head tag

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -37,6 +37,7 @@ type LegacyContent = {
   script: string;
   noForm: boolean;
   title: string;
+  metaTags: string;
   fullscreenMode: string;
   menuMode: string;
   hideAppBar: boolean;
@@ -50,6 +51,7 @@ export interface PageContent {
   state: StateData;
   script: string;
   title: string;
+  metaTags: string;
   fullscreenMode: string;
   menuMode: string;
   hideAppBar: boolean;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -31,6 +31,7 @@ interface LegacyPageProps extends TemplateUpdateProps {
 
 export function templatePropsForLegacy({
   title,
+  metaTags,
   html,
   contentId,
   hideAppBar,
@@ -45,6 +46,7 @@ export function templatePropsForLegacy({
   );
   return {
     title,
+    metaTags,
     hideAppBar,
     fullscreenMode: fullscreenMode as FullscreenMode,
     menuMode: menuMode as MenuMode,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -60,6 +60,8 @@ export interface TemplateProps {
   menuMode?: MenuMode;
   disableNotifications?: boolean;
   currentUser?: UserData;
+  /* Extra meta tags */
+  metaTags?: string;
 }
 
 export interface TemplateUpdateProps {
@@ -85,6 +87,7 @@ export type TemplateUpdate = (
  * No footer content
  * Show the menu
  * Allow notifications links
+ * No extra meta tags
  */
 export function templateDefaults(title: string): TemplateUpdate {
   return tp =>
@@ -100,7 +103,8 @@ export function templateDefaults(title: string): TemplateUpdate {
       hideAppBar: undefined,
       fullscreenMode: undefined,
       menuMode: undefined,
-      disableNotifications: undefined
+      disableNotifications: undefined,
+      metaTags: undefined
     } as TemplateProps);
 }
 
@@ -116,6 +120,8 @@ export const strings = languageStrings.template;
 export const coreStrings = languageStrings["com.equella.core"];
 
 const topBarString = coreStrings.topbar.link;
+
+const specialMetaTagNames = languageStrings.metatags;
 
 declare const logoURL: string;
 
@@ -281,6 +287,29 @@ export const Template = React.memo(function Template(props: TemplateProps) {
   React.useEffect(() => {
     window.document.title = `${props.title}${coreStrings.windowtitlepostfix}`;
   }, [props.title]);
+
+  React.useEffect(() => {
+    updateMetaTags(props.metaTags);
+  }, [props.metaTags]);
+
+  function updateMetaTags(tags: string | undefined) {
+    const head = document.head;
+    if (tags) {
+      // The meta tags generated on Server side separates each other by a newline symbol
+      const newMetaTags = tags.split("\n");
+      newMetaTags.forEach(tag => {
+        head.appendChild(document.createRange().createContextualFragment(tag));
+      });
+    } else {
+      const existingMetaTags = document.querySelectorAll("meta");
+      // Remove those specific meta tags
+      existingMetaTags.forEach(tag => {
+        if (specialMetaTagNames.includes(tag.name)) {
+          head.removeChild(tag);
+        }
+      });
+    }
+  }
 
   function linkItem(
     link: LocationDescriptor,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -296,7 +296,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
   function updateMetaTags(tags: string | undefined) {
     const head = document.head;
     if (tags) {
-      // The meta tags generated on Server side separates each other by a newline symbol
+      // The meta tags generated on the server side, separated by new line symbols
       const newMetaTags = tags.split("\n");
       newMetaTags.forEach(newMetaTag => {
         head.appendChild(

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -121,8 +121,6 @@ export const coreStrings = languageStrings["com.equella.core"];
 
 const topBarString = coreStrings.topbar.link;
 
-const specialMetaTagNames = languageStrings.metatags;
-
 declare const logoURL: string;
 
 interface ExtTheme {
@@ -259,6 +257,9 @@ export const Template = React.memo(function Template(props: TemplateProps) {
   const [navMenuOpen, setNavMenuOpen] = React.useState(false);
   const [errorOpen, setErrorOpen] = React.useState(false);
 
+  // Record what customised meta tags have been added into <head>
+  const [metaTags, setMetaTags] = React.useState<Array<string>>([]);
+
   const classes = useStyles();
 
   React.useEffect(() => {
@@ -297,15 +298,22 @@ export const Template = React.memo(function Template(props: TemplateProps) {
     if (tags) {
       // The meta tags generated on Server side separates each other by a newline symbol
       const newMetaTags = tags.split("\n");
-      newMetaTags.forEach(tag => {
-        head.appendChild(document.createRange().createContextualFragment(tag));
+      newMetaTags.forEach(newMetaTag => {
+        head.appendChild(
+          document.createRange().createContextualFragment(newMetaTag)
+        );
       });
+      setMetaTags(newMetaTags);
     } else {
+      // While there are no new meta tags to display, also remove old customised meta tags
       const existingMetaTags = document.querySelectorAll("meta");
-      // Remove those specific meta tags
-      existingMetaTags.forEach(tag => {
-        if (specialMetaTagNames.includes(tag.name)) {
-          head.removeChild(tag);
+      existingMetaTags.forEach(existingMetaTag => {
+        if (
+          metaTags.some(tag => {
+            return tag === existingMetaTag.outerHTML;
+          })
+        ) {
+          head.removeChild(existingMetaTag);
         }
       });
     }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -370,6 +370,5 @@ export const languageStrings = {
       notor: "None match"
     },
     convertGroup: "Convert to group"
-  },
-  metatags: ["citation_title", "citation_description"]
+  }
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -370,5 +370,6 @@ export const languageStrings = {
       notor: "None match"
     },
     convertGroup: "Convert to group"
-  }
+  },
+  metatags: ["citation_title", "citation_description"]
 };

--- a/Source/Plugins/Core/com.equella.core/resources/view/layouts/outer/react.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/layouts/outer/react.ftl
@@ -5,7 +5,6 @@
     <head>
       <meta http-equiv="X-UA-Compatible" content="IE=edge" >
     	<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-      <meta name="robots" content="noindex, follow">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
     	<base href="${baseHref}">
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -85,6 +85,7 @@ case class LegacyContent(html: Map[String, String],
                          script: String,
                          state: Map[String, Array[String]],
                          title: String,
+                         metaTags: String,
                          menuMode: String,
                          fullscreenMode: String,
                          hideAppBar: Boolean,
@@ -491,6 +492,7 @@ class LegacyContentApi {
       val cssFiles = context.getCssFiles.asScala.collect {
         case css: CssInclude => css.getHref(context)
       }
+      val metaTags = context.getHeaderMarkup
       val title =
         Option(decs.getBannerTitle).orElse(Option(decs.getTitle)).map(_.getText).getOrElse("")
       val menuMode       = decs.getMenuMode.toString
@@ -506,6 +508,7 @@ class LegacyContentApi {
           scripts.mkString("\n"),
           getBookmarkState(info, new BookmarkEvent(null, true, info)),
           title,
+          metaTags,
           menuMode,
           fullscreenMode,
           hideAppBar,

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/DiscoverabilityTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/DiscoverabilityTest.java
@@ -28,10 +28,8 @@ public class DiscoverabilityTest extends AbstractCleanupTest {
 
     SummaryPage summary = wizard.save().publish();
     // Skip this check for new UI until Github issue #1148 is fixed
-    if (!summary.usingNewUI()) {
-      assertTrue(summary.hasMeta("citation_title", fullName));
-      assertTrue(summary.hasMeta("citation_description", description));
-    }
+    assertTrue(summary.hasMeta("citation_title", fullName));
+    assertTrue(summary.hasMeta("citation_description", description));
   }
 
   @Test
@@ -68,10 +66,7 @@ public class DiscoverabilityTest extends AbstractCleanupTest {
     wizard.save().publish();
 
     HarvestPage harvestPage = new HarvestPage(context).load();
-    // Skip this check for new UI until Github issue #1148 is fixed
-    if (!harvestPage.usingNewUI()) {
-      assertTrue(harvestPage.hasMeta("robots", "noindex, follow"));
-    }
+    assertTrue(harvestPage.hasMeta("robots", "noindex, follow"));
 
     // might not be on the first page so loop through
     int pages = harvestPage.getPageCount();


### PR DESCRIPTION
#1148 
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
With the New UI turned on,  meta tags for discoverability are missing and two test (`metaTest` and `validatationTest`) have been skipped in the New UI due to this issue.

This PR aims to fix this issue by passing the tags from back-end to front-end through `LegacyConetent` and then use React hook to dynamically control these tags.

Although there are no new tests against this fix, the two previously skipped tests are re enabled to work for these changes.


![Screenshot from 2019-11-13 11-46-45](https://user-images.githubusercontent.com/47203811/68723013-7543b580-060b-11ea-9db1-9357aa80a01d.png)
![Screenshot from 2019-11-13 11-45-56](https://user-images.githubusercontent.com/47203811/68723014-7543b580-060b-11ea-8fec-f1460bc8ad6a.png)




