### PR TITLE
Update indexes of child nodes when sort from a top level

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
@@ -86,7 +86,7 @@ import org.hibernate.annotations.NamedQuery;
       name = "shiftByPath",
       query =
           "UPDATE Term SET lft = lft + :amount, rht = rht + :amount "
-              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '\uD83D\uDE80') "
+              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '\u0021') "
               + "AND taxonomy = :taxonomy",
       cacheable = true)
 })

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
@@ -86,7 +86,7 @@ import org.hibernate.annotations.NamedQuery;
       name = "shiftByPath",
       query =
           "UPDATE Term SET lft = lft + :amount, rht = rht + :amount "
-              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '!') "
+              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '❗') "
               + "AND taxonomy = :taxonomy",
       cacheable = true)
 })

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
@@ -86,7 +86,7 @@ import org.hibernate.annotations.NamedQuery;
       name = "shiftByPath",
       query =
           "UPDATE Term SET lft = lft + :amount, rht = rht + :amount "
-              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild) "
+              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '\uD83D\uDE80') "
               + "AND taxonomy = :taxonomy",
       cacheable = true)
 })

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
@@ -86,7 +86,7 @@ import org.hibernate.annotations.NamedQuery;
       name = "shiftByPath",
       query =
           "UPDATE Term SET lft = lft + :amount, rht = rht + :amount "
-              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '\u0021') "
+              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '!') "
               + "AND taxonomy = :taxonomy",
       cacheable = true)
 })

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/taxonomy/impl/TermDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/taxonomy/impl/TermDaoImpl.java
@@ -617,7 +617,7 @@ public class TermDaoImpl extends GenericDaoImpl<Term, Long> implements TermDao {
                 if (shiftAmount != 0) {
                   // we need to use the term path for hierarchical identification, as the
                   // left+right indexes will get messed up during this process
-                  shift(session, taxonomy, tsd.term, shiftAmount);
+					shift(session, taxonomy, tsd.term, shiftAmount);
                 }
               }
               return null;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/taxonomy/impl/TermDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/taxonomy/impl/TermDaoImpl.java
@@ -558,7 +558,7 @@ public class TermDaoImpl extends GenericDaoImpl<Term, Long> implements TermDao {
       Query q = session.getNamedQuery("shiftByPath");
       q.setInteger("amount", amount);
       q.setString("fullValue", term.getFullValue());
-      q.setString("fullValueWild", term.getFullValue() + "%");
+      q.setString("fullValueWild", term.getFullValue() + "\\%");
       q.setParameter("taxonomy", taxonomy);
       q.executeUpdate();
     } else {
@@ -617,7 +617,7 @@ public class TermDaoImpl extends GenericDaoImpl<Term, Long> implements TermDao {
                 if (shiftAmount != 0) {
                   // we need to use the term path for hierarchical identification, as the
                   // left+right indexes will get messed up during this process
-					shift(session, taxonomy, tsd.term, shiftAmount);
+                  shift(session, taxonomy, tsd.term, shiftAmount);
                 }
               }
               return null;

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/TaxonomyApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/TaxonomyApiTest.java
@@ -27,6 +27,7 @@ public class TaxonomyApiTest extends AbstractRestApiTest {
   private static final String TERM_1_UUID = "abbd2610-1c3e-489a-a107-1c16fa22b0a0";
   private static final String API_TAXONOMY_PATH = "api/taxonomy";
   private static final String API_TERM_PATH_PART = "term";
+  private static final String ROOT_NODE_NAME = "root";
 
   @Override
   protected void addOAuthClients(List<Pair<String, String>> clients) {
@@ -75,16 +76,7 @@ public class TaxonomyApiTest extends AbstractRestApiTest {
     ObjectNode termNode = (ObjectNode) getEntity(termUrl, getToken());
     assertEquals(termValue, termNode.get("term").asText());
 
-    termNode.put("parentUuid", TERM_1_UUID);
-    String putUrl =
-        PathUtils.urlPath(
-            context.getBaseUrl(),
-            API_TAXONOMY_PATH,
-            TAXONOMY_UUID,
-            API_TERM_PATH_PART,
-            termNode.get("uuid").getTextValue());
-    HttpResponse putRequest = getPut(putUrl, termNode, getToken());
-    assertResponse(putRequest, 200, "failed to update term");
+    moveNode(termNode, TERM_1_UUID, TAXONOMY_UUID, -1);
 
     HttpResponse response = deleteResource(termUrl, getToken());
     assertResponse(response, 200, "failed to delete term");
@@ -138,14 +130,8 @@ public class TaxonomyApiTest extends AbstractRestApiTest {
     final HttpResponse sortRootsResponse = sortChildren(taxonomyUuid, null);
     assertResponse(sortRootsResponse, 200, "failed to sort root terms");
 
-    final List<String> returnedSortedRootTerms = new ArrayList<>(10);
     final ArrayNode arrayNode = getChildren(taxonomyUuid, null);
-
-    for (int i = 0; i < arrayNode.size(); i++) {
-      final JsonNode node = arrayNode.get(i);
-      final String termName = node.get("term").getTextValue();
-      returnedSortedRootTerms.add(termName);
-    }
+    final List<String> returnedSortedRootTerms = getNodeNames(arrayNode);
     assertEquals(rootTerms, returnedSortedRootTerms);
 
     unlock(taxonomyUuid);
@@ -173,17 +159,23 @@ public class TaxonomyApiTest extends AbstractRestApiTest {
     final int testTermIndex = 5;
     String testTermPath = null;
 
+    // Create root node
+    final String rootUuid = UUID.randomUUID().toString();
+    createTerm(taxonomyUuid, rootUuid, ROOT_NODE_NAME);
+
+    // Create first-level nodes
     for (int i = 0; i < 10; i++) {
       final String termName = randomString(8);
       final boolean isTestTerm = (i == testTermIndex);
-      final int childCount = (isTestTerm ? 100 : 8);
+      int childCount = (isTestTerm ? 100 : 8);
       final String termUuid = (isTestTerm ? testTermUuid : UUID.randomUUID().toString());
       if (isTestTerm) {
         testTermPath = termName;
       }
       rootTerms.add(termName);
-      createTerm(taxonomyUuid, termUuid, termName);
+      createTerm(taxonomyUuid, termUuid, termName, rootUuid, -1);
 
+      // Create second-level nodes
       for (int j = 0; j < childCount; j++) {
         final String subTermName = termName + "-" + randomString(8);
         if (isTestTerm) {
@@ -197,33 +189,46 @@ public class TaxonomyApiTest extends AbstractRestApiTest {
     alphaSort(rootTerms);
     alphaSort(testTermChildren);
 
+    final String rootNodePath = ROOT_NODE_NAME;
+    final String firstLevelNodePath = ROOT_NODE_NAME + "\\" + testTermPath;
     // Sort root
-    final HttpResponse sortRootsResponse = sortChildren(taxonomyUuid, null);
+    final HttpResponse sortRootsResponse = sortChildren(taxonomyUuid, rootNodePath);
     assertResponse(sortRootsResponse, 200, "failed to sort root terms");
     // Sort test terms children
-    final HttpResponse sortTestTermChildrenResponse = sortChildren(taxonomyUuid, testTermPath);
+    final HttpResponse sortTestTermChildrenResponse =
+        sortChildren(taxonomyUuid, firstLevelNodePath);
     assertResponse(sortTestTermChildrenResponse, 200, "failed to sort test term children");
 
     // Check root sorted
-    final List<String> returnedSortedRootTerms = new ArrayList<>(10);
-    final ArrayNode arrayNode = getChildren(taxonomyUuid, null);
-    for (int i = 0; i < arrayNode.size(); i++) {
-      final JsonNode node = arrayNode.get(i);
-      final String termName = node.get("term").getTextValue();
-      returnedSortedRootTerms.add(termName);
-    }
+    final ArrayNode firstLevelNodes = getChildren(taxonomyUuid, ROOT_NODE_NAME);
+    final List<String> returnedSortedRootTerms = getNodeNames(firstLevelNodes);
     assertEquals(rootTerms, returnedSortedRootTerms);
 
     // Check test terms children sorted
-    final List<String> returnedSortedChildTerms = new ArrayList<>(10);
-    final ArrayNode testTermSortedChildren = getChildren(taxonomyUuid, testTermPath);
-
-    for (int i = 0; i < testTermSortedChildren.size(); i++) {
-      final JsonNode node = testTermSortedChildren.get(i);
-      final String termName = node.get("term").getTextValue();
-      returnedSortedChildTerms.add(termName);
-    }
+    final ArrayNode testTermSortedChildren = getChildren(taxonomyUuid, firstLevelNodePath);
+    final List<String> returnedSortedChildTerms = getNodeNames(testTermSortedChildren);
     assertEquals(testTermChildren, returnedSortedChildTerms);
+
+    // Check if the root sorting breaks the order of second-level nodes
+    final JsonNode firstNode = firstLevelNodes.get(0);
+    String firstNodePath = firstNode.get("fullTerm").asText();
+    String firstNodeUuid = firstNode.get("uuid").asText();
+
+    // Sort before any node movements
+    sortChildren(taxonomyUuid, firstNodePath);
+    ArrayNode firstNodeChildren = getChildren(taxonomyUuid, firstNodePath);
+    final List<String> nodeNames = getNodeNames(firstNodeChildren);
+
+    // Move a child node
+    JsonNode lastChildTerm = firstNodeChildren.get(firstNodeChildren.size() - 1);
+    moveNode((ObjectNode) lastChildTerm, firstNodeUuid, taxonomyUuid, 0);
+
+    // Sort again
+    sortChildren(taxonomyUuid, firstNodePath);
+    firstNodeChildren = getChildren(taxonomyUuid, firstNodePath);
+    final List<String> sortedNodeNames = getNodeNames(firstNodeChildren);
+
+    assertEquals(nodeNames, sortedNodeNames);
 
     unlock(taxonomyUuid);
 
@@ -458,6 +463,33 @@ public class TaxonomyApiTest extends AbstractRestApiTest {
                 context.getBaseUrl(), API_TAXONOMY_PATH, taxonomyUuid, API_TERM_PATH_PART),
             getToken(),
             varargs);
+  }
+
+  private List<String> getNodeNames(ArrayNode nodes) {
+    final List<String> nodeNames = new ArrayList<>();
+    for (int i = 0; i < nodes.size(); i++) {
+      final JsonNode node = nodes.get(i);
+      final String termName = node.get("term").getTextValue();
+      nodeNames.add(termName);
+    }
+    return nodeNames;
+  }
+
+  private void moveNode(ObjectNode node, String parentUuid, String taxonomyUuid, int index)
+      throws IOException {
+    node.put("parentUuid", parentUuid);
+    if (index >= 0) {
+      node.put("index", index);
+    }
+    String putUrl =
+        PathUtils.urlPath(
+            context.getBaseUrl(),
+            API_TAXONOMY_PATH,
+            taxonomyUuid,
+            API_TERM_PATH_PART,
+            node.get("uuid").getTextValue());
+    HttpResponse putRequest = getPut(putUrl, node, getToken());
+    assertResponse(putRequest, 200, "failed to move term");
   }
 
   private HttpResponse sortChildren(String taxonomyUuid, @Nullable String path) throws IOException {


### PR DESCRIPTION
##### Checklist
#1225 

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
The problem I found is when sort from a top level, the indexes of each direct child node's are properly changed. However, if any child node also has its own children, indexes of these children are not changed accordingly. Therefore the order of all nodes is messed up. 

So the proposed fix is to walk through the tree and update all affected nodes's indexes.

Please note that the order of grandchildren is not changed (this is the feature of sorting all nodes).



<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
