### PR TITLE
Added config to disable RemoveStagingAreas

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/filesystem/staging/service/impl/StagingServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/filesystem/staging/service/impl/StagingServiceImpl.java
@@ -67,10 +67,12 @@ public class StagingServiceImpl implements StagingService {
     if (s == null) {
       LOGGER.error("Staging area does not exist");
     } else {
+      LOGGER.info("Deleting Staging entry in DB [" + s.getStagingID() + "]");
       stagingDao.delete(s);
     }
 
     if (removeFiles) {
+      LOGGER.info("Removing Staging area in the filestore [" + s.getStagingID() + "]");
       fileSystemService.removeFile(staging);
     }
   }
@@ -100,9 +102,10 @@ public class StagingServiceImpl implements StagingService {
             String uuid = file.getFileName().toString();
             if (!stagingExists(uuid)) {
               try {
+                LOGGER.debug("Deleting staging area [" + uuid + "]");
                 FileUtils.delete(file, null, true);
               } catch (IOException ex) {
-                LOGGER.warn("Could not delete staging area: " + uuid, ex);
+                LOGGER.warn("Could not delete staging area [" + uuid + "]", ex);
               }
             }
           }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/filesystem/staging/service/impl/StagingServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/filesystem/staging/service/impl/StagingServiceImpl.java
@@ -67,12 +67,12 @@ public class StagingServiceImpl implements StagingService {
     if (s == null) {
       LOGGER.error("Staging area does not exist");
     } else {
-      LOGGER.info("Deleting Staging entry in DB [" + s.getStagingID() + "]");
+      LOGGER.debug("Deleting Staging entry in DB [" + s.getStagingID() + "]");
       stagingDao.delete(s);
     }
 
     if (removeFiles) {
-      LOGGER.info("Removing Staging area in the filestore [" + s.getStagingID() + "]");
+      LOGGER.debug("Removing Staging area in the filestore [" + s.getStagingID() + "]");
       fileSystemService.removeFile(staging);
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/impl/SchedulerModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/impl/SchedulerModule.java
@@ -26,6 +26,6 @@ public class SchedulerModule extends OptionalConfigModule {
   protected void configure() {
     bindInt("com.tle.core.tasks.RemoveDeletedItems.daysBeforeRemoval");
     bindInt("com.tle.core.tasks.RemoveOldAuditLogs.daysBeforeRemoval");
-    bindBoolean("com.tle.core.tasks.RemoveStagingAreas.enable");
+    bindBoolean("com.tle.core.tasks.RemoveStagingAreas.enable", true);
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/impl/SchedulerModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/impl/SchedulerModule.java
@@ -26,5 +26,6 @@ public class SchedulerModule extends OptionalConfigModule {
   protected void configure() {
     bindInt("com.tle.core.tasks.RemoveDeletedItems.daysBeforeRemoval");
     bindInt("com.tle.core.tasks.RemoveOldAuditLogs.daysBeforeRemoval");
+    bindBoolean("com.tle.core.tasks.RemoveStagingAreas.enable");
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/standard/task/RemoveStagingAreas.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/standard/task/RemoveStagingAreas.java
@@ -44,7 +44,7 @@ public class RemoveStagingAreas implements ScheduledTask {
     if (enableTask) {
       stagingService.removeUnusedStagingAreas();
     } else {
-      LOGGER.info("RemoveStagingAreas is disabled.  Not running task.");
+      LOGGER.debug("RemoveStagingAreas is disabled.  Not running task.");
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/standard/task/RemoveStagingAreas.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/scheduler/standard/task/RemoveStagingAreas.java
@@ -22,16 +22,29 @@ import com.tle.core.filesystem.staging.service.StagingService;
 import com.tle.core.guice.Bind;
 import com.tle.core.scheduler.ScheduledTask;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
+import org.apache.log4j.Logger;
 
 /** @author Nicholas Read */
 @Bind
 @Singleton
 public class RemoveStagingAreas implements ScheduledTask {
+  private static final Logger LOGGER = Logger.getLogger(RemoveStagingAreas.class);
+
   @Inject private StagingService stagingService;
+
+  @com.google.inject.Inject(optional = true)
+  @Named("com.tle.core.tasks.RemoveStagingAreas.enable")
+  // Can be overrode by the optional-config.properties
+  private boolean enableTask = true;
 
   @Override
   public void execute() {
-    stagingService.removeUnusedStagingAreas();
+    if (enableTask) {
+      stagingService.removeUnusedStagingAreas();
+    } else {
+      LOGGER.info("RemoveStagingAreas is disabled.  Not running task.");
+    }
   }
 }


### PR DESCRIPTION
##### Checklist
- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] documentation is changed or added - once approved / merged, I'll update the docs repo.

##### Description of change
Allows a system admin to turn off the `RemoveStagingAreas` via the boolean system-level config `com.tle.core.tasks.RemoveStagingAreas.enable` in `optional-config.properties`.  Also adding more file audit logging.  

This will affect both the background task and the manual invocation via `/access/scheduledtasksdebug.do`.  Didn't seem like a clean way to allow the manual and block the background method, and this _should_ be a rarely used configuration.

Issue: #1344 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
