### PR TITLE
Exclude archived items for attachment duplicate checking

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
@@ -58,7 +58,7 @@ public class AttachmentDaoImpl extends GenericDaoImpl<Attachment, Long> implemen
     query.append("SELECT a FROM Item i LEFT JOIN i.attachments a WHERE a.md5sum = :md5sum");
     query.append(" AND i.itemDefinition = :collection AND i.institution = :institution");
     if (ignoreDeletedRejectedSuspenedItems) {
-      query.append(" AND i.status NOT IN ('REJECTED', 'SUSPENDED', 'DELETED')");
+      query.append(" AND i.status NOT IN ('REJECTED', 'SUSPENDED', 'DELETED', 'ARCHIVED')");
     }
     if (excludedItemUuid != null) {
       query.append(" AND i.uuid != :excludedItemUuid");


### PR DESCRIPTION
The issue this PR aims to fix is related to the RDA feature Attachment Duplicate Checking.
There is not a specific Github issue related however.

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

At the moment, the Attachment Duplicate Checking excludes items that are with status of Deleted, Rejected or Suspended. In order to make it consistent with the Field Duplicate Checking, archived items should be excluded.

I remember @abidingotter mentioned `SimpleDBA` would get involved in this fix, but I have not found any change about `SimpleDBA` is required. 

Also please note this change will make differences on another functionality called `QuickUpload`. I checked the code and discussed with Charlie, and we are confident that this change will not break `QuickUpload`
