### PR TITLE
Disallow the special like escape character in the taxonomy UI

### DIFF
--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/taxonomy/tool/internal/TermTree.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/taxonomy/tool/internal/TermTree.java
@@ -110,7 +110,8 @@ public class TermTree extends AbstractTreeEditorTree<TermTreeNode> {
     final JValidatingTextField field =
         new JValidatingTextField(
             new JValidatingTextField.MaxLength(Term.MAX_TERM_VALUE_LENGTH),
-            new JValidatingTextField.DisallowStr(TaxonomyConstants.TERM_SEPARATOR));
+            new JValidatingTextField.DisallowStr(TaxonomyConstants.TERM_SEPARATOR),
+            new JValidatingTextField.DisallowStr(TaxonomyConstants.LIKE_ESCAPE));
     String name = null;
     do {
       final int result =

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/TaxonomyConstants.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/TaxonomyConstants.java
@@ -22,6 +22,7 @@ package com.tle.common.taxonomy;
 public final class TaxonomyConstants {
   public static final String TERM_SEPARATOR = "\\";
   public static final String TERM_SEPARATOR_REGEX = "\\\\";
+  public static final String LIKE_ESCAPE = "!";
 
   public static final String TERM_ALLOW_ADDITION = "TERM_ALLOW_ADDITION";
 

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/terms/Term.java
@@ -22,6 +22,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import com.tle.common.Check;
 import com.tle.common.DontUseMethod;
 import com.tle.common.taxonomy.Taxonomy;
+import com.tle.common.taxonomy.TaxonomyConstants;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -86,7 +87,9 @@ import org.hibernate.annotations.NamedQuery;
       name = "shiftByPath",
       query =
           "UPDATE Term SET lft = lft + :amount, rht = rht + :amount "
-              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '❗') "
+              + "WHERE (fullValue = :fullValue OR fullValue LIKE :fullValueWild ESCAPE '"
+              + TaxonomyConstants.LIKE_ESCAPE
+              + "') "
               + "AND taxonomy = :taxonomy",
       cacheable = true)
 })


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

Prevent user from entering the ! character in a new term as it used as an escape character in an internal LIKE query.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
