### PR TITLE
Delay the cloud search until after page rendered by React

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/cloud.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/cloud.js
@@ -1,17 +1,15 @@
-var Cloud = 
-{
-		onSearch: function(cb, $span, searchingText)
-		{
-			//TODO: spinner
-			$span.text(searchingText);
-			
-			var updateCount = function(data)
-			{
-				if ($span[0] && $.contains(document, $span[0]))
-				{
-					$span.text(data.text);
-				}
-			}
-			cb.call(null, updateCount);
-		}
+var Cloud = {
+  onSearch: function(cb, $span, searchingText) {
+    setTimeout(function() {
+      //TODO: spinner
+      $span.text(searchingText);
+
+      var updateCount = function(data) {
+        if ($span[0] && $.contains(document, $span[0])) {
+          $span.text(data.text);
+        }
+      };
+      cb.call(null, updateCount);
+    }, 0);
+  }
 };


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

The cloud search sends an AJAX request to the server before various React components have been rendered on the page. This means that the screen options div is not present when the cloud search collects all the form elements on the page to submit to the server.
The fix is to do a setTimeout(..., 0) so that the AJAX request does not happen until all the rendering scripts have occurred.

#1162 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
