### PR TITLE
Decrease frequency of Stale Bot activities

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,16 +1,17 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 120
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - pinned
-  - security
-  - Tech debt
-  - roadmap
   - Edalex
   - Edalex RDA
+  - Ready for Testing
+  - Tech debt
   - Unicon SE
+  - pinned
+  - roadmap
+  - security
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included - NA
- [ ] screenshots are included showing significant UI changes - NA
- [ ] documentation is changed or added - NA

##### Description of change

Some have commented Stale Bot is a bit too active. Now that we've
worked our way through old possibly out of date issues from initial
migrations etc, let's double the duration between triggers.

Also: Sorted the list of labels.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
