### PR TITLE
Ensure 'customer.css' is loaded in the New UI;

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -77,6 +77,7 @@ object RenderNewTemplate {
       supportIEPolyFills(info)
       info.preRender(bundleJs)
       links.foreach(l => info.addCss(r.url(l.attr("href"))))
+      info.addCss(RenderTemplate.CUSTOMER_CSS)
     }
     (prerender, htmlDoc)
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/customisation/RootThemeSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/customisation/RootThemeSection.java
@@ -62,6 +62,8 @@ import com.tle.web.template.section.HelpAndScreenOptionsSection;
 import java.io.IOException;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.NotFileFilter;
 
 @Bind
 public class RootThemeSection
@@ -89,6 +91,8 @@ public class RootThemeSection
   @Component private FileUpload upload;
   private JSAssignable validateFile;
 
+  private final String LEGACY_CSS = "legacy.css";
+
   @Override
   public void registered(String id, SectionTree tree) {
     super.registered(id, tree);
@@ -107,8 +111,9 @@ public class RootThemeSection
   public void prepare(SectionContext context) throws IOException {
     RootCustomisationModel model = getModel(context);
     CustomisationFile baseCustomisations = new CustomisationFile();
-
-    FileEntry[] entries = fileSystemService.enumerate(baseCustomisations, "", null);
+    // Exclude 'legacy.css' as it's not a customer css file
+    NotFileFilter fileFilter = new NotFileFilter(new NameFileFilter(LEGACY_CSS));
+    FileEntry[] entries = fileSystemService.enumerate(baseCustomisations, "", fileFilter);
     model.setExistsCurrentTheme(entries.length > 0);
   }
 


### PR DESCRIPTION
##### Checklist
#1184 
- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

1. Support `customer.css` in the New UI;
2. Fix the issue that the `Themes settings` page displays wrong things

Please note once a customer CSS file is uploaded or removed, a force refresh is required to reload the CSS file.

![Screenshot from 2019-12-04 13-49-07](https://user-images.githubusercontent.com/47203811/70108458-75305600-169d-11ea-9f23-6cc9d430b10a.png)
