### PR TITLE
Remove Firefox workaround that is no longer required

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
@@ -1553,13 +1553,6 @@ Expandable button
   margin-right: 3px;
 }
 
-/* Firefox3-specific CSS property for expandable button icon position*/
-@-moz-document url-prefix() {
-  .button-expandable i {
-    margin-left: 6px;
-  }
-}
-
 .button-expandable:hover {
   width: auto;
   /* Transition */


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- n/a tests are included
- [x] screenshots are included showing significant UI changes
- n/a documentation is changed or added

##### Description of change

A CSS workaround that was required for previous versions of Firefox is no longer required, so it was removed.

#1010 

Fixed buttons:
![image](https://user-images.githubusercontent.com/1694589/70283236-9bc4cd00-1814-11ea-9cca-544ef496b6ff.png)
