### PR TITLE
Fix Youtube view links

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
@@ -275,7 +275,7 @@ public class YoutubeHandler
               VideoSnippet vidInfo = video.getSnippet();
 
               final String title = vidInfo.getTitle();
-              String href = "//www.youtube.com/v/" + videoId;
+              String href = "//www.youtube.com/watch?v=" + videoId;
               final LinkRenderer titleLink =
                   new PopupLinkRenderer(new HtmlLinkState(new SimpleBookmark(href)));
               titleLink.setLabel(new TextLabel(title));
@@ -388,7 +388,7 @@ public class YoutubeHandler
       a.setData(YoutubeUtils.PROPERTY_THUMB_URL, defaultThumb.getUrl());
       a.setThumbnail(defaultThumb.getUrl());
 
-      a.setData(YoutubeUtils.PROPERTY_PLAY_URL, "//www.youtube.com/v/" + v.getId());
+      a.setData(YoutubeUtils.PROPERTY_PLAY_URL, "//www.youtube.com/watch?v=" + v.getId());
 
       a.setData(YoutubeUtils.PROPERTY_ID, v.getId());
       a.setData(YoutubeUtils.PROPERTY_DURATION, v.getContentDetails().getDuration());


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] n/a screenshots are included showing significant UI changes
- [ ] n/a documentation is changed or added

##### Description of change

Change the generated YouTube video URLs to the new format.  

Note: tests could be made, but we'd need to create a page object for the YouTube video page, which would take a while and it could change at any time.  I deem it not worth the time and effort for such a minor bug.

#1087