### PR TITLE
Fix flakiness for PortalsTest

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
@@ -322,6 +322,7 @@ public class PortalsTest extends AbstractCleanupTest {
     // Edit the portal
     RecentContributionsEditPage edit = recent.edit(portal);
     edit.setStatus("draft");
+    edit.checkSelectedCollection();
     edit.save(new HomePage(context));
 
     // Check that the draft item is displayed

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -2,6 +2,7 @@ package com.tle.webtests.pageobject.portal;
 
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.AbstractPage;
+import com.tle.webtests.pageobject.ExpectedConditions2;
 import com.tle.webtests.pageobject.HomePage;
 import com.tle.webtests.pageobject.WaitingPageObject;
 import org.openqa.selenium.By;
@@ -74,7 +75,11 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     showButtons();
-    getBoxHead().findElement(By.className("box_edit")).click();
+    WebElement boxHead = getBoxHead();
+    waiter.until(ExpectedConditions2.presenceOfElement(boxHead));
+    waiter.until(
+        ExpectedConditions2.presenceOfElement(boxHead.findElement(By.className("box_edit"))));
+    boxHead.findElement(By.className("box_edit")).click();
     return portal.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsEditPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsEditPage.java
@@ -3,6 +3,7 @@ package com.tle.webtests.pageobject.portal;
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.generic.component.EquellaSelect;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 public class RecentContributionsEditPage
     extends AbstractPortalEditPage<RecentContributionsEditPage> {
@@ -21,6 +22,12 @@ public class RecentContributionsEditPage
     super.checkLoaded();
     stausList = new EquellaSelect(context, driver.findElement(By.id("rct_s")));
     displayList = new EquellaSelect(context, driver.findElement(By.id("rct_d")));
+  }
+
+  public void checkSelectedCollection() {
+    WebElement allResourceOption =
+        driver.findElement(By.xpath("//input[@id=//label[text()='All resources']/@for]"));
+    if (!allResourceOption.isSelected()) allResourceOption.click();
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
The PortalsTest keeps failing in Travis when looking for the options button in the Recent Portal. Added a couple of waits to ensure that the header itself exists in the tree and then the options button. 
During local testing the PortalsTest would break roughly once in 5 times, since making this change  I have run the test locally 25 times without a fail. 
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
