### PR TITLE
Ensure form data are properly sent to ECS services

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -205,10 +205,13 @@ class WizardApi {
                 content: InputStream): Response = {
     val streamedBody =
       readInputStream(IO(content), 4096, Implicits.global).chunks.map(_.toByteBuffer)
+
+    val headers = for {
+      headerName <- req.getHeaderNames.asScala
+    } yield (headerName, req.getHeader(headerName))
+
     proxyRequest(wizid, req, providerId, serviceId, uriInfo) { uri =>
-      sttp
-        .post(uri)
-        .streamBody(streamedBody)
+      sttp.post(uri).streamBody(streamedBody).headers(headers.toMap)
     }
   }
 }

--- a/autotest/IntegTester/ps/www/control.tsx
+++ b/autotest/IntegTester/ps/www/control.tsx
@@ -182,6 +182,25 @@ function TestControl(p: ControlApi<MyConfig>) {
       >
         Execute
       </button>
+
+      <button
+        onClick={_ => {
+          const formData = new FormData();
+          var file = document.getElementById("attachments") as HTMLInputElement;
+          for (var i = 0; i < file.files.length; i++) {
+            formData.append("file_" + i, file.files[i]);
+          }
+          const url = p.providerUrl(serviceId);
+          const req = axios.post(url, formData);
+          return req
+            .then(resp => setServiceResponse(resp.data))
+            .catch((err: Error) => {
+              setServiceResponse(err.message);
+            });
+        }}
+      >
+        Streaming test
+      </button>
     </div>
   );
 
@@ -277,6 +296,7 @@ function TestControl(p: ControlApi<MyConfig>) {
       <h4>Upload file</h4>
       <input
         type="file"
+        id="attachments"
         multiple
         onChange={e => {
           Array.from(e.currentTarget.files).forEach(f => {


### PR DESCRIPTION
* Copy headers to the requests sent to ECS services by the Proxy
* Add requests' content inputstream to 'RemappedRequest'
* Add streaming upload check to IntegTester
#1356 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

The 'inputstream' passed to the Cloud Provider Proxy endpoint has been consumed by Servlet filters so the requests sent to ECS do not have the original body information. Also the requests do not have correct headers.

The proposed fix is to copy the origin inputstream to the wrapped request (RemappedRequest) so we can read the inputstream at the Proxy endpoint. Also add headers to the requests. 

In order to test if files are uploaded in streaming, I slightly modify the Integtester. It is expected that the response message should include the multiparts information and  large files are saved locally in the root folder of oEQ without the 'OutOfMemory' error.

![Screenshot from 2019-12-19 16-28-42](https://user-images.githubusercontent.com/47203811/71147858-3219d980-227e-11ea-937b-676741a3e345.png)

