### PR TITLE
Enable Cloud Provider Proxy to handle Delete requests

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -211,6 +211,16 @@ class WizardApi {
         .streamBody(streamedBody)
     }
   }
+
+  @DELETE
+  @Path("provider/{providerId}/{serviceId}")
+  def proxyDELETE(@PathParam("wizid") wizid: String,
+                  @PathParam("providerId") providerId: UUID,
+                  @PathParam("serviceId") serviceId: String,
+                  @Context uriInfo: UriInfo,
+                  @Context req: HttpServletRequest): Response = {
+    proxyRequest(wizid, req, providerId, serviceId, uriInfo)(sttp.delete)
+  }
 }
 
 class SimpleWorkflowOperation extends WorkflowOperation {

--- a/autotest/IntegTester/ps/www/control.tsx
+++ b/autotest/IntegTester/ps/www/control.tsx
@@ -182,6 +182,20 @@ function TestControl(p: ControlApi<MyConfig>) {
       >
         Execute
       </button>
+
+      <button
+        onClick={_ => {
+          const url = p.providerUrl(serviceId) + "?param1=ecs_video_test";
+          const req = axios.delete(url);
+          return req
+            .then(resp => setServiceResponse(resp.data))
+            .catch((err: Error) => {
+              setServiceResponse(err.message);
+            });
+        }}
+      >
+        Delete Test
+      </button>
     </div>
   );
 

--- a/autotest/IntegTester/ps/www/control.tsx
+++ b/autotest/IntegTester/ps/www/control.tsx
@@ -185,7 +185,7 @@ function TestControl(p: ControlApi<MyConfig>) {
 
       <button
         onClick={_ => {
-          const url = p.providerUrl(serviceId) + "?param1=ecs_video_test";
+          const url = p.providerUrl(serviceId) + "?param1=test_param_one";
           const req = axios.delete(url);
           return req
             .then(resp => setServiceResponse(resp.data))

--- a/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
+++ b/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
@@ -135,6 +135,8 @@ class TestingCloudProvider(implicit val cs: ContextShift[IO]) extends Http4sDsl[
     case authReq @ GET -> Root / "myService" as user =>
       val req = authReq.req
       Ok(ServiceResponse(user, "<NONE>", req.queryString).asJson)
+    case authReq @ DELETE -> Root / "myService" as user =>
+      Ok(ServiceResponse(user, "<NONE>", authReq.req.queryString).asJson)
   }
 
   val oauthService = publicServices <+> middleware(protectedService)


### PR DESCRIPTION
#1369 
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
Add a REST endpoint in oEQ so that Cloud Provider Proxy can handle Delete requests;
Add a REST endpoint in IntegTester to respond to Delete requests.

Please note that some Header information is missing. Tom suggests we raise another ticket and fix it.
Also I feel it's better to open another PR which will include autotests for these proxy functions.

![Screenshot from 2020-01-02 11-50-45](https://user-images.githubusercontent.com/47203811/71648272-be380080-2d56-11ea-9780-e8d146873a1b.png)

