### PR TITLE
Do not use 'cd -' after building import-export-tool

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,7 +20,7 @@ phases:
       - (cd Source/Plugins/Core/com.equella.core/js && npm install && npm test)
       - sbt -no-colors -Dconfig.file=${HOME}/build.conf test installerZip writeLanguagePack writeScriptingJavadoc
       - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
-      - (cd import-export-tool && ./gradlew build); cd -
+      - (cd import-export-tool && ./gradlew build)
   post_build:
     commands:
       - publishBuildResults


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]


##### Description of change
Recently, Codebuild has failed several times due to the directory for publishing build results being wrong. We do not know why this is happening yet, but we can avoid it by removing `cd -` after building the import/export tools

