### PR TITLE
Stop duplication issue in screen options

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -14,7 +14,6 @@ import {
   LegacyContentProps
 } from "../legacycontent/LegacyContent";
 import { LegacyContentRenderer } from "../legacycontent/LegacyContentRenderer";
-import v4 = require("uuid/v4");
 
 interface LegacyPageProps extends TemplateUpdateProps {
   location: Location;
@@ -41,7 +40,7 @@ export function templatePropsForLegacy({
 }: PageContent): TemplateProps {
   let soHtml = html["so"];
   let menuExtra = soHtml ? (
-    <ScreenOptions optionsHtml={soHtml} contentId={contentId} key={v4()} />
+    <ScreenOptions optionsHtml={soHtml} contentId={contentId} key={contentId} />
   ) : (
     undefined
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -14,6 +14,7 @@ import {
   LegacyContentProps
 } from "../legacycontent/LegacyContent";
 import { LegacyContentRenderer } from "../legacycontent/LegacyContentRenderer";
+import v4 = require("uuid/v4");
 
 interface LegacyPageProps extends TemplateUpdateProps {
   location: Location;
@@ -40,7 +41,7 @@ export function templatePropsForLegacy({
 }: PageContent): TemplateProps {
   let soHtml = html["so"];
   let menuExtra = soHtml ? (
-    <ScreenOptions optionsHtml={soHtml} contentId={contentId} />
+    <ScreenOptions optionsHtml={soHtml} contentId={contentId} key={v4()} />
   ) : (
     undefined
   );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
A bug in the new UI causes this drop down selector in the screen options to duplicate each time a new page that contains screen options is opened. The issue looks like this.
![image](https://user-images.githubusercontent.com/24543345/71949077-48380b80-3226-11ea-9d92-a3682a687223.png)
This happens because the screen options component rerenders incorrectly. I fixed this by tying the key of the screen options component to the page contentId.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
