### PR TITLE
Create a REST endpoint to handle Cloud Provider Proxy PUT requests;

### DIFF
--- a/autotest/IntegTester/ps/www/control.tsx
+++ b/autotest/IntegTester/ps/www/control.tsx
@@ -196,6 +196,22 @@ function TestControl(p: ControlApi<MyConfig>) {
       >
         Delete Test
       </button>
+
+      <button
+        onClick={_ => {
+          const url = p.providerUrl(serviceId) + "?" + queryString;
+          const req = axios.put(url, {
+            data: serviceContent
+          });
+          return req
+            .then(resp => setServiceResponse(resp.data))
+            .catch((err: Error) => {
+              setServiceResponse(err.message);
+            });
+        }}
+      >
+        Put Test
+      </button>
     </div>
   );
 

--- a/autotest/IntegTester/ps/www/control.tsx
+++ b/autotest/IntegTester/ps/www/control.tsx
@@ -1,6 +1,6 @@
 import * as ReactDOM from "react-dom";
 import * as React from "react";
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 
 import {
   ControlApi,
@@ -93,6 +93,28 @@ function TestControl(p: ControlApi<MyConfig>) {
     [failValidation, required]
   );
 
+  interface TestingButtonProps {
+    buttonName: string;
+    onClick: () => Promise<AxiosResponse<any>>;
+  }
+  const TestingButton = TestingButtonProps => (
+    <button
+      onClick={() => {
+        TestingButtonProps.onClick()
+          .then(resp => setServiceResponse(resp.data))
+          .catch((err: Error) => {
+            setServiceResponse(err.message);
+          });
+      }}
+    >
+      {TestingButtonProps.buttonName}
+    </button>
+  );
+
+  const requestUrl = (query: String = queryString) => {
+    return p.providerUrl(serviceId) + "?" + query;
+  };
+
   React.useEffect(() => {
     p.registerValidator(validator);
     return () => p.deregisterValidator(validator);
@@ -135,14 +157,6 @@ function TestControl(p: ControlApi<MyConfig>) {
           onChange={e => setQueryString(e.target.value)}
         />
       </div>
-      <div>
-        POST Request?{" "}
-        <input
-          type="checkbox"
-          checked={postRequest}
-          onChange={e => setPostRequest(e.target.checked)}
-        />
-      </div>
       {postRequest && (
         <div>
           Payload:
@@ -165,53 +179,31 @@ function TestControl(p: ControlApi<MyConfig>) {
           />
         </div>
       )}
-      <button
-        onClick={_ => {
-          const url = p.providerUrl(serviceId) + "?" + queryString;
-          const req = postRequest
-            ? axios.post(url, {
-                data: serviceContent
-              })
-            : axios.get(url);
-          return req
-            .then(resp => setServiceResponse(resp.data))
-            .catch((err: Error) => {
-              setServiceResponse(err.message);
-            });
-        }}
-      >
-        Execute
-      </button>
 
-      <button
-        onClick={_ => {
-          const url = p.providerUrl(serviceId) + "?param1=test_param_one";
-          const req = axios.delete(url);
-          return req
-            .then(resp => setServiceResponse(resp.data))
-            .catch((err: Error) => {
-              setServiceResponse(err.message);
-            });
-        }}
-      >
-        Delete Test
-      </button>
+      <TestingButton buttonName="GET" onClick={() => axios.get(requestUrl())} />
 
-      <button
-        onClick={_ => {
-          const url = p.providerUrl(serviceId) + "?" + queryString;
-          const req = axios.put(url, {
+      <TestingButton
+        buttonName="POST"
+        onClick={() =>
+          axios.post(requestUrl(), {
             data: serviceContent
-          });
-          return req
-            .then(resp => setServiceResponse(resp.data))
-            .catch((err: Error) => {
-              setServiceResponse(err.message);
-            });
-        }}
-      >
-        Put Test
-      </button>
+          })
+        }
+      />
+
+      <TestingButton
+        buttonName="DELETE"
+        onClick={() => axios.delete(requestUrl("param1=test_param_one"))}
+      />
+
+      <TestingButton
+        buttonName="PUT"
+        onClick={() =>
+          axios.put(requestUrl(), {
+            data: serviceContent
+          })
+        }
+      />
     </div>
   );
 

--- a/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
+++ b/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
@@ -148,7 +148,7 @@ class TestingCloudProvider(implicit val cs: ContextShift[IO]) extends Http4sDsl[
     if (cookies.isDefined) {
       val jSessionId = cookies.get.value.split(";").exists(value => value.startsWith("JSESSIONID"))
       if (jSessionId) {
-        return BadRequest("Unexpected cookie is found.")
+        return BadRequest("The unexpected cookie name (JSESSIONID) was found.")
       }
     }
     if (decode) {

--- a/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
+++ b/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
@@ -11,6 +11,7 @@ import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.AuthMiddleware
+import org.http4s.util.CaseInsensitiveString
 import scalaoauth2.provider._
 
 import scala.collection.JavaConverters._
@@ -127,21 +128,36 @@ class TestingCloudProvider(implicit val cs: ContextShift[IO]) extends Http4sDsl[
     case req @ POST -> Root / "itemNotification" as user =>
       System.err.println(req.req.queryString)
       Ok()
+
     case authReq @ POST -> Root / "myService" as user =>
-      val req = authReq.req
-      req.decode[String] { serviceData =>
-        Ok(ServiceResponse(user, serviceData, req.queryString).asJson)
-      }
+      createResponse(true, authReq.req, user)
+
     case authReq @ PUT -> Root / "myService" as user =>
-      val req = authReq.req
+      createResponse(true, authReq.req, user)
+
+    case authReq @ GET -> Root / "myService" as user =>
+      createResponse(false, authReq.req, user)
+
+    case authReq @ DELETE -> Root / "myService" as user =>
+      createResponse(false, authReq.req, user)
+  }
+  def createResponse(decode: Boolean, req: Request[IO], user: TestUser): IO[Response[IO]] = {
+    val cookies = req.headers.get(CaseInsensitiveString("cookie"))
+
+    // If header includes cookies then check if JSESSIONID exists; if yes then respond with a bad request.
+    if (cookies.isDefined) {
+      val jSessionId = cookies.get.value.split(";").exists(value => value.startsWith("JSESSIONID"))
+      if (jSessionId) {
+        return BadRequest("Unexpected cookie is found.")
+      }
+    }
+    if (decode) {
       req.decode[String] { serviceData =>
         Ok(ServiceResponse(user, serviceData, req.queryString).asJson)
       }
-    case authReq @ GET -> Root / "myService" as user =>
-      val req = authReq.req
+    } else {
       Ok(ServiceResponse(user, "<NONE>", req.queryString).asJson)
-    case authReq @ DELETE -> Root / "myService" as user =>
-      Ok(ServiceResponse(user, "<NONE>", authReq.req.queryString).asJson)
+    }
   }
 
   val oauthService = publicServices <+> middleware(protectedService)

--- a/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
+++ b/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
@@ -132,6 +132,11 @@ class TestingCloudProvider(implicit val cs: ContextShift[IO]) extends Http4sDsl[
       req.decode[String] { serviceData =>
         Ok(ServiceResponse(user, serviceData, req.queryString).asJson)
       }
+    case authReq @ PUT -> Root / "myService" as user =>
+      val req = authReq.req
+      req.decode[String] { serviceData =>
+        Ok(ServiceResponse(user, serviceData, req.queryString).asJson)
+      }
     case authReq @ GET -> Root / "myService" as user =>
       val req = authReq.req
       Ok(ServiceResponse(user, "<NONE>", req.queryString).asJson)


### PR DESCRIPTION
#1414 #1413 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] screenshots are included showing significant UI changes

##### Description of change
1. Add a new REST endpoint to support PUT requests through Cloud Provider proxy;
2. Include HTTP headers in Cloud Provider proxy (JSESSIONID is dropped).

![Screenshot from 2020-01-13 14-16-15](https://user-images.githubusercontent.com/47203811/72231725-29b08680-3611-11ea-99b7-cbb430902c52.png)


