### PR TITLE
fix functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,9 @@ install:
   - unzip chromedriver_linux64.zip
   - whereis google-chrome
   - whereis google-chrome-beta
+  - apt-get purge google-chrome-stable
+  - whereis google-chrome
+  - whereis google-chrome-beta
   - echo "google chrome version"
   - echo `google-chrome --version`
   - echo `google-chrome-beta --version`

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
       - sourceline: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
         key_url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
     packages:
-      - google-chrome
+      - google-chrome-beta
       - ffmpeg
       - libimage-exiftool-perl
       - openjdk-8-jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
       - sourceline: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
         key_url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
     packages:
-      - google-chrome-beta
+      - google-chrome
       - ffmpeg
       - libimage-exiftool-perl
       - openjdk-8-jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ install:
   - unzip chromedriver_linux64.zip
   - echo "google chrome version"
   - echo `google-chrome --version`
+  - echo `google-chrome-beta --version`
+  - echo `google-chrome-unstable --version`
+  - echo `google-chrome-stable --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,14 @@ jobs:
         - ci/s3cp.sh target/reference-language-pack.zip                  $S3_DEST_BUILD
         - ci/s3cp.sh target/scriptingapi-javadoc-*.zip                   $S3_DEST_BUILD
     - stage: build and check
+      script: sbt "project IntegTester" package
+      workspaces:
+        create:
+          name: prebuilt-integtester
+          paths:
+            - autotest/IntegTester/target/
+      name: Pre-build IntegTester
+    - stage: build and check
       script: sbt test
       name: Unit test
     - stage: build and check
@@ -105,7 +113,9 @@ jobs:
         installEquella startEquella configureInstall setupForTests \
         Tests/test dumpCoverage
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: Scalacheck
       after_script: ci/scalacheck-save-results.sh Tests
     - stage: functional test
@@ -113,21 +123,27 @@ jobs:
         installEquella startEquella configureInstall setupForTests \
         Tests/Serial/test dumpCoverage
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: Scalacheck Serial
       after_script: ci/scalacheck-save-results.sh Tests-Serial
     # Admin
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (admin)
       env: OLD_TEST_SUITE=admin
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (admin - new UI)
       env:
         - OLD_TEST_SUITE=admin
@@ -137,14 +153,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (advanced script controls - ASC)
       env: OLD_TEST_SUITE=asc
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (advanced script controls - ASC - new UI)
       env:
         - OLD_TEST_SUITE=asc
@@ -154,14 +174,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (contribution)
       env: OLD_TEST_SUITE=contribution
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (contribution - new UI)
       env:
         - OLD_TEST_SUITE=contribution
@@ -171,14 +195,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (controls)
       env: OLD_TEST_SUITE=controls
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (controls - new UI)
       env:
         - OLD_TEST_SUITE=controls
@@ -188,14 +216,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (searching)
       env: OLD_TEST_SUITE=searching
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (searching - new UI)
       env:
         - OLD_TEST_SUITE=searching
@@ -205,14 +237,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (users)
       env: OLD_TEST_SUITE=users
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (users - new UI)
       env:
         - OLD_TEST_SUITE=users
@@ -222,14 +258,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (viewing)
       env: OLD_TEST_SUITE=viewing
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (viewing - new UI)
       env:
         - OLD_TEST_SUITE=viewing
@@ -239,14 +279,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (webservices)
       env: OLD_TEST_SUITE=webservices
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (webservices - new UI)
       env:
         - OLD_TEST_SUITE=webservices
@@ -256,14 +300,18 @@ jobs:
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (workflow)
       env: OLD_TEST_SUITE=workflow
       after_script: ci/oldtests-save-results.sh
     - stage: functional test
       script: ci/oldtests-run.sh
       workspaces:
-        use: oeq-installer
+        use:
+          - oeq-installer
+          - prebuilt-integtester
       name: TestNG (workflow - new UI)
       env:
         - OLD_TEST_SUITE=workflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ addons:
   postgresql: "9.6"
   apt:
     sources:
-      - google-chrome
+      - sourceline: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+        key_url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
     packages:
       - google-chrome-beta
       - ffmpeg

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ services:
   - postgresql
 addons:
   postgresql: "9.6"
+  chrome: beta
   apt:
     packages:
       - ffmpeg
@@ -50,8 +51,8 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
-  - wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-  - sudo dpkg -i google-chrome-beta_current_amd64.deb
+  #  - wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+  #  - sudo dpkg -i google-chrome-beta_current_amd64.deb
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - echo "google chrome version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,7 @@ jobs:
           name: prebuilt-integtester
           paths:
             - autotest/IntegTester/target/
-            - autotest/IntegTester/ps/output/
-            - autotest/IntegTester/ps/target/
+            - autotest/IntegTester/ps/
       name: Pre-build IntegTester
     - stage: build and check
       script: sbt test
@@ -111,9 +110,14 @@ jobs:
       name: Build the Import/Export tool
 
     - stage: functional test
-      script: sbt -jvm-opts autotest/.jvmopts "project autotest" \
-        installEquella startEquella configureInstall setupForTests \
-        Tests/test dumpCoverage
+      script:
+        # DEBUG: Confirm PS directory is being properly cached
+        - ls -l autotest/IntegTester/ps/
+        # DEBUG: Confirm Target directory is being properly cached
+        - ls -l autotest/IntegTester/target/
+        - sbt -jvm-opts autotest/.jvmopts "project autotest" \
+          installEquella startEquella configureInstall setupForTests \
+          Tests/test dumpCoverage
       workspaces:
         use:
           - oeq-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ before_script:
 stages:
   - name: build and check
   - name: functional test
-    if: false # Currently disabled due to Travis now running with Chromium 79 which is having issues headless
   - name: finalise
     if: fork = false # No access to S3, so skip for forks
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,6 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
-  #  - wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-  #  - sudo dpkg -i google-chrome-beta_current_amd64.deb
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo apt-get purge google-chrome-stable # have to delete the stable version to force chromedriver to use the beta
@@ -116,10 +114,6 @@ jobs:
 
     - stage: functional test
       script:
-        # DEBUG: Confirm PS directory is being properly cached
-        - ls -l autotest/IntegTester/ps/
-        # DEBUG: Confirm Target directory is being properly cached
-        - ls -l autotest/IntegTester/target/
         - sbt -jvm-opts autotest/.jvmopts "project autotest" \
           installEquella startEquella configureInstall setupForTests \
           Tests/test dumpCoverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - echo "google chrome version"
-  - echo google-chrome --version
+  - echo `google-chrome --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ install:
   #  - sudo dpkg -i google-chrome-beta_current_amd64.deb
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
+  - whereis google-chrome
+  - whereis google-chrome-beta
   - echo "google chrome version"
   - echo `google-chrome --version`
   - echo `google-chrome-beta --version`

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ env:
 services:
   - postgresql
 addons:
-  chrome: beta
   postgresql: "9.6"
   apt:
     packages:
+      - google-chrome-beta
       - ffmpeg
       - libimage-exiftool-perl
       - openjdk-8-jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,8 @@ install:
   #  - sudo dpkg -i google-chrome-beta_current_amd64.deb
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
-  - whereis google-chrome
-  - whereis google-chrome-beta
-  - sudo apt-get purge google-chrome-stable
-  - whereis google-chrome
-  - whereis google-chrome-beta
-  - echo "google chrome version"
+  - sudo apt-get purge google-chrome-stable # have to delete the stable version to force chromedriver to use the beta
   - echo `google-chrome --version`
-  - echo `google-chrome-beta --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
     - master
     - /^release\/.+/
     - /^stable-.+/
+    - /^travis\/.+/
 env:
   global:
     ### AWS START ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,10 @@ env:
 services:
   - postgresql
 addons:
+  chrome: beta
   postgresql: "9.6"
   apt:
     packages:
-      - chromium-browser
-      - chromium-chromedriver
       - ffmpeg
       - libimage-exiftool-perl
       - openjdk-8-jdk
@@ -52,6 +51,8 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
+  - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - unzip chromedriver_linux64.zip
   - whereis google-chrome
   - whereis google-chrome-beta
-  - apt-get purge google-chrome-stable
+  - sudo apt-get purge google-chrome-stable
   - whereis google-chrome
   - whereis google-chrome-beta
   - echo "google chrome version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ before_install:
 install:
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
+  - echo "google chrome version"
+  - echo google-chrome --version
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,7 @@ services:
 addons:
   postgresql: "9.6"
   apt:
-    sources:
-      - sourceline: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
-        key_url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
     packages:
-      - google-chrome-beta
       - ffmpeg
       - libimage-exiftool-perl
       - openjdk-8-jdk
@@ -54,13 +50,13 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
+  - wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+  - sudo dpkg -i google-chrome-beta_current_amd64.deb
   - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - echo "google chrome version"
   - echo `google-chrome --version`
   - echo `google-chrome-beta --version`
-  - echo `google-chrome-unstable --version`
-  - echo `google-chrome-stable --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ services:
 addons:
   postgresql: "9.6"
   apt:
+    sources:
+      - google-chrome
     packages:
       - google-chrome-beta
       - ffmpeg

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,8 @@ jobs:
           name: prebuilt-integtester
           paths:
             - autotest/IntegTester/target/
+            - autotest/IntegTester/ps/output/
+            - autotest/IntegTester/ps/target/
       name: Pre-build IntegTester
     - stage: build and check
       script: sbt test

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
@@ -139,7 +139,7 @@ public class UserServiceImpl
 
   @Transactional
   @Override
-  public void saveUserInfoBackup(UserBean userBean) {
+  public synchronized void saveUserInfoBackup(UserBean userBean) {
     String userUniqueId = userBean.getUniqueID();
     UserInfoBackup userInfoBackup = findUserInfoBackup(userUniqueId);
     if (userInfoBackup == null) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
@@ -139,7 +139,7 @@ public class UserServiceImpl
 
   @Transactional
   @Override
-  public synchronized void saveUserInfoBackup(UserBean userBean) {
+  public void saveUserInfoBackup(UserBean userBean) {
     String userUniqueId = userBean.getUniqueID();
     UserInfoBackup userInfoBackup = findUserInfoBackup(userUniqueId);
     if (userInfoBackup == null) {
@@ -492,7 +492,9 @@ public class UserServiceImpl
   public void userSessionCreatedEvent(UserSessionLoginEvent event) {
     UserState userState = event.getUserState();
     if (!userState.isGuest()) {
-      saveUserInfoBackup(userState.getUserBean());
+      synchronized (this) {
+        saveUserInfoBackup(userState.getUserBean());
+      }
     }
   }
 

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/cal/CALActivationsRolloverTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/cal/CALActivationsRolloverTest.java
@@ -7,6 +7,7 @@ import com.tle.webtests.pageobject.cal.ActivationListPage;
 import com.tle.webtests.pageobject.cal.CALRolloverDialog;
 import com.tle.webtests.pageobject.cal.CALSummaryPage;
 import com.tle.webtests.pageobject.cal.ManageActivationsPage;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.annotations.Test;
 
 public class CALActivationsRolloverTest extends AbstractActivationsTest {
@@ -40,7 +41,18 @@ public class CALActivationsRolloverTest extends AbstractActivationsTest {
     rolloverDialog.selectCourse(ROLLOVER_COURSE);
     assertTrue(rolloverDialog.execute(activationResults));
 
+    activations
+        .getWaiter()
+        .until(
+            ExpectedConditions.textToBePresentInElement(
+                activationResults.getResultsDiv(), ORIGINAL_COURSE));
     assertTrue(activationResults.isShowing(portionName, ORIGINAL_COURSE));
+
+    activations
+        .getWaiter()
+        .until(
+            ExpectedConditions.textToBePresentInElement(
+                activationResults.getResultsDiv(), ROLLOVER_COURSE));
     assertTrue(activationResults.isShowing(portionName, ROLLOVER_COURSE));
 
     // bulk all activations rollover using same course + dates

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -234,8 +234,9 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     AttachmentsPage attachments = wizard.save().publish().attachments();
     assertTrue(attachments.attachmentExists("Empty Node"));
     PackageViewer pv = attachments.viewFullscreen();
-    assertEquals(pv.tabText("", "Tab 1"), "");
-    assertEquals(pv.tabText("", "Another Tab"), "This is a verifiable attachment");
+    assertEquals(pv.tabText("", "Tab 1", ""), "");
+    String expectedText = "This is a verifiable attachment";
+    assertEquals(pv.tabText("", "Another Tab", expectedText), expectedText);
     // DTEC-14853
     assertEquals(pv.getTabOrder(), Lists.newArrayList("Tab 1", "Another Tab"));
   }
@@ -294,7 +295,9 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     PackageViewer viewer = attachments.viewFullscreen();
     viewer.clickAttachment("pageC.html");
     assertTrue(viewer.selectedAttachmentContainsText("This is a verifiable attachment 3"));
-    assertEquals(viewer.tabText("Tab holder", "Tab number 2"), "This is a verifiable attachment 2");
+
+    String expectedText = "This is a verifiable attachment 2";
+    assertEquals(viewer.tabText("Tab holder", "Tab number 2", expectedText), expectedText);
     // DTEC-14853
     assertEquals(viewer.getTabOrder(), Lists.newArrayList("Tab number 1", "Tab number 2"));
 
@@ -309,10 +312,11 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     viewer.clickAttachment("Tab holder");
     viewer.clickSplitView();
 
-    assertEquals(
-        viewer.tabText("Tab holder", "Tab number 1", 0), "This is a verifiable attachment 3");
-    assertEquals(
-        viewer.tabText("Tab holder", "Tab number 2", 1), "This is a verifiable attachment 2");
+    expectedText = "This is a verifiable attachment 3";
+    assertEquals(viewer.tabText("Tab holder", "Tab number 1", expectedText, 0), expectedText);
+
+    expectedText = "This is a verifiable attachment 2";
+    assertEquals(viewer.tabText("Tab holder", "Tab number 2", expectedText, 1), expectedText);
     // DTEC-14853
     assertEquals(viewer.getTabOrder(), Lists.newArrayList("Tab number 1", "Tab number 2"));
 

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -235,7 +235,9 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(attachments.attachmentExists("Empty Node"));
     PackageViewer pv = attachments.viewFullscreen();
     assertEquals(pv.tabText("", "Tab 1"), "");
-    pv.get();
+    context.getDriver().navigate().back();
+    attachments.get();
+    attachments.viewFullscreen();
     assertEquals(pv.tabText("", "Another Tab"), "This is a verifiable attachment");
     // DTEC-14853
     assertEquals(pv.getTabOrder(), Lists.newArrayList("Tab 1", "Another Tab"));

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -235,9 +235,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(attachments.attachmentExists("Empty Node"));
     PackageViewer pv = attachments.viewFullscreen();
     assertEquals(pv.tabText("", "Tab 1"), "");
-    context.getDriver().navigate().back();
-    attachments.get();
-    attachments.viewFullscreen();
     assertEquals(pv.tabText("", "Another Tab"), "This is a verifiable attachment");
     // DTEC-14853
     assertEquals(pv.getTabOrder(), Lists.newArrayList("Tab 1", "Another Tab"));

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -234,9 +234,9 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     AttachmentsPage attachments = wizard.save().publish().attachments();
     assertTrue(attachments.attachmentExists("Empty Node"));
     PackageViewer pv = attachments.viewFullscreen();
-    assertEquals(pv.tabText("", "Tab 1", ""), "");
-    String expectedText = "This is a verifiable attachment";
-    assertEquals(pv.tabText("", "Another Tab", expectedText), expectedText);
+    assertEquals(pv.tabText("", "Tab 1"), "");
+    pv.get();
+    assertEquals(pv.tabText("", "Another Tab"), "This is a verifiable attachment");
     // DTEC-14853
     assertEquals(pv.getTabOrder(), Lists.newArrayList("Tab 1", "Another Tab"));
   }
@@ -296,8 +296,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     viewer.clickAttachment("pageC.html");
     assertTrue(viewer.selectedAttachmentContainsText("This is a verifiable attachment 3"));
 
-    String expectedText = "This is a verifiable attachment 2";
-    assertEquals(viewer.tabText("Tab holder", "Tab number 2", expectedText), expectedText);
+    assertEquals(viewer.tabText("Tab holder", "Tab number 2"), "This is a verifiable attachment 2");
     // DTEC-14853
     assertEquals(viewer.getTabOrder(), Lists.newArrayList("Tab number 1", "Tab number 2"));
 
@@ -312,11 +311,11 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     viewer.clickAttachment("Tab holder");
     viewer.clickSplitView();
 
-    expectedText = "This is a verifiable attachment 3";
-    assertEquals(viewer.tabText("Tab holder", "Tab number 1", expectedText, 0), expectedText);
+    assertEquals(
+        viewer.tabText("Tab holder", "Tab number 1", 0), "This is a verifiable attachment 3");
 
-    expectedText = "This is a verifiable attachment 2";
-    assertEquals(viewer.tabText("Tab holder", "Tab number 2", expectedText, 1), expectedText);
+    assertEquals(
+        viewer.tabText("Tab holder", "Tab number 2", 1), "This is a verifiable attachment 2");
     // DTEC-14853
     assertEquals(viewer.getTabOrder(), Lists.newArrayList("Tab number 1", "Tab number 2"));
 

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -297,7 +297,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     PackageViewer viewer = attachments.viewFullscreen();
     viewer.clickAttachment("pageC.html");
     assertTrue(viewer.selectedAttachmentContainsText("This is a verifiable attachment 3"));
-
     assertEquals(viewer.tabText("Tab holder", "Tab number 2"), "This is a verifiable attachment 2");
     // DTEC-14853
     assertEquals(viewer.getTabOrder(), Lists.newArrayList("Tab number 1", "Tab number 2"));
@@ -315,7 +314,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
 
     assertEquals(
         viewer.tabText("Tab holder", "Tab number 1", 0), "This is a verifiable attachment 3");
-
     assertEquals(
         viewer.tabText("Tab holder", "Tab number 2", 1), "This is a verifiable attachment 2");
     // DTEC-14853

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/asc/AdvancedScriptControlTests.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/asc/AdvancedScriptControlTests.java
@@ -1086,6 +1086,8 @@ public class AdvancedScriptControlTests extends AbstractCleanupTest {
 
   private void ascEditbox(int ctrlNum, String suffix, String text) {
     WebElement field = context.getDriver().findElement(By.name("c" + ctrlNum + suffix));
+    WebDriverWait wait = new WebDriverWait(context.getDriver(), 30);
+    wait.until(ExpectedConditions.visibilityOf(field));
     field.clear();
     field.sendKeys(text);
   }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/asc/AdvancedScriptControlTests.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/asc/AdvancedScriptControlTests.java
@@ -39,6 +39,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.annotations.Test;
 
 @TestInstitution("asc")
@@ -1065,7 +1066,10 @@ public class AdvancedScriptControlTests extends AbstractCleanupTest {
    * @return
    */
   private WebElement getAscMessage() {
-    return context.getDriver().findElement(By.xpath("//div[@id='ascMessage']/pre"));
+    By ascMessageXpath = By.xpath("//div[@id='ascMessage']/pre");
+    WebDriverWait wait = new WebDriverWait(context.getDriver(), 30);
+    wait.until(ExpectedConditions.visibilityOfElementLocated(ascMessageXpath));
+    return context.getDriver().findElement(ascMessageXpath);
   }
 
   private WebElement getAscMessage1() {
@@ -1093,6 +1097,8 @@ public class AdvancedScriptControlTests extends AbstractCleanupTest {
    * @param text
    */
   private void ascSelectDropdown(String id, String optText) {
+    WebDriverWait wait = new WebDriverWait(context.getDriver(), 30);
+    wait.until(ExpectedConditions.presenceOfElementLocated(By.id(id)));
     Select dropdown = new Select(context.getDriver().findElement(By.id(id)));
     dropdown.selectByVisibleText(optText);
   }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
@@ -32,6 +32,7 @@ import com.tle.webtests.pageobject.viewitem.SummaryPage;
 import com.tle.webtests.pageobject.wizard.ContributePage;
 import com.tle.webtests.pageobject.wizard.WizardPageTab;
 import com.tle.webtests.test.AbstractCleanupTest;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -354,6 +355,9 @@ public class PortalsTest extends AbstractCleanupTest {
 
     // Edit portlet for description option
     home = new MenuSection(context).home();
+    recent
+        .getWaiter()
+        .until(ExpectedConditions.textToBePresentInElement(recent.getBoxHead(), recentName));
     edit = recent.edit(portal);
     edit.setDisplayTitleOnly(true);
     edit.save(new HomePage(context));

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
@@ -32,7 +32,6 @@ import com.tle.webtests.pageobject.viewitem.SummaryPage;
 import com.tle.webtests.pageobject.wizard.ContributePage;
 import com.tle.webtests.pageobject.wizard.WizardPageTab;
 import com.tle.webtests.test.AbstractCleanupTest;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -355,9 +354,7 @@ public class PortalsTest extends AbstractCleanupTest {
 
     // Edit portlet for description option
     home = new MenuSection(context).home();
-    recent
-        .getWaiter()
-        .until(ExpectedConditions.textToBePresentInElement(recent.getBoxHead(), recentName));
+    recent = new RecentContributionsSection(context, recentName).get();
     edit = recent.edit(portal);
     edit.setDisplayTitleOnly(true);
     edit.save(new HomePage(context));

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
@@ -322,6 +322,7 @@ public class PortalsTest extends AbstractCleanupTest {
     // Edit the portal
     RecentContributionsEditPage edit = recent.edit(portal);
     edit.setStatus("draft");
+    edit.checkSelectedCollection();
     edit.save(new HomePage(context));
 
     // Check that the draft item is displayed

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
@@ -345,6 +345,7 @@ public class PortalsTest extends AbstractCleanupTest {
     edit = recent.edit(portal);
     edit.setQuery("query item");
     edit.setStatus("live");
+    edit.checkSelectedCollection();
     edit.save(new HomePage(context));
     // Check that the queried item is displayed
     home = new MenuSection(context).home();
@@ -357,6 +358,7 @@ public class PortalsTest extends AbstractCleanupTest {
     recent = new RecentContributionsSection(context, recentName).get();
     edit = recent.edit(portal);
     edit.setDisplayTitleOnly(true);
+    edit.checkSelectedCollection();
     edit.save(new HomePage(context));
 
     // Check that the description not displayed

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/dashboard/PortalsTest.java
@@ -350,7 +350,7 @@ public class PortalsTest extends AbstractCleanupTest {
     home = new MenuSection(context).home();
     recent = new RecentContributionsSection(context, recentName).get();
     assertTrue(recent.recentContributionExists(itemToQuery));
-    assertTrue(recent.descriptionExists(description));
+    assertTrue(recent.descriptionExists(description, true));
 
     // Edit portlet for description option
     home = new MenuSection(context).home();
@@ -361,7 +361,7 @@ public class PortalsTest extends AbstractCleanupTest {
     // Check that the description not displayed
     home = new MenuSection(context).home();
     recent = new RecentContributionsSection(context, recentName).get();
-    assertFalse(recent.descriptionExists(description));
+    assertFalse(recent.descriptionExists(description, false));
   }
 
   @Test

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/viewing/ItemSummaryTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/viewing/ItemSummaryTest.java
@@ -68,6 +68,7 @@ public class ItemSummaryTest extends AbstractCleanupTest {
     logon();
     SearchPage searchPage = new SearchPage(context).load();
     ItemListPage itemList = searchPage.resultsPageObject();
+    searchPage.exactQuery(LAST_KNOWN_OWNER_ITEM_NAME);
     SummaryPage summaryPage = itemList.getResultForTitle(LAST_KNOWN_OWNER_ITEM_NAME).viewSummary();
 
     // Check if LAST_KNOWN_OWNER_ITEM_NAME is displayed instead of 'unknown user'

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
@@ -414,6 +414,12 @@ public abstract class AbstractPage<T extends PageObject>
   @Override
   public T get() {
     refreshTime = System.currentTimeMillis();
+    getWaiter()
+        .until(
+            driver ->
+                ((JavascriptExecutor) driver)
+                    .executeScript("return document.readyState")
+                    .equals("complete"));
     return getWaiter()
         .until(
             new ExpectedCondition<T>() {

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
@@ -414,6 +414,8 @@ public abstract class AbstractPage<T extends PageObject>
   @Override
   public T get() {
     refreshTime = System.currentTimeMillis();
+    // Due to some of the pages using various Sections AJAXy stuff, we need
+    // a bit more thorough wait checking then the plain old check by Selenium.
     getWaiter()
         .until(
             driver ->

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -75,7 +75,12 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     showButtons();
-    WebElement editButton = getBoxHead().findElement(By.className("box_edit"));
+    WebElement editButton =
+        driver.findElement(
+            By.xpath(
+                "//div[contains(@title,"
+                    + quoteXPath(getTitle())
+                    + ")]/following-sibling::img[contains(@class, 'box_edit')]"));
     waiter.until(ExpectedConditions.elementToBeClickable(editButton));
     editButton.click();
     return portal.get();

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -2,6 +2,7 @@ package com.tle.webtests.pageobject.portal;
 
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.AbstractPage;
+import com.tle.webtests.pageobject.ExpectedConditions2;
 import com.tle.webtests.pageobject.HomePage;
 import com.tle.webtests.pageobject.WaitingPageObject;
 import org.openqa.selenium.By;
@@ -74,7 +75,11 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     showButtons();
-    getBoxHead().findElement(By.className("box_edit")).click();
+    WebElement boxHead = getBoxHead();
+    waiter.until(ExpectedConditions2.presenceOfElement(boxHead));
+    waiter.until(
+        ExpectedConditions2.presenceOfElement(boxHead.findElement(By.className("box_edit"))));
+    boxHead.findElement(By.className("box_edit")).click();
     return portal.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -2,13 +2,13 @@ package com.tle.webtests.pageobject.portal;
 
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.AbstractPage;
-import com.tle.webtests.pageobject.ExpectedConditions2;
 import com.tle.webtests.pageobject.HomePage;
 import com.tle.webtests.pageobject.WaitingPageObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
     extends AbstractPage<T> {
@@ -19,7 +19,7 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
     this.title = title;
   }
 
-  protected WebElement getBoxHead() {
+  public WebElement getBoxHead() {
     return find(
         driver,
         By.xpath(
@@ -75,11 +75,9 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
 
   public <P extends AbstractPortalEditPage<P>> P edit(P portal) {
     showButtons();
-    WebElement boxHead = getBoxHead();
-    waiter.until(ExpectedConditions2.presenceOfElement(boxHead));
-    waiter.until(
-        ExpectedConditions2.presenceOfElement(boxHead.findElement(By.className("box_edit"))));
-    boxHead.findElement(By.className("box_edit")).click();
+    WebElement editButton = getBoxHead().findElement(By.className("box_edit"));
+    waiter.until(ExpectedConditions.elementToBeClickable(editButton));
+    editButton.click();
     return portal.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/AbstractPortalSection.java
@@ -19,7 +19,7 @@ public abstract class AbstractPortalSection<T extends AbstractPortalSection<T>>
     this.title = title;
   }
 
-  public WebElement getBoxHead() {
+  protected WebElement getBoxHead() {
     return find(
         driver,
         By.xpath(

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsEditPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsEditPage.java
@@ -3,6 +3,7 @@ package com.tle.webtests.pageobject.portal;
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.generic.component.EquellaSelect;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 public class RecentContributionsEditPage
     extends AbstractPortalEditPage<RecentContributionsEditPage> {
@@ -21,6 +22,12 @@ public class RecentContributionsEditPage
     super.checkLoaded();
     stausList = new EquellaSelect(context, driver.findElement(By.id("rct_s")));
     displayList = new EquellaSelect(context, driver.findElement(By.id("rct_d")));
+  }
+
+  public void checkSelectedCollection() {
+    WebElement allResourceOption =
+        driver.findElement(By.xpath("//input[@id=//label[text()='All resources']/@for]"));
+    if (!allResourceOption.isSelected()) allResourceOption.click();
   }
 
   @Override

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
@@ -11,29 +11,21 @@ public class RecentContributionsSection extends AbstractPortalSection<RecentCont
   }
 
   public boolean recentContributionExists(String itemName) {
-    waiter.until(
-        ExpectedConditions.visibilityOfElementLocated(
-            By.xpath("//a[normalize-space(text())=" + quoteXPath(itemName) + "]")));
-    return isPresent(
-        getBoxContent(),
+    By recentContributionXpath =
         By.xpath(
             ".//div[normalize-space(@class)='recent-items']//a[normalize-space(text())="
                 + quoteXPath(itemName)
-                + "]"));
+                + "]");
+    waiter.until(ExpectedConditions.visibilityOfElementLocated(recentContributionXpath));
+    return isPresent(recentContributionXpath);
   }
 
   public boolean descriptionExists(String description, boolean expectedExisting) {
-    String descriptionQuoteXpath = quoteXPath(description);
+    By descriptionQuoteXpath =
+        By.xpath("//p[normalize-space(text())=" + quoteXPath(description) + "]");
     if (expectedExisting) {
-      waiter.until(
-          ExpectedConditions.visibilityOfElementLocated(
-              By.xpath("//p[normalize-space(text())=" + descriptionQuoteXpath + "]")));
+      waiter.until(ExpectedConditions.visibilityOfElementLocated(descriptionQuoteXpath));
     }
-    return isPresent(
-        getBoxContent(),
-        By.xpath(
-            ".//div[normalize-space(@class)='recent-items']//p[normalize-space(text())="
-                + descriptionQuoteXpath
-                + "]"));
+    return isPresent(descriptionQuoteXpath);
   }
 }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
@@ -2,6 +2,7 @@ package com.tle.webtests.pageobject.portal;
 
 import com.tle.webtests.framework.PageContext;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class RecentContributionsSection extends AbstractPortalSection<RecentContributionsSection> {
 
@@ -18,12 +19,18 @@ public class RecentContributionsSection extends AbstractPortalSection<RecentCont
                 + "]"));
   }
 
-  public boolean descriptionExists(String description) {
+  public boolean descriptionExists(String description, boolean expectedExisting) {
+    String descriptionQuoteXpath = quoteXPath(description);
+    if (expectedExisting) {
+      waiter.until(
+          ExpectedConditions.visibilityOfElementLocated(
+              By.xpath("//p[normalize-space(text())=" + descriptionQuoteXpath + "]")));
+    }
     return isPresent(
         getBoxContent(),
         By.xpath(
             ".//div[normalize-space(@class)='recent-items']//p[normalize-space(text())="
-                + quoteXPath(description)
+                + descriptionQuoteXpath
                 + "]"));
   }
 }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
@@ -11,6 +11,9 @@ public class RecentContributionsSection extends AbstractPortalSection<RecentCont
   }
 
   public boolean recentContributionExists(String itemName) {
+    waiter.until(
+        ExpectedConditions.visibilityOfElementLocated(
+            By.xpath("//a[normalize-space(text())=" + quoteXPath(itemName) + "]")));
     return isPresent(
         getBoxContent(),
         By.xpath(

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/tasklist/ModerationView.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/tasklist/ModerationView.java
@@ -11,6 +11,7 @@ import com.tle.webtests.pageobject.wizard.RejectMessagePage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class ModerationView extends AbstractPage<ModerationView> {
   @FindBy(className = "moderate-reject")
@@ -48,6 +49,7 @@ public class ModerationView extends AbstractPage<ModerationView> {
   }
 
   public ModerationMessagePage acceptToMessagePage() {
+    waiter.until(ExpectedConditions.elementToBeClickable(approveButton));
     approveButton.click();
     return new ApproveMessagePage(context).get();
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
@@ -93,10 +93,8 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
     switchToFrame(split);
     driver.findElement(By.xpath("//a/span[text()=" + quoteXPath(tabName) + "]")).click();
     waiter.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("iframe-content"));
-    By body = By.tagName("body");
-    waiter.until(ExpectedConditions.numberOfWindowsToBe(1));
-    waiter.until(ExpectedConditions.visibilityOfElementLocated(body));
-    String text = driver.findElement(body).getAttribute("innerText");
+    By body = By.cssSelector("body");
+    String text = waiter.until(ExpectedConditions.visibilityOfElementLocated(body)).getText();
     driver.switchTo().defaultContent();
     return text;
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
@@ -85,19 +85,21 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
     return rv;
   }
 
-  public String tabText(String attachment, String tabName) {
-    return tabText(attachment, tabName, 0);
+  public String tabText(String attachment, String tabName, String expectedText) {
+    return tabText(attachment, tabName, expectedText, 0);
   }
 
-  public String tabText(String attachment, String tabName, int split) {
+  public String tabText(String attachment, String tabName, String expectedText, int split) {
     clickAttachment(attachment);
     switchToFrame(split);
     driver.findElement(By.xpath("//a/span[text()=" + quoteXPath(tabName) + "]")).click();
     waiter.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("iframe-content"));
 
     waitForBody();
+    WebElement body = driver.findElement(By.cssSelector("body"));
+    waiter.until(ExpectedConditions.textToBePresentInElement(body, expectedText));
 
-    String text = driver.findElement(By.tagName("body")).getText();
+    String text = body.getText();
     driver.switchTo().defaultContent();
     return text;
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
@@ -65,8 +65,7 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
           @Override
           public Boolean apply(WebDriver d) {
             try {
-              WebElement body = driver.findElement(By.tagName("body"));
-              waiter.until(ExpectedConditions.visibilityOf(body));
+              driver.findElement(By.tagName("body"));
               return Boolean.TRUE;
             } catch (StaleElementReferenceException ste) {
               return Boolean.FALSE;
@@ -94,8 +93,9 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
     switchToFrame(split);
     driver.findElement(By.xpath("//a/span[text()=" + quoteXPath(tabName) + "]")).click();
     waiter.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("iframe-content"));
-    waitForBody();
-    String text = driver.findElement(By.tagName("body")).getText();
+    By body = By.tagName("body");
+    waiter.until(ExpectedConditions.visibilityOfElementLocated(body));
+    String text = driver.findElement(body).getAttribute("innerText");
     driver.switchTo().defaultContent();
     return text;
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class PackageViewer extends AbstractPage<PackageViewer> {
 
@@ -64,7 +65,8 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
           @Override
           public Boolean apply(WebDriver d) {
             try {
-              driver.findElement(By.tagName("body"));
+              WebElement body = driver.findElement(By.tagName("body"));
+              waiter.until(ExpectedConditions.visibilityOf(body));
               return Boolean.TRUE;
             } catch (StaleElementReferenceException ste) {
               return Boolean.FALSE;
@@ -91,7 +93,7 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
     clickAttachment(attachment);
     switchToFrame(split);
     driver.findElement(By.xpath("//a/span[text()=" + quoteXPath(tabName) + "]")).click();
-    driver.switchTo().frame("iframe-content");
+    waiter.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("iframe-content"));
 
     waitForBody();
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
@@ -85,21 +85,17 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
     return rv;
   }
 
-  public String tabText(String attachment, String tabName, String expectedText) {
-    return tabText(attachment, tabName, expectedText, 0);
+  public String tabText(String attachment, String tabName) {
+    return tabText(attachment, tabName, 0);
   }
 
-  public String tabText(String attachment, String tabName, String expectedText, int split) {
+  public String tabText(String attachment, String tabName, int split) {
     clickAttachment(attachment);
     switchToFrame(split);
     driver.findElement(By.xpath("//a/span[text()=" + quoteXPath(tabName) + "]")).click();
     waiter.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("iframe-content"));
-
     waitForBody();
-    WebElement body = driver.findElement(By.cssSelector("body"));
-    waiter.until(ExpectedConditions.textToBePresentInElement(body, expectedText));
-
-    String text = body.getText();
+    String text = driver.findElement(By.tagName("body")).getText();
     driver.switchTo().defaultContent();
     return text;
   }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/PackageViewer.java
@@ -94,6 +94,7 @@ public class PackageViewer extends AbstractPage<PackageViewer> {
     driver.findElement(By.xpath("//a/span[text()=" + quoteXPath(tabName) + "]")).click();
     waiter.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("iframe-content"));
     By body = By.tagName("body");
+    waiter.until(ExpectedConditions.numberOfWindowsToBe(1));
     waiter.until(ExpectedConditions.visibilityOfElementLocated(body));
     String text = driver.findElement(body).getAttribute("innerText");
     driver.switchTo().defaultContent();

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/AbstractWizardControlPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/AbstractWizardControlPage.java
@@ -345,11 +345,13 @@ public abstract class AbstractWizardControlPage<T extends AbstractWizardControlP
   }
 
   public String getErrorMessage(int ctrlNum) {
-    return driver
-        .findElement(
+    WebElement errorMessage =
+        driver.findElement(
             By.xpath(
-                "id(" + quoteXPath(getControlId(ctrlNum)) + ")/div/p[@class='ctrlinvalidmessage']"))
-        .getText()
-        .trim();
+                "id("
+                    + quoteXPath(getControlId(ctrlNum))
+                    + ")/div/p[@class='ctrlinvalidmessage']"));
+    waiter.until(ExpectedConditions.visibilityOf(errorMessage));
+    return errorMessage.getText().trim();
   }
 }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/AbstractWizardTab.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/AbstractWizardTab.java
@@ -46,8 +46,8 @@ public abstract class AbstractWizardTab<T extends AbstractWizardTab<T>> extends 
     } else {
       xpath = "//div[@id='wizard-actions']/a[normalize-space(text())=" + quoteXPath(command) + "]";
     }
-    WebElement elem = driver.findElement(By.xpath(xpath));
     ((JavascriptExecutor) driver).executeScript("window.scrollTo(0, -document.body.scrollHeight)");
+    WebElement elem = driver.findElement(By.xpath(xpath));
     waiter.until(ExpectedConditions.elementToBeClickable(elem));
     elem.click();
   }

--- a/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -39,10 +39,13 @@ case class LoginNoticePage(ctx: PageContext)
 
   private def switchToTinyMCEIFrame(): Unit = {
     driver.switchTo().frame(preNoticeIFrame)
+    waiter.until(ExpectedConditions.presenceOfElementLocated(By.id("tinymce")))
   }
 
   private def switchFromTinyMCEIFrame(): Unit = {
     driver.switchTo().defaultContent()
+    waiter.until(
+      ExpectedConditions.presenceOfElementLocated(By.xpath("//h5[text()='Login notice editor']")))
   }
 
   private def clearAndPopulatePreNoticeField(notice: String): Unit = {

--- a/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -47,8 +47,8 @@ case class LoginNoticePage(ctx: PageContext)
 
   private def clearAndPopulatePreNoticeField(notice: String): Unit = {
     switchToTinyMCEIFrame()
-    preNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
-    preNoticeField.sendKeys(Keys.DELETE)
+    preNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a", Keys.BACK_SPACE))
+
     preNoticeField.sendKeys(notice)
     waitFor(ExpectedConditions.textToBePresentInElement(preNoticeField, notice))
   }
@@ -124,8 +124,7 @@ case class LoginNoticePage(ctx: PageContext)
 
   def populatePostNoticeField(notice: String): Unit = {
     gotoPostNoticeTab()
-    postNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
-    postNoticeField.sendKeys(Keys.DELETE)
+    postNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a", Keys.BACK_SPACE))
     postNoticeField.sendKeys(notice)
   }
 

--- a/autotest/travis.conf
+++ b/autotest/travis.conf
@@ -2,7 +2,7 @@ server.url = "http://localhost:8080/"
 server.password = autotestpassword
 
 webdriver.chrome {
-  driver = "/usr/lib/chromium-browser/chromedriver"
+  driver = ${TRAVIS_BUILD_DIR}"/chromedriver"
   headless = true
 }
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

This PR aims to make the Selenium tests more stable. 

PackageAndNavigationTest is less likely to fail. This test was very stable before the version 79 of Chrome . Although we use the beta version Chrome and make some changes, this test can still fail intermittently. So this test should become stable again once the next stable version of Chrome is available.

PortalsTest and AdvancedScriptingControlTest are less likely to fail.

For the oEQ installing issue (only failed on Travis), just need more builds to verify the fix.

For the Scala tests which sometimes fail on Codebuild, it should not happen any more.





