### PR TITLE
Update the incorrect link in the apidocs.do page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/view/swagger.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/swagger.ftl
@@ -6,8 +6,8 @@
 <div class="area">
 	<h2>${b.key('docs.title')}</h2>
 
-	<p>${b.key('guide.download', 'https://equella.github.io/')}</p>
-	
+	<p>${b.key('guide.download', 'https://openequella.github.io/')}</p>
+
     <div id="swagger-ui"></div>
     <script src="${p.url('apidocs/bundle.js')}"></script>
 </div>


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
This fixes the broken link to the openEQUELLA docs site was incorrectly pointing to equella.github.io rather than openequella.github.io. 

#1430

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
