### PR TITLE
Accessibility: Add alt tags where they are missing

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -381,7 +381,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
       >
         <ListItemIcon>
           {item.iconUrl ? (
-            <img src={item.iconUrl} />
+            <img src={item.iconUrl} alt={item.title} />
           ) : (
             <Icon color="inherit" className={classes.menuIcon}>
               {item.systemIcon ? item.systemIcon : "folder"}
@@ -409,7 +409,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
   const menuContent = React.useMemo(
     () => (
       <div className={classes.logo}>
-        <img role="presentation" src={logoURL} />
+        <img role="presentation" src={logoURL} alt={"Logo"} />
         {hasMenu && (
           <div id="menulinks">
             {currentUser.menuGroups.map((group, ind) => (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
@@ -404,7 +404,7 @@ class ThemePage extends React.Component<
               </Typography>
             </Grid>
             <Grid item>
-              <img src={this.state.logoURL} />
+              <img src={this.state.logoURL} alt={strings.logosettings.alt} />
             </Grid>
           </Grid>
         </CardContent>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -228,6 +228,7 @@ export const languageStrings = {
       sidebariconcolour: "Icon Colour"
     },
     logosettings: {
+      alt: "Logo",
       title: "Logo Settings",
       imagespeclabel: "Use a PNG file of 230x36 pixels for best results.",
       current: "Current Logo: ",

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/ImageRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/ImageRenderer.java
@@ -100,9 +100,13 @@ public class ImageRenderer extends TagRenderer {
     attrs.put("src", source); // $NON-NLS-1$
     attrs.put("width", width); // $NON-NLS-1$
     attrs.put("height", height); // $NON-NLS-1$
-    if (alt != null) {
+    if (alt != null && alt.getText().length() > 0) {
       attrs.put("alt", alt.getText()); // $NON-NLS-1$
       attrs.put("title", alt.getText()); // $NON-NLS-1$
+    } else {
+      // If the alt tag is not set, just use the source as the alt
+      attrs.put("alt", source); // $NON-NLS-1$
+      attrs.put("title", source); // $NON-NLS-1$
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/ImageRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/ImageRenderer.java
@@ -26,6 +26,7 @@ import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TagState;
 import java.io.IOException;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
 public class ImageRenderer extends TagRenderer {
   private String source;
@@ -48,7 +49,7 @@ public class ImageRenderer extends TagRenderer {
   }
 
   public ImageRenderer(TagState state, String source, Label alt) {
-    super("img", state); // $NON-NLS-1$
+    super("img", state);
     this.source = source;
     this.alt = alt;
   }
@@ -97,16 +98,16 @@ public class ImageRenderer extends TagRenderer {
   protected void prepareFirstAttributes(SectionWriter writer, Map<String, String> attrs)
       throws IOException {
     super.prepareFirstAttributes(writer, attrs);
-    attrs.put("src", source); // $NON-NLS-1$
-    attrs.put("width", width); // $NON-NLS-1$
-    attrs.put("height", height); // $NON-NLS-1$
-    if (alt != null && alt.getText().length() > 0) {
-      attrs.put("alt", alt.getText()); // $NON-NLS-1$
-      attrs.put("title", alt.getText()); // $NON-NLS-1$
+    attrs.put("src", source);
+    attrs.put("width", width);
+    attrs.put("height", height);
+    if (alt != null && StringUtils.isNotBlank(alt.getText())) {
+      attrs.put("alt", alt.getText());
+      attrs.put("title", alt.getText());
     } else {
       // If the alt tag is not set, just use the source as the alt
-      attrs.put("alt", source); // $NON-NLS-1$
-      attrs.put("title", source); // $NON-NLS-1$
+      attrs.put("alt", source);
+      attrs.put("title", source);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
#1432
-->
- Add alt tags to the logo (including in the theme editor page)
- Change the ImageRenderer such that if the alt tag is null or empty, the image src becomes the alt tag rather than just an empty string.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
