### PR TITLE
Add role=alert to the Duplicate Warning string

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -1217,7 +1217,7 @@ duplicatedatasection.pagename=Duplicate data
 duplicatedatasection.preamble=The following data is duplicated by other items in this collection.
 duplicatedatasection.preambleforattachment=The following data are duplicates of your attachments in this collection.
 duplicatedatasection.usedby=''{0}'' is also used by\:
-duplicatewarning.message=<b>Duplicate warning!</b>
+duplicatewarning.message=<b role="alert">Duplicate warning!</b>
 duplicatewarning.linktext=Click here to view existing items that contain duplicates
 duration.hour=hour
 duration.hours=hours

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -1217,7 +1217,7 @@ duplicatedatasection.pagename=Duplicate data
 duplicatedatasection.preamble=The following data is duplicated by other items in this collection.
 duplicatedatasection.preambleforattachment=The following data are duplicates of your attachments in this collection.
 duplicatedatasection.usedby=''{0}'' is also used by\:
-duplicatewarning.message=<b role="alert">Duplicate warning!</b>
+duplicatewarning.message=Duplicate warning!
 duplicatewarning.linktext=Click here to view existing items that contain duplicates
 duration.hour=hour
 duration.hours=hours

--- a/Source/Plugins/Core/com.equella.core/resources/view/editbox.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/editbox.ftl
@@ -6,7 +6,9 @@
 
 <@a.div id="${id}_editbox_duplicate_warning">
 <#if m.displayDuplicateWarning>
-  <p style="color:red">${m.duplicateWarningMessage}</p>
+    <p>
+      <b style="color:red" role="alert">${m.duplicateWarningMessage}</b>
+    </p>
   <@link section=s.duplicateWarningLink/>
 </#if>
 </@a.div>

--- a/Source/Plugins/Core/com.equella.core/resources/view/universalattachmentlist.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/universalattachmentlist.ftl
@@ -9,7 +9,9 @@
   <#assign visibility = "none">
 </#if>
 <div id="${m.id}_attachment_duplicate_warning" style="display: ${visibility}">
-  <p style="color:red">${m.duplicateWarningMessage}</p>
+  <p>
+    <b style="color:red" role="alert">${m.duplicateWarningMessage}</b>
+  </p>
   <@link section=s.duplicateWarningLink/>
 </div>
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
#1432 
-->
The "Duplicate Warning!" string for attachment and editbox duplicates should have role=alert as an attribute for accessibility reasons (So that a screen reader should prioritise those on the readout)
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
