### PR TITLE
Add material Icons to repeater buttons

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -734,9 +734,8 @@ Contribution wizard inputs
   position: relative;
 }
 
-.repeater-remove:before {
-  content: "\e5cd"; //material ui close icon
-  font-family: "Material Icons";
+.repeater-remove {
+  background: url(../../images/repeater-remove.png) no-repeat 0px 0px;
   font-size: 20px;
   color: #000000;
   padding-right: 4px;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -735,7 +735,7 @@ Contribution wizard inputs
 }
 
 .repeater-remove:before {
-  content: "\e5cd";
+  content: "\e5cd"; //material ui close icon
   font-family: "Material Icons";
   font-size: 20px;
   color: #000000;
@@ -748,7 +748,7 @@ Contribution wizard inputs
 }
 
 a[title="move-up"]:before {
-  content: "\e5ce";
+  content: "\e5ce"; //material ui up chevron icon
   font-family: "Material Icons";
   font-size: 20px;
   color: #000000;
@@ -760,7 +760,7 @@ a[title="move-up"]:before {
   width: 17px;
 }
 a[title="move-down"]:before {
-  content: "\e5cf";
+  content: "\e5cf"; //material ui down chevron icon
   font-family: "Material Icons";
   font-size: 20px;
   color: #000000;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -734,8 +734,12 @@ Contribution wizard inputs
   position: relative;
 }
 
-.repeater-remove {
-  background: url(../images/repeater-remove.png) no-repeat 0px 0px;
+.repeater-remove:before {
+  content: "\e5cd";
+  font-family: "Material Icons";
+  font-size: 20px;
+  color: #000000;
+  padding-right: 4px;
   margin-left: 3px;
   cursor: pointer;
   height: 17px;
@@ -743,6 +747,30 @@ Contribution wizard inputs
   width: 17px;
 }
 
+a[title="move-up"]:before {
+  content: "\e5ce";
+  font-family: "Material Icons";
+  font-size: 20px;
+  color: #000000;
+  padding-right: 4px;
+  margin-left: 3px;
+  cursor: pointer;
+  height: 17px;
+  float: right;
+  width: 17px;
+}
+a[title="move-down"]:before {
+  content: "\e5cf";
+  font-family: "Material Icons";
+  font-size: 20px;
+  color: #000000;
+  padding-right: 4px;
+  margin-left: 3px;
+  cursor: pointer;
+  height: 17px;
+  float: right;
+  width: 17px;
+}
 .repeater-move {
   background: url(../images/repeater-button-bg.png) no-repeat 0px 0px;
   height: 17px;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
#1432 
-->
The move up, move down and delete icons in the repeater control were not visible in the new UI post EBP.  This PR fixes that by using the material UI icons.
![image](https://user-images.githubusercontent.com/24543345/73238140-fa427200-41eb-11ea-86a1-7cb0fc15900f.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
