### PR TITLE
Accessibility: Set width of the save button to remove horizontal scroll bar

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -2662,6 +2662,7 @@ Contribution wizard styling
   background-image: url("../../images/baseline_save_white_18dp.png");
   text-align: left;
   padding-left: 42px;
+  width: 80%;
 }
 
 #wizard-major-actions .action-button.edit {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -2657,12 +2657,14 @@ Contribution wizard styling
 #wizard-navigation input[type="button"] {
   margin: 0 0 0 3px;
 }
+#wizard-major-actions {
+  display: flex;
+}
 
 #wizard-major-actions .action-button.save {
   background-image: url("../../images/baseline_save_white_18dp.png");
   text-align: left;
   padding-left: 42px;
-  width: 80%;
 }
 
 #wizard-major-actions .action-button.edit {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
#1432 
-->
![image](https://user-images.githubusercontent.com/24543345/73318365-48f41880-428d-11ea-8faa-385ffd3a4748.png)
The Save button changes in the EBP caused the save button to be slightly too wide for the page, causing an unnecessary horizontal scrollbar. 
 
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
