### PR TITLE
Accessibility: Set the image alt in the ThumbnailDisplay.java

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/search/itemlist/ThumbnailDisplay.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/search/itemlist/ThumbnailDisplay.java
@@ -84,6 +84,7 @@ public class ThumbnailDisplay implements ItemlikeListEntryExtension<Item, ItemLi
                     ImageRenderer image =
                         viewableResource.createStandardThumbnailRenderer(
                             new TextLabel(Constants.BLANK));
+                    image.setAlt(new TextLabel(viewableResource.getDescription()));
                     if (image != null) {
                       entry.addThumbnail(image);
                     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
#1432 
-->
This sets the img tag alt for thumbnails to be the image fiilename. 
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
