### PR TITLE
Bugfix/focus accessibility

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -378,7 +378,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
           );
         }}
         key={ind}
-        button=true
+        button={true}
       >
         <ListItemIcon>
           {item.iconUrl ? (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -229,7 +229,7 @@ export const useStyles = makeStyles((theme: Theme) => {
       background: menuColors.background
     },
     menuItem: {
-      color: menuColors.text
+      color: menuColors.text,
     },
     menuIcon: {
       color: menuColors.icon
@@ -378,6 +378,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
           );
         }}
         key={ind}
+        button=true
       >
         <ListItemIcon>
           {item.iconUrl ? (
@@ -393,7 +394,6 @@ export const Template = React.memo(function Template(props: TemplateProps) {
           primary={
             <Typography
               variant="subtitle1"
-              className={classes.menuItem}
               component="div"
             >
               {item.title}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -229,7 +229,7 @@ export const useStyles = makeStyles((theme: Theme) => {
       background: menuColors.background
     },
     menuItem: {
-      color: menuColors.text,
+      color: menuColors.text
     },
     menuIcon: {
       color: menuColors.icon
@@ -392,10 +392,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
         <ListItemText
           disableTypography
           primary={
-            <Typography
-              variant="subtitle1"
-              component="div"
-            >
+            <Typography variant="subtitle1" component="div">
               {item.title}
             </Typography>
           }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -392,7 +392,11 @@ export const Template = React.memo(function Template(props: TemplateProps) {
         <ListItemText
           disableTypography
           primary={
-            <Typography variant="subtitle1" component="div">
+            <Typography
+              variant="subtitle1"
+              className={classes.menuItem}
+              component="div"
+            >
               {item.title}
             </Typography>
           }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -295,6 +295,39 @@ ul {
   list-style: none;
 }
 
+a {
+  &:focus {
+    text-decoration: underline;
+  }
+}
+
+/*****************************************************************************
+Accessiblity mode
+*****************************************************************************/
+//mostly a copy paste from the original styles.css
+#content-body.accessibility {
+  div.area a:focus,
+  div.modal-content a:focus,
+  .box a:focus,
+  div.area input:focus,
+  div.modal-content input:focus,
+  .box input:focus,
+  div.area button:focus,
+  div.modal-content button:focus,
+  .box button:focus,
+  div.area select:focus,
+  div.modal-content select:focus,
+  .box select:focus,
+  td:focus {
+    outline: thin solid rgba(299, 151, 0, 255);
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
+  }
+  .accessibility select {
+    border: 1px solid #cbc7b9;
+  }
+}
+
 /*****************************************************************************
 Buttons
 *****************************************************************************/

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -302,7 +302,7 @@ a {
 }
 
 /*****************************************************************************
-Accessiblity mode
+Accessibility mode
 *****************************************************************************/
 //mostly a copy paste from the original styles.css
 #content-body.accessibility {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -22,6 +22,7 @@ import com.google.inject.AbstractModule;
 import com.tle.cal.service.CALService;
 import com.tle.cal.web.service.CALWebServiceImpl;
 import com.tle.common.scripting.service.ScriptingService;
+import com.tle.core.accessibility.AccessibilityModeService;
 import com.tle.core.activation.service.ActivationService;
 import com.tle.core.encryption.EncryptionService;
 import com.tle.core.events.services.EventService;
@@ -209,6 +210,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static ItemEditorService itemEditorService;
 
   @Inject public static ViewItemUrlFactory viewItemUrlFactory;
+
+  @Inject public static AccessibilityModeService accessibilityModeService;
 
   @Override
   protected void configure() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
#1432 

- Added button property to new ui left menu, to give it some hover effects
- Add accessibility class to legacy content, based on the logged in user's accessibility mode setting (in the user profile section). That means regular users won't see focus rings. That's also how it works in the old ui

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
