### PR TITLE
force redirect for hierarchy topics, to get the back button working properly in the new ui

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/hierarchy/section/TopicDisplaySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/hierarchy/section/TopicDisplaySection.java
@@ -191,7 +191,6 @@ public class TopicDisplaySection
       hideZero = topic.isHideSubtopicsWithNoResults();
     }
     model.setName(getLabelForTopic(topic, topicVirtValue));
-
     // We now need the current topic and value to be in the "values" map so
     // that the counts and URLs for the child topics are generated
     // correctly.
@@ -235,7 +234,6 @@ public class TopicDisplaySection
 
       HtmlLinkState link =
           new HtmlLinkState(events.getNamedHandler("changeTopic", dynamicHierarchyId));
-
       List<HierarchyTopicDynamicKeyResources> dynamicKeyResources =
           hierarchyService.getDynamicKeyResource(dynamicHierarchyId);
 
@@ -253,7 +251,6 @@ public class TopicDisplaySection
       }
     }
     model.setSubTopics(subNodes);
-
     // for the benefit of skinny sessions ...
     if (skinnySearchActions != null) {
       // If there's no topic, we're showing the topic display and so don't
@@ -294,6 +291,7 @@ public class TopicDisplaySection
   public void changeTopic(SectionInfo info, String topicUuid) {
     getModel(info).setTopicId(topicUuid);
     pager.resetToFirst(info);
+    info.forceRedirect();
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

#1465 
Navigating through hierarchy topic links in the new ui were being treated as an update to the existing page content, instead of an internal redirect.

This change forces a redirect, so each topic gets a route, and a subsequent entry in the browser history object. SO the back button is behaving as expected. 
Based on my initial testing this change doesn't break the old ui, but it needs some slightly more in-depth testing

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
