### PR TITLE
Feature/improve-oEQ-accessibility

### DIFF
--- a/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagRenderer.java
+++ b/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagRenderer.java
@@ -56,6 +56,14 @@ public class TagRenderer extends AbstractWrappedElementId
   @Nullable protected Set<String> styleClasses;
   private String tag;
 
+  public static final String ARIA_LABEL = "aria-label";
+  public static final String ARIA_CONTROL = "aria-controls";
+  public static final String ARIA_EXPANDED = "aria-expanded";
+  public static final String ARIA_HIDDEN = "aria-hidden";
+  public static final String ARIA_REQUIRED = "aria-required";
+  public static final String ARIA_LABELLEDBY = "aria-labelledby";
+  public static final String ARIA_DESCRIBEDBY = "aria-describedby";
+
   public TagRenderer(String tag, TagState state) {
     super(state);
     this.tag = tag;
@@ -294,6 +302,11 @@ public class TagRenderer extends AbstractWrappedElementId
       }
     }
     prepareLastAttributes(writer, attrs);
+
+    // Add aria-xxx attributes
+    if (tagState.getAccessibilityAttrs() != null) {
+      attrs.putAll(tagState.getAccessibilityAttrs());
+    }
     return attrs;
   }
 

--- a/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagState.java
+++ b/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagState.java
@@ -53,6 +53,7 @@ public class TagState extends AbstractWrappedElementId {
   private List<PreRenderable> preRenderables;
   private List<TagProcessor> processors;
   private final HandlerMap handlerMap = new HandlerMap();
+  private Map<String, String> accessibilityAttrs;
 
   public TagState() {
     super(new PageUniqueId());
@@ -114,6 +115,17 @@ public class TagState extends AbstractWrappedElementId {
       return null;
     }
     return (T) attrs.get(key);
+  }
+
+  public void setAccessibilityAttr(String key, String value) {
+    if (accessibilityAttrs == null) {
+      accessibilityAttrs = new HashMap<String, String>();
+    }
+    accessibilityAttrs.put(key, value);
+  }
+
+  public Map<String, String> getAccessibilityAttrs() {
+    return accessibilityAttrs;
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/ScreenOptions.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/ScreenOptions.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/styles";
 import { IconButton, Popover } from "@material-ui/core";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import JQueryDiv from "../legacycontent/JQueryDiv";
+import { languageStrings } from "../util/langstrings";
 
 const useStyles = makeStyles(t => ({
   screenOptions: {
@@ -22,6 +23,7 @@ export default React.memo(function ScreenOptions(props: {
       <IconButton
         id="screenOptionsOpen"
         onClick={e => setOptionsAnchor(e.currentTarget)}
+        aria-label={languageStrings.screenOptions.descrption}
       >
         <MoreVertIcon />
       </IconButton>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/ScreenOptions.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/ScreenOptions.tsx
@@ -23,7 +23,7 @@ export default React.memo(function ScreenOptions(props: {
       <IconButton
         id="screenOptionsOpen"
         onClick={e => setOptionsAnchor(e.currentTarget)}
-        aria-label={languageStrings.screenOptions.descrption}
+        aria-label={languageStrings.screenoptions.description}
       >
         <MoreVertIcon />
       </IconButton>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -372,7 +372,7 @@ export const languageStrings = {
     },
     convertGroup: "Convert to group"
   },
-  screenOptions: {
-    descrption: "Screen options"
+  screenoptions: {
+    description: "Screen options"
   }
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -371,5 +371,8 @@ export const languageStrings = {
       notor: "None match"
     },
     convertGroup: "Convert to group"
+  },
+  screenOptions: {
+    descrption: "Screen options"
   }
 };

--- a/Source/Plugins/Core/com.equella.core/resources/view/attachmentlisttoggle.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/attachmentlisttoggle.ftl
@@ -2,7 +2,7 @@
 <#include "/com.tle.web.sections.standard@/ajax.ftl" />
 
 <@div tag=m.divToggle class="toggler">
-	<a title="${m.linkLabel}" href="#" >
+	<a title="${m.linkLabel}" href="#" aria-controls="${m.linkedItemId}" aria-expanded="${m.expanded?c}">
 		<i class="${m.iconClass}"> </i>
 	</a>
 </@div>

--- a/Source/Plugins/Core/com.equella.core/resources/view/layouts/inner/dialog.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/layouts/inner/dialog.ftl
@@ -2,7 +2,7 @@
 <#import "/com.tle.web.sections.standard@/ajax.ftl" as ajax/>
 
 <div class="modal<#if m.contentBodyClass??> ${m.contentBodyClass}</#if>">
-	<div class="modal-title">
+	<div class="modal-title" id="${m.titleId}">
 		<h3><@render m.pageTitle /></h3><@render m.template["head"] />
 	</div>
 	<div class="modal-content">

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/itemlistattachments.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/itemlistattachments.js
@@ -1,20 +1,17 @@
 var ItemListAttachments = {
-	toggle: function($toggler, $attachments, updateFunc, uuid, version)
-	{
-		if ($attachments.hasClass('opened'))
-		{
-			$attachments.removeClass('opened');
-			updateFunc(uuid, version, false);
-		}
-		else
-		{
-			$attachments.addClass('opened');
-			updateFunc(uuid, version, true);
-		}
-	},
-	
-	endToggle: function()
-	{
-		$(document).trigger('equella_showattachments');
-	}
+  toggle: function($toggler, $attachments, updateFunc, uuid, version) {
+    const opened = $attachments.hasClass("opened");
+    if (opened) {
+      $attachments.removeClass("opened");
+      updateFunc(uuid, version, false);
+    } else {
+      $attachments.addClass("opened");
+      updateFunc(uuid, version, true);
+    }
+    $attachments.attr("aria-hidden", opened);
+  },
+
+  endToggle: function() {
+    $(document).trigger("equella_showattachments");
+  }
 };

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/resultactions.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/resultactions.js
@@ -1,40 +1,46 @@
-function showHideActions(oldDiv, newContents, onSuccess)
-{
-	if (newContents)
-	{
-		updateIncludes(newContents, function()
-		{
-			var showNewContent = function(onSuccess)
-			{
-				var newhtml = newContents.html['searchresults-actions'];
-				oldDiv.html(newhtml.html).children('.resulttopblock').hide();
-				
-				var newButtons = newContents.html['actionbuttons'];
-				$("#actionbuttons").html(newButtons.html);				
-				
-				$.globalEval(newhtml.script)
-				oldDiv.children('.resulttopblock').show("blind", {
-					direction : "vertical",
-					mode : "show"
-				}, 500, onSuccess);
-			};
+function showHideActions(oldDiv, newContents, onSuccess) {
+  if (newContents) {
+    updateIncludes(newContents, function() {
+      var showNewContent = function(onSuccess) {
+        var newhtml = newContents.html["searchresults-actions"];
+        oldDiv
+          .html(newhtml.html)
+          .children(".resulttopblock")
+          .hide();
 
-			var foundChildren = oldDiv.children('.resulttopblock');
-			if (foundChildren.length > 0)
-			{
-				foundChildren.hide("blind", {
-					direction : "vertical",
-					mode : "hide"
-				}, 500, function()
-				{
-					oldDiv.children('.resulttopblock').remove();
-					showNewContent();
-				});
-			}
-			else
-			{
-				showNewContent(onSuccess);
-			}
-		});
-	}
+        var newButtons = newContents.html["actionbuttons"];
+        $("#actionbuttons").html(newButtons.html);
+
+        $.globalEval(newhtml.script);
+        oldDiv.children(".resulttopblock").show(
+          "blind",
+          {
+            direction: "vertical",
+            mode: "show"
+          },
+          500,
+          onSuccess
+        );
+        $("#searchresults-actions").attr("aria-hidden", !newhtml.html);
+      };
+
+      var foundChildren = oldDiv.children(".resulttopblock");
+      if (foundChildren.length > 0) {
+        foundChildren.hide(
+          "blind",
+          {
+            direction: "vertical",
+            mode: "hide"
+          },
+          500,
+          function() {
+            oldDiv.children(".resulttopblock").remove();
+            showNewContent();
+          }
+        );
+      } else {
+        showNewContent(onSuccess);
+      }
+    });
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/standard/AbstractItemlikeListAttachmentDisplaySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/standard/AbstractItemlikeListAttachmentDisplaySection.java
@@ -67,6 +67,7 @@ import com.tle.web.sections.js.generic.function.IncludeFile;
 import com.tle.web.sections.render.CombinedRenderer;
 import com.tle.web.sections.render.HtmlRenderer;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TagState;
 import com.tle.web.sections.standard.renderers.DivRenderer;
 import com.tle.web.selection.SelectAttachmentHandler;
@@ -177,7 +178,9 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
                   createAttachmentsList(
                       context, item, structured, attId, itemUuid, itemVersion, true));
             } else {
-              entry.addExtras(new DivRenderer(new TagState(attId)));
+              TagState state = new TagState(attId);
+              state.setAccessibilityAttr(TagRenderer.ARIA_HIDDEN, String.valueOf(!model.show));
+              entry.addExtras(new DivRenderer(state));
             }
           }
 
@@ -215,6 +218,8 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
     model.put(
         "linkLabel", CurrentLocale.get(ATTACHMENT_LABEL_PREFIX + (defaultOpen ? "hide" : "show")));
     model.put("divToggle", new DivRenderer(divToggle));
+    model.put("linkedItemId", ATTACHMENTS_ID_PREFIX + itemUuid + itemVersion);
+    model.put("expanded", defaultOpen);
 
     return viewFactory.createResultWithModel("attachmentlisttoggle.ftl", model);
   }
@@ -342,7 +347,6 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
 
     final TagState attDivState = createAttDivState(attId);
     final TagState captureDiv = createCaptureDiv(context, item, attId, itemUuid, itemVersion);
-
     final List<AttachmentRowDisplay> attachments =
         buildAttachmentRowDisplay(context, item, structured, attId);
     model.setAttachmentRows(attachments);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/standard/AbstractItemlikeListAttachmentDisplaySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/standard/AbstractItemlikeListAttachmentDisplaySection.java
@@ -234,6 +234,7 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
       boolean defaultOpen) {
     final TagState attDivState = createAttDivState(attId);
     final TagState captureDiv = createCaptureDiv(context, item, attId, itemUuid, itemVersion);
+    attDivState.setAccessibilityAttr(TagRenderer.ARIA_HIDDEN, String.valueOf(!defaultOpen));
 
     // Build Attachments
     final List<AttachmentRowDisplay> attachments =

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/myresource/MyResourceContributeSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/myresource/MyResourceContributeSection.java
@@ -77,6 +77,7 @@ import com.tle.web.sections.js.generic.function.PartiallyApply;
 import com.tle.web.sections.js.generic.function.RuntimeFunction;
 import com.tle.web.sections.render.HtmlRenderer;
 import com.tle.web.sections.render.Label;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TextLabel;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.Button;
@@ -108,7 +109,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.inject.Inject;
 
@@ -247,7 +250,10 @@ public class MyResourceContributeSection
 
     saveButton.setLabel(context, model.isEditing() ? LABEL_SAVE_EDIT : LABEL_UPLOAD);
     archiveOptionsDropDown.setRendererType(context, "bootstrapsplitdropdown");
-
+    Map<String, String> toggleAttrs = new HashMap<>();
+    toggleAttrs.put(
+        TagRenderer.ARIA_LABEL, archiveOptionsDropDown.getState(context).getLabelText());
+    archiveOptionsDropDown.getState(context).setAttribute("toggleAttrs", toggleAttrs);
     if (model.isEditing()) {
       final ItemId itemId = new ItemId(model.getEditItem());
       final FileAttachment attachment = getAttachment(context, itemId);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/renderer/SearchPortletRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/renderer/SearchPortletRenderer.java
@@ -42,6 +42,7 @@ import com.tle.web.sections.events.js.EventGenerator;
 import com.tle.web.sections.jquery.libraries.JQueryTextFieldHint;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
@@ -82,6 +83,7 @@ public class SearchPortletRenderer extends PortletContentRenderer<Object> {
 
   @Override
   public SectionRenderable renderHtml(RenderEventContext context) {
+    search.getState(context).setAccessibilityAttr(TagRenderer.ARIA_LABEL, TEXTFIELD_HINT.getText());
     return view.createResult("searchportlet.ftl", context);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
@@ -92,6 +92,7 @@ import com.tle.web.sections.js.generic.function.ExternallyDefinedFunction;
 import com.tle.web.sections.js.generic.function.IncludeFile;
 import com.tle.web.sections.js.generic.statement.FunctionCallStatement;
 import com.tle.web.sections.render.Label;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.Checkbox;
@@ -911,7 +912,9 @@ public class SearchQuerySection
   @Override
   public void addBlueBarResults(RenderContext context, BlueBarEvent event) {
     if (getSearchSettings().isSearchingShowNonLiveCheckbox()) {
-      includeNonLive.getState(context).setLabelText(LABEL_NONLIVE.getText());
+      includeNonLive
+          .getState(context)
+          .setAccessibilityAttr(TagRenderer.ARIA_LABEL, LABEL_NONLIVE.getText());
       event.addScreenOptions(
           new SettingsRenderer(
               LABEL_NONLIVE,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
@@ -911,6 +911,7 @@ public class SearchQuerySection
   @Override
   public void addBlueBarResults(RenderContext context, BlueBarEvent event) {
     if (getSearchSettings().isSearchingShowNonLiveCheckbox()) {
+      includeNonLive.getState(context).setLabelText(LABEL_NONLIVE.getText());
       event.addScreenOptions(
           new SettingsRenderer(
               LABEL_NONLIVE,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/dialog/EquellaDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/dialog/EquellaDialog.java
@@ -58,6 +58,7 @@ public abstract class EquellaDialog<S extends DialogModel> extends AbstractDialo
 
   private boolean alwaysShowFooter;
   private ElementId footerId;
+  private ElementId titleId;
 
   @Override
   protected SectionRenderable getDialogContents(RenderContext context) {
@@ -68,13 +69,15 @@ public abstract class EquellaDialog<S extends DialogModel> extends AbstractDialo
         this,
         getTemplateCloseFunction(),
         getContentBodyClass(context),
-        footerId);
+        footerId,
+        titleId);
   }
 
   @Override
   public void registered(String id, SectionTree tree) {
     super.registered(id, tree);
     footerId = new AppendedElementId(this, "footer");
+    titleId = new AppendedElementId(this, "title");
   }
 
   @Override
@@ -152,6 +155,10 @@ public abstract class EquellaDialog<S extends DialogModel> extends AbstractDialo
 
   public ElementId getFooterId() {
     return footerId;
+  }
+
+  public ElementId getTitleId() {
+    return titleId;
   }
 
   protected void setAlwaysShowFooter(boolean show) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/BootstrapSplitDropDownRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/BootstrapSplitDropDownRenderer.java
@@ -29,6 +29,7 @@ import com.tle.web.sections.standard.model.HtmlComponentState;
 import com.tle.web.sections.standard.model.HtmlListState;
 import com.tle.web.sections.standard.model.Option;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Render as button + dropdown as opposed to just a dropdown
@@ -89,6 +90,14 @@ public class BootstrapSplitDropDownRenderer extends BootstrapDropDownRenderer {
     }
     toggleButton.setNestedRenderable(caret());
     toggleButton.addClass("dropdown-toggle");
+
+    if (state.getAttribute("toggleAttrs") != null) {
+      Map<String, String> params = state.getAttribute("toggleAttrs");
+      params.forEach(
+          (key, value) -> {
+            toggleState.setAccessibilityAttr(key, value);
+          });
+    }
     writer.render(toggleButton);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/PagingSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/PagingSection.java
@@ -193,7 +193,8 @@ public class PagingSection<
     if (userPrefs.isSearchAttachment()) {
       attachmentSearch.setChecked(context, true);
     }
-
+    attachmentSearch.getState(context).setLabelText(LABEL_ATTACHMENT_SEARCH.getText());
+    perPage.getState(context).setLabelText(LABEL_PERPAGE.getText());
     event.addScreenOptions(
         new SettingsRenderer(LABEL_PERPAGE, renderSection(context, perPage), "screen-option"));
     SearchSettings searchingSettings = getSearchSettings();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/PagingSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/PagingSection.java
@@ -37,6 +37,7 @@ import com.tle.web.sections.generic.AbstractPrototypeSection;
 import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.js.generic.StatementHandler;
 import com.tle.web.sections.render.Label;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.Checkbox;
 import com.tle.web.sections.standard.Pager;
@@ -193,8 +194,10 @@ public class PagingSection<
     if (userPrefs.isSearchAttachment()) {
       attachmentSearch.setChecked(context, true);
     }
-    attachmentSearch.getState(context).setLabelText(LABEL_ATTACHMENT_SEARCH.getText());
-    perPage.getState(context).setLabelText(LABEL_PERPAGE.getText());
+    attachmentSearch
+        .getState(context)
+        .setAccessibilityAttr(TagRenderer.ARIA_LABEL, LABEL_ATTACHMENT_SEARCH.getText());
+    perPage.getState(context).setAccessibilityAttr(TagRenderer.ARIA_LABEL, LABEL_PERPAGE.getText());
     event.addScreenOptions(
         new SettingsRenderer(LABEL_PERPAGE, renderSection(context, perPage), "screen-option"));
     SearchSettings searchingSettings = getSearchSettings();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/SearchResultsActionsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/SearchResultsActionsSection.java
@@ -50,6 +50,7 @@ import com.tle.web.sections.js.generic.function.ExternallyDefinedFunction;
 import com.tle.web.sections.js.generic.function.IncludeFile;
 import com.tle.web.sections.render.HtmlRenderer;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.result.util.IconLabel.Icon;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.annotations.Component;
@@ -150,7 +151,6 @@ public class SearchResultsActionsSection<RE extends AbstractSearchResultsEvent<R
     if (model.isSearchDisabled()) {
       return null;
     }
-
     setupButton(sort, sortSections, showing, context);
     setupButton(filter, filterSections, showing, context);
 
@@ -177,6 +177,9 @@ public class SearchResultsActionsSection<RE extends AbstractSearchResultsEvent<R
         button.setClickHandler(context, new OverrideHandler(showFunc, buttonMode.toString()));
         state.setAttribute(Icon.class, Icon.DOWN);
       }
+      state.setAccessibilityAttr(TagRenderer.ARIA_CONTROL, ACTIONS_AJAX_ID);
+      state.setAccessibilityAttr(
+          TagRenderer.ARIA_EXPANDED, String.valueOf(!mode.equals(Showing.NONE)));
       getModel(context).addButton(button);
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/model/HtmlComponentState.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/model/HtmlComponentState.java
@@ -65,6 +65,7 @@ public class HtmlComponentState extends TagState implements RendererSelectable {
   private String name;
   private boolean cancel;
   private Label title;
+  private String labelText;
 
   public HtmlComponentState() {
     // nothing
@@ -164,8 +165,14 @@ public class HtmlComponentState extends TagState implements RendererSelectable {
   public String getLabelText() {
     if (label != null) {
       return label.getText();
+    } else if (labelText != null) {
+      return labelText;
     }
     return ""; //$NON-NLS-1$
+  }
+
+  public void setLabelText(String labelText) {
+    this.labelText = labelText;
   }
 
   public static final Comparator<HtmlComponentState> LABEL_COMPARATOR =

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/model/HtmlComponentState.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/model/HtmlComponentState.java
@@ -65,7 +65,6 @@ public class HtmlComponentState extends TagState implements RendererSelectable {
   private String name;
   private boolean cancel;
   private Label title;
-  private String labelText;
 
   public HtmlComponentState() {
     // nothing
@@ -165,14 +164,8 @@ public class HtmlComponentState extends TagState implements RendererSelectable {
   public String getLabelText() {
     if (label != null) {
       return label.getText();
-    } else if (labelText != null) {
-      return labelText;
     }
     return ""; //$NON-NLS-1$
-  }
-
-  public void setLabelText(String labelText) {
-    this.labelText = labelText;
   }
 
   public static final Comparator<HtmlComponentState> LABEL_COMPARATOR =

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
@@ -34,7 +34,10 @@ public abstract class AbstractElementRenderer extends AbstractComponentRenderer 
   protected void prepareFirstAttributes(SectionWriter writer, Map<String, String> attrs)
       throws IOException {
     super.prepareFirstAttributes(writer, attrs);
-    attrs.put("name", getName(writer)); // $NON-NLS-1$
+    attrs.put("name", getName(writer));
+    if (state.getLabel() == null && !state.getLabelText().isEmpty()) {
+      attrs.put("aria-label", getLabelText());
+    }
   }
 
   protected String getName(SectionInfo info) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
@@ -35,9 +35,6 @@ public abstract class AbstractElementRenderer extends AbstractComponentRenderer 
       throws IOException {
     super.prepareFirstAttributes(writer, attrs);
     attrs.put("name", getName(writer));
-    if (state.getLabel() == null && !state.getLabelText().isEmpty()) {
-      attrs.put("aria-label", getLabelText());
-    }
   }
 
   protected String getName(SectionInfo info) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/fancybox/FancyBoxDialogRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/fancybox/FancyBoxDialogRenderer.java
@@ -264,6 +264,7 @@ public class FancyBoxDialogRenderer extends AbstractComponentRenderer implements
     renderer.style = style;
     renderer.styleClasses = styleClasses;
     renderer.attrs = attrs;
+    renderer.setAttribute("role", "dialog");
     return renderer;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/DialogTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/DialogTemplate.java
@@ -30,6 +30,7 @@ import com.tle.web.sections.render.GenericTemplateResult;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.LabelRenderer;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TemplateRenderable;
 import com.tle.web.sections.render.TemplateResult;
 import com.tle.web.sections.result.util.KeyLabel;
@@ -76,7 +77,7 @@ public class DialogTemplate {
     DialogTemplateModel model = new DialogTemplateModel();
     model.setPageTitle(new LabelRenderer(title));
     model.setFooterId(footerId.getElementId(info));
-
+    model.setTitleId(dialog.getElementId(info));
     model.setTemplate(result);
     model.setContentBodyClass(contentBodyClass);
 
@@ -84,7 +85,7 @@ public class DialogTemplate {
     if (footer != null && footer.exists(info)) {
       model.setFooter(footer);
     }
-
+    dialog.getState(info).setAccessibilityAttr(TagRenderer.ARIA_LABELLEDBY, model.getTitleId());
     return viewFactory.createResultWithModel("layouts/inner/dialog.ftl", model);
   }
 
@@ -95,6 +96,7 @@ public class DialogTemplate {
     private String contentBodyClass;
     private TemplateRenderable footer;
     private String footerId;
+    private String titleId;
 
     public String getContentBodyClass() {
       return contentBodyClass;
@@ -142,6 +144,14 @@ public class DialogTemplate {
 
     public void setFooterId(String footerId) {
       this.footerId = footerId;
+    }
+
+    public String getTitleId() {
+      return titleId;
+    }
+
+    public void setTitleId(String titleId) {
+      this.titleId = titleId + "_title";
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/DialogTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/DialogTemplate.java
@@ -61,7 +61,8 @@ public class DialogTemplate {
       AbstractDialog<?> dialog,
       JSHandler closeHandler,
       String contentBodyClass,
-      ElementId footerId) {
+      ElementId footerId,
+      ElementId titleId) {
     if (dialog.isModal()) {
       HtmlComponentState closeDialog = new HtmlComponentState(closeHandler);
       closeDialog.setId(dialog.getElementId(info) + "_close");
@@ -77,7 +78,7 @@ public class DialogTemplate {
     DialogTemplateModel model = new DialogTemplateModel();
     model.setPageTitle(new LabelRenderer(title));
     model.setFooterId(footerId.getElementId(info));
-    model.setTitleId(dialog.getElementId(info));
+    model.setTitleId(titleId.getElementId(info));
     model.setTemplate(result);
     model.setContentBodyClass(contentBodyClass);
 
@@ -151,7 +152,7 @@ public class DialogTemplate {
     }
 
     public void setTitleId(String titleId) {
-      this.titleId = titleId + "_title";
+      this.titleId = titleId;
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/WebControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/WebControl.java
@@ -43,7 +43,6 @@ public interface WebControl extends HTMLControl, Section, HtmlRenderer {
 
   CombinedDisableable getDisabler(SectionInfo info);
 
-  // Yes this is rubbish
   void doEditsIfRequired(SectionInfo info);
 
   void doReads(SectionInfo info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/standard/controls/EditBox.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/standard/controls/EditBox.java
@@ -43,6 +43,7 @@ import com.tle.web.sections.js.generic.function.AnonymousFunction;
 import com.tle.web.sections.js.generic.function.AssignableFunction;
 import com.tle.web.sections.js.generic.statement.ReturnStatement;
 import com.tle.web.sections.js.generic.statement.ScriptStatement;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.standard.Link;
 import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
@@ -133,6 +134,9 @@ public class EditBox extends AbstractWebControl<EditBoxModel> implements SimpleV
           new OverrideHandler(
               new ScriptStatement(
                   "if(this.value.length > 8192) this.value = this.value.slice(0, 8192);")));
+    }
+    if (box.isMandatory()) {
+      field.getState(context).setAccessibilityAttr(TagRenderer.ARIA_REQUIRED, String.valueOf(true));
     }
     addDisabler(context, field);
     return viewFactory.createResult("editbox.ftl", context);


### PR DESCRIPTION
#1432 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] screenshots are included showing significant UI changes

##### Description of change
As discussed with @mrblippy , we need to add the attribute 'aria-label' to `Screen option`' elements. 

This PR provides the ability of adding 'aria-label' to Wizard controls (e.g. Editbox and Drop-down List) that do not have `<label>` to describe themselves.

In terms of the `vertical dots`, as it is a standard Material-UI component, we can directly add `aria-label` to it.

![Screenshot from 2020-02-11 11-43-03](https://user-images.githubusercontent.com/47203811/74203528-118d5f00-4cc4-11ea-8454-b62681fa4e55.png)

