### PR TITLE
show options when enter key is pressed, instead of tab

### DIFF
--- a/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagRenderer.java
+++ b/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagRenderer.java
@@ -56,6 +56,14 @@ public class TagRenderer extends AbstractWrappedElementId
   @Nullable protected Set<String> styleClasses;
   private String tag;
 
+  public static final String ARIA_LABEL = "aria-label";
+  public static final String ARIA_CONTROL = "aria-controls";
+  public static final String ARIA_EXPANDED = "aria-expanded";
+  public static final String ARIA_HIDDEN = "aria-hidden";
+  public static final String ARIA_REQUIRED = "aria-required";
+  public static final String ARIA_LABELLEDBY = "aria-labelledby";
+  public static final String ARIA_DESCRIBEDBY = "aria-describedby";
+
   public TagRenderer(String tag, TagState state) {
     super(state);
     this.tag = tag;
@@ -294,6 +302,11 @@ public class TagRenderer extends AbstractWrappedElementId
       }
     }
     prepareLastAttributes(writer, attrs);
+
+    // Add aria-xxx attributes
+    if (tagState.getAccessibilityAttrs() != null) {
+      attrs.putAll(tagState.getAccessibilityAttrs());
+    }
     return attrs;
   }
 

--- a/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagState.java
+++ b/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/render/TagState.java
@@ -53,6 +53,7 @@ public class TagState extends AbstractWrappedElementId {
   private List<PreRenderable> preRenderables;
   private List<TagProcessor> processors;
   private final HandlerMap handlerMap = new HandlerMap();
+  private Map<String, String> accessibilityAttrs;
 
   public TagState() {
     super(new PageUniqueId());
@@ -114,6 +115,17 @@ public class TagState extends AbstractWrappedElementId {
       return null;
     }
     return (T) attrs.get(key);
+  }
+
+  public void setAccessibilityAttr(String key, String value) {
+    if (accessibilityAttrs == null) {
+      accessibilityAttrs = new HashMap<String, String>();
+    }
+    accessibilityAttrs.put(key, value);
+  }
+
+  public Map<String, String> getAccessibilityAttrs() {
+    return accessibilityAttrs;
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/ScreenOptions.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/ScreenOptions.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/styles";
 import { IconButton, Popover } from "@material-ui/core";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import JQueryDiv from "../legacycontent/JQueryDiv";
+import { languageStrings } from "../util/langstrings";
 
 const useStyles = makeStyles(t => ({
   screenOptions: {
@@ -22,6 +23,7 @@ export default React.memo(function ScreenOptions(props: {
       <IconButton
         id="screenOptionsOpen"
         onClick={e => setOptionsAnchor(e.currentTarget)}
+        aria-label={languageStrings.screenoptions.description}
       >
         <MoreVertIcon />
       </IconButton>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -378,6 +378,7 @@ export const Template = React.memo(function Template(props: TemplateProps) {
           );
         }}
         key={ind}
+        button={true}
       >
         <ListItemIcon>
           {item.iconUrl ? (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
@@ -99,7 +99,7 @@ class ThemePage extends React.Component<
   handleDefaultButton = () => {
     this.setState(
       {
-        primary: "#2196f3",
+        primary: "#186caf",
         secondary: "#ff9800",
         background: "#fafafa",
         menuText: "#000000",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -371,5 +371,8 @@ export const languageStrings = {
       notor: "None match"
     },
     convertGroup: "Convert to group"
+  },
+  screenoptions: {
+    description: "Screen options"
   }
 };

--- a/Source/Plugins/Core/com.equella.core/resources/view/attachmentlisttoggle.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/attachmentlisttoggle.ftl
@@ -2,7 +2,7 @@
 <#include "/com.tle.web.sections.standard@/ajax.ftl" />
 
 <@div tag=m.divToggle class="toggler">
-	<a title="${m.linkLabel}" href="#" >
+	<a title="${m.linkLabel}" href="#" aria-controls="${m.linkedItemId}" aria-expanded="${m.expanded?c}">
 		<i class="${m.iconClass}"> </i>
 	</a>
 </@div>

--- a/Source/Plugins/Core/com.equella.core/resources/view/layouts/inner/dialog.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/layouts/inner/dialog.ftl
@@ -2,7 +2,7 @@
 <#import "/com.tle.web.sections.standard@/ajax.ftl" as ajax/>
 
 <div class="modal<#if m.contentBodyClass??> ${m.contentBodyClass}</#if>">
-	<div class="modal-title">
+	<div class="modal-title" id="${m.titleId}">
 		<h3><@render m.pageTitle /></h3><@render m.template["head"] />
 	</div>
 	<div class="modal-content">

--- a/Source/Plugins/Core/com.equella.core/resources/view/logon/logon.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/logon/logon.ftl
@@ -6,20 +6,20 @@
 
 <div class="area">
 	<h2>${b.key("logon.title")}</h2>
-	
+
 	<#if m.failed??>
-		<p class="warning">${b.gkey(m.failed)}</p>
+		<p class="warning" role="alert">${b.gkey(m.failed)}</p>
 	</#if>
 	<#if m.error??>
-		<p class="warning">${b.key('logon.problems')}</p>
+		<p class="warning" role="alert">${b.key('logon.problems')}</p>
 		<p class="warning">${m.error?html}</p>
 	</#if>
 
 	<noscript>
-		<p class="warning">${b.key("logon.enablejs")}</p>
+		<p class="warning" role="alert">${b.key("logon.enablejs")}</p>
 	</noscript>
-	<p id="cookieWarning" class="warning" style="display: none">${b.key("logon.enablecookies")}</p>
-	
+	<p id="cookieWarning" class="warning" style="display: none" role="alert">${b.key("logon.enablecookies")}</p>
+
 	<p>
 		<label for="username">${b.key("logon.username")}</label>
 		<@textfield id="username" section=s.username autoSubmitButton=s.logonButton/>
@@ -32,7 +32,7 @@
 	<#if m.childSections??>
 		<@render m.childSections/>
 	</#if>
-	
+
 	<#list m.loginLinks as link>
 		<@render link />
 	</#list>

--- a/Source/Plugins/Core/com.equella.core/resources/web/css/component/zebratable.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/component/zebratable.css
@@ -1,156 +1,154 @@
 .sortData {
-	display: none;
+  display: none;
 }
 
 .filterData {
-	display: none;
+  display: none;
 }
 
-DIV.tableContainer {
-	position: relative;
+div.tableContainer {
+  position: relative;
 }
 
-DIV.tableFilter {
-	text-align: left;
-	vertical-align: middle;
-	white-space: nowrap;
-	padding-bottom: 5px;
-	float: right;
+div.tableFilter {
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+  padding-bottom: 5px;
+  float: right;
 }
 
-DIV.tableContainer DIV.tableFilter {
-	position: absolute;
-	top: -30px;
-	right: 0;
+div.tableContainer div.tableFilter {
+  position: absolute;
+  top: -30px;
+  right: 0;
 }
 
-DIV.tableFilter INPUT.filterBox {
-	width: 300px !important;
-	background-image: url(../../images/component/tablefilter.png);
-	background-repeat: no-repeat;
-	background-position: right;
-	padding-right: 22px;
-
+div.tableFilter input.filterBox {
+  width: 300px !important;
+  background-image: url(../../images/component/tablefilter.png);
+  background-repeat: no-repeat;
+  background-position: right;
+  padding-right: 22px;
 }
 
-DIV.tableFilter INPUT.blur {
-	color: #AAAAAA;
-	background-image: url(../../images/component/tablefilterdis.png);
+div.tableFilter input.blur {
+  color: #aaaaaa;
+  background-image: url(../../images/component/tablefilterdis.png);
 }
 
-TABLE.zebra {
-	border: 1px solid #8f8b7f;
-	width: 100%;
-	margin: 10px 0;
+table.zebra {
+  border: 1px solid #8f8b7f;
+  width: 100%;
+  margin: 10px 0;
 }
 
-TABLE.zebra.withfilter {
-	margin-top: 5px;
+table.zebra.withfilter {
+  margin-top: 5px;
 }
 
-TABLE.zebra TR.rowHidden {
-	display: none;
+table.zebra tr.rowHidden {
+  display: none;
 }
 
-TABLE.zebra TR.rowShown {
-	display: table-row;
+table.zebra tr.rowShown {
+  display: table-row;
 }
 
-TABLE.zebra TR TH {
-	color: #fff;
-	background: #d4cfb9;
-	text-align: left;
-	vertical-align: middle;
-	padding: 8px 10px;
-	white-space: nowrap;
+table.zebra tr th {
+  color: #fff;
+  background: #212121;
+  text-align: left;
+  vertical-align: middle;
+  padding: 8px 10px;
+  white-space: nowrap;
 }
 
-TABLE.zebra.large TH {
-	font-size: 13px;
-	font-weight: bold;
-	padding: 13px 11px 12px;
+table.zebra.large th {
+  font-size: 13px;
+  font-weight: bold;
+  padding: 13px 11px 12px;
 }
 
-TABLE.zebra TR TD.nowrap {
-	white-space: nowrap;
+table.zebra tr td.nowrap {
+  white-space: nowrap;
 }
 
-TABLE.zebra TR TD {
-	text-align: left;
-	vertical-align: top;
-	padding: 8px 10px;
+table.zebra tr td {
+  text-align: left;
+  vertical-align: top;
+  padding: 8px 10px;
 }
 
-TABLE.zebra.large TR TD {
-	font-size: 12px;
-	padding: 11px 11px 9px;
-	line-height: 1.5;
+table.zebra.large tr td {
+  font-size: 12px;
+  padding: 11px 11px 9px;
+  line-height: 1.5;
 }
 
-TABLE.zebra TR TD.middle {
-	vertical-align: middle;
+table.zebra tr td.middle {
+  vertical-align: middle;
 }
 
-TABLE.zebra TR TD A.position {
-	padding-right: 2px;
+table.zebra tr td a.position {
+  padding-right: 2px;
 }
 
-
-TABLE.zebra TR.even TD {
-	background: #fefefe;
+table.zebra tr.even td {
+  background: #fefefe;
 }
 
-TABLE.zebra TR.odd TD {
-	background: #f3f1eb;
+table.zebra tr.odd td {
+  background: #f3f1eb;
 }
 
-TABLE.zebra.alternate TR.even TD {
-	background: #f3f1eb;
+table.zebra.alternate tr.even td {
+  background: #f3f1eb;
 }
 
-TABLE.zebra.alternate TR.odd TD {
-	background: #fefefe;
+table.zebra.alternate tr.odd td {
+  background: #fefefe;
 }
 
-TABLE.zebra TR:hover TD, TABLE.zebra TR:focus TD 
-{
-/* !important */
-	background-color: #ffc;
+table.zebra tr:hover td,
+table.zebra tr:focus td {
+  /* !important */
+  background-color: #ffc;
 }
 
-.area h2+TABLE.zebra {
-	margin-top: 20px;
+.area h2 + table.zebra {
+  margin-top: 20px;
 }
 
-.area h3+TABLE.zebra {
-	margin-top: 4px;
+.area h3 + table.zebra {
+  margin-top: 4px;
 }
 
-TABLE.zebra TH.sortable {
-	cursor: pointer;
+table.zebra th.sortable {
+  cursor: pointer;
 }
 
-TABLE.zebra TH.sortable:hover {
-	background-color: #E4DFC9;
-	text-decoration: underline;
+table.zebra th.sortable:hover {
+  background-color: #4c4c4c;
+  text-decoration: underline;
 }
 
-TABLE.zebra TH.sortable DIV.sortArrow {
-	width: 8px;
-	height: 8px;
-	display: inline-block;
-	background-repeat: no-repeat;
-	margin-left: 1em;
+table.zebra th.sortable div.sortArrow {
+  width: 8px;
+  height: 8px;
+  display: inline-block;
+  background-repeat: no-repeat;
+  margin-left: 1em;
 }
 
-TABLE.zebra TH.sortable.sortedasc DIV.sortArrow,TABLE.zebra TH.sortable.unsorted.sortAsc:hover DIV.sortArrow
-	{
-	background-image: url(../../images/component/tablesortasc.png);
-	/*background-color: #E4DFC9;*/
+table.zebra th.sortable.sortedasc div.sortArrow,
+table.zebra th.sortable.unsorted.sortAsc:hover div.sortArrow {
+  background-image: url(../../images/component/tablesortasc.png);
+  /*background-color: #E4DFC9;*/
 }
 
-TABLE.zebra TH.sortable.sorteddesc DIV.sortArrow,TABLE.zebra TH.sortable.unsorted.sortDesc:hover DIV.sortArrow
-	{
-	background-image: url(../../images/component/tablesortdesc.png);
-	/*background-color: #E4DFC9;*/
+table.zebra th.sortable.sorteddesc div.sortArrow,
+table.zebra th.sortable.unsorted.sortDesc:hover div.sortArrow {
+  background-image: url(../../images/component/tablesortdesc.png);
+  /*background-color: #E4DFC9;*/
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
@@ -419,7 +419,7 @@ kbd {
 
 .content a,
 .modal a {
-  color: #0c96c4;
+  color: #097092;
   text-decoration: none;
 }
 
@@ -605,7 +605,7 @@ div.tooltip {
 }
 
 .area h2 {
-  color: #8d897e;
+  color: #636058;
   font-size: 22px;
   font-weight: normal;
   margin-bottom: 10px;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -295,6 +295,39 @@ ul {
   list-style: none;
 }
 
+a {
+  &:focus {
+    text-decoration: underline;
+  }
+}
+
+/*****************************************************************************
+Accessibility mode
+*****************************************************************************/
+//mostly a copy paste from the original styles.css
+#content-body.accessibility {
+  div.area a:focus,
+  div.modal-content a:focus,
+  .box a:focus,
+  div.area input:focus,
+  div.modal-content input:focus,
+  .box input:focus,
+  div.area button:focus,
+  div.modal-content button:focus,
+  .box button:focus,
+  div.area select:focus,
+  div.modal-content select:focus,
+  .box select:focus,
+  td:focus {
+    outline: thin solid rgba(299, 151, 0, 255);
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
+  }
+  .accessibility select {
+    border: 1px solid #cbc7b9;
+  }
+}
+
 /*****************************************************************************
 Buttons
 *****************************************************************************/

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -562,7 +562,7 @@ Contribution wizard inputs
 
 .wizard-controls .ctrlmandatory,
 .wizard-controls .ctrlinvalidmessage {
-  color: red;
+  color: #b90202;
   text-align: center;
 }
 
@@ -880,7 +880,7 @@ div.error-receipt {
   padding: 5px;
   display: block;
   text-align: left;
-  color: red;
+  color: #b90202;
   margin: 12px 0;
 }
 
@@ -1658,7 +1658,7 @@ Search page
   position: absolute;
   left: 20px;
   top: 22px;
-  color: #8d897e;
+  color: $menuTextColor;
   font-size: 18px;
 }
 
@@ -2010,7 +2010,7 @@ ul.ui-autocomplete {
 }
 
 .separator {
-  color: transparent;
+  visibility: hidden;
 }
 
 #searchresults-actions {
@@ -2038,6 +2038,7 @@ ul.ui-autocomplete {
       font-size: 24px;
       color: $menuItemIconColor;
       padding-right: 4px;
+
     }
     &#sra_sort:before {
       content: "\E164";
@@ -2051,12 +2052,15 @@ ul.ui-autocomplete {
     &:hover {
       background-color: transparentize($primaryColor, 0.7);
     }
-    &:active {
-      background-color: transparentize($primaryColor, 1);
-    }
     &.active {
       background-color: $primaryColor;
       color: set-text-color($primaryColor);
+      &:before {
+        color: set-text-color($primaryColor);
+      }
+    }
+    i:before {
+      display:none;
     }
   }
 }
@@ -2452,7 +2456,7 @@ html.wait {
 
 .itemresult-metaline .itemresult-meta-delim,
 .itemresult-metaline abbr {
-  color: #b1b17b;
+  color: $menuTextColor;
 }
 
 .highlight {
@@ -2795,13 +2799,13 @@ button + .repeater-groups {
 }
 
 .filedrop {
-  border: 3px dotted #ccc;
+  border: 3px dotted transparentize($menuTextColor, 0.2);
   padding-top: 45px;
   padding-bottom: 45px;
   margin: 1em 0;
   text-align: center;
   cursor: pointer;
-  color: rgb(130, 130, 130);
+  color: $menuTextColor;
 }
 
 .filedrop-file {
@@ -3958,11 +3962,11 @@ div.universaliframe iframe {
 }
 
 p.warning {
-  background-color: #f90;
-  border: 1px solid red;
+  background-color: #fdd;
   margin-bottom: 20px;
   padding: 10px;
   text-align: center;
+  color: #b90202;
 }
 
 .warningimg {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1182,6 +1182,7 @@ div.rightPanel {
 
 .settingHelp {
   padding-top: 20px;
+  color: $menuTextColor;
 }
 
 //scripted portlet
@@ -2071,7 +2072,6 @@ ul.ui-autocomplete {
       font-size: 24px;
       color: $menuItemIconColor;
       padding-right: 4px;
-
     }
     &#sra_sort:before {
       content: "\E164";
@@ -2093,7 +2093,7 @@ ul.ui-autocomplete {
       }
     }
     i:before {
-      display:none;
+      display: none;
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/component/richdropdown.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/component/richdropdown.js
@@ -67,11 +67,12 @@
           }
         })
         .on("keyup.richdrop", function(event) {
-          //tab key
-          if (event.which == 9) {
+          //enter key
+          if (event.which == 13 && $containerDiv.hasClass("active")) {
+            hideOptions();
+          } else if (event.which == 13) {
             showMenu(event);
           }
-
           if (event.which == 27) {
             hideOptions();
             $("#searchform-search").focus();

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/itemlistattachments.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/itemlistattachments.js
@@ -1,20 +1,17 @@
 var ItemListAttachments = {
-	toggle: function($toggler, $attachments, updateFunc, uuid, version)
-	{
-		if ($attachments.hasClass('opened'))
-		{
-			$attachments.removeClass('opened');
-			updateFunc(uuid, version, false);
-		}
-		else
-		{
-			$attachments.addClass('opened');
-			updateFunc(uuid, version, true);
-		}
-	},
-	
-	endToggle: function()
-	{
-		$(document).trigger('equella_showattachments');
-	}
+  toggle: function($toggler, $attachments, updateFunc, uuid, version) {
+    const opened = $attachments.hasClass("opened");
+    if (opened) {
+      $attachments.removeClass("opened");
+      updateFunc(uuid, version, false);
+    } else {
+      $attachments.addClass("opened");
+      updateFunc(uuid, version, true);
+    }
+    $attachments.attr("aria-hidden", opened);
+  },
+
+  endToggle: function() {
+    $(document).trigger("equella_showattachments");
+  }
 };

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/resultactions.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/resultactions.js
@@ -1,40 +1,46 @@
-function showHideActions(oldDiv, newContents, onSuccess)
-{
-	if (newContents)
-	{
-		updateIncludes(newContents, function()
-		{
-			var showNewContent = function(onSuccess)
-			{
-				var newhtml = newContents.html['searchresults-actions'];
-				oldDiv.html(newhtml.html).children('.resulttopblock').hide();
-				
-				var newButtons = newContents.html['actionbuttons'];
-				$("#actionbuttons").html(newButtons.html);				
-				
-				$.globalEval(newhtml.script)
-				oldDiv.children('.resulttopblock').show("blind", {
-					direction : "vertical",
-					mode : "show"
-				}, 500, onSuccess);
-			};
+function showHideActions(oldDiv, newContents, onSuccess) {
+  if (newContents) {
+    updateIncludes(newContents, function() {
+      var showNewContent = function(onSuccess) {
+        var newhtml = newContents.html["searchresults-actions"];
+        oldDiv
+          .html(newhtml.html)
+          .children(".resulttopblock")
+          .hide();
 
-			var foundChildren = oldDiv.children('.resulttopblock');
-			if (foundChildren.length > 0)
-			{
-				foundChildren.hide("blind", {
-					direction : "vertical",
-					mode : "hide"
-				}, 500, function()
-				{
-					oldDiv.children('.resulttopblock').remove();
-					showNewContent();
-				});
-			}
-			else
-			{
-				showNewContent(onSuccess);
-			}
-		});
-	}
+        var newButtons = newContents.html["actionbuttons"];
+        $("#actionbuttons").html(newButtons.html);
+
+        $.globalEval(newhtml.script);
+        oldDiv.children(".resulttopblock").show(
+          "blind",
+          {
+            direction: "vertical",
+            mode: "show"
+          },
+          500,
+          onSuccess
+        );
+        $("#searchresults-actions").attr("aria-hidden", !newhtml.html);
+      };
+
+      var foundChildren = oldDiv.children(".resulttopblock");
+      if (foundChildren.length > 0) {
+        foundChildren.hide(
+          "blind",
+          {
+            direction: "vertical",
+            mode: "hide"
+          },
+          500,
+          function() {
+            oldDiv.children(".resulttopblock").remove();
+            showNewContent();
+          }
+        );
+      } else {
+        showNewContent(onSuccess);
+      }
+    });
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -22,6 +22,7 @@ import com.google.inject.AbstractModule;
 import com.tle.cal.service.CALService;
 import com.tle.cal.web.service.CALWebServiceImpl;
 import com.tle.common.scripting.service.ScriptingService;
+import com.tle.core.accessibility.AccessibilityModeService;
 import com.tle.core.activation.service.ActivationService;
 import com.tle.core.encryption.EncryptionService;
 import com.tle.core.events.services.EventService;
@@ -209,6 +210,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static ItemEditorService itemEditorService;
 
   @Inject public static ViewItemUrlFactory viewItemUrlFactory;
+
+  @Inject public static AccessibilityModeService accessibilityModeService;
 
   @Override
   protected void configure() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/newuitheme/impl/NewUITheme.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/newuitheme/impl/NewUITheme.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class NewUITheme {
 
-  private String primaryColor = "#2196f3";
+  private String primaryColor = "#186caf";
   private String secondaryColor = "#ff9800";
   private String backgroundColor = "#fafafa";
   private String menuItemColor = "#ffffff";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/standard/AbstractItemlikeListAttachmentDisplaySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/standard/AbstractItemlikeListAttachmentDisplaySection.java
@@ -67,6 +67,7 @@ import com.tle.web.sections.js.generic.function.IncludeFile;
 import com.tle.web.sections.render.CombinedRenderer;
 import com.tle.web.sections.render.HtmlRenderer;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TagState;
 import com.tle.web.sections.standard.renderers.DivRenderer;
 import com.tle.web.selection.SelectAttachmentHandler;
@@ -177,7 +178,9 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
                   createAttachmentsList(
                       context, item, structured, attId, itemUuid, itemVersion, true));
             } else {
-              entry.addExtras(new DivRenderer(new TagState(attId)));
+              TagState state = new TagState(attId);
+              state.setAccessibilityAttr(TagRenderer.ARIA_HIDDEN, String.valueOf(!model.show));
+              entry.addExtras(new DivRenderer(state));
             }
           }
 
@@ -215,6 +218,8 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
     model.put(
         "linkLabel", CurrentLocale.get(ATTACHMENT_LABEL_PREFIX + (defaultOpen ? "hide" : "show")));
     model.put("divToggle", new DivRenderer(divToggle));
+    model.put("linkedItemId", ATTACHMENTS_ID_PREFIX + itemUuid + itemVersion);
+    model.put("expanded", defaultOpen);
 
     return viewFactory.createResultWithModel("attachmentlisttoggle.ftl", model);
   }
@@ -229,6 +234,7 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
       boolean defaultOpen) {
     final TagState attDivState = createAttDivState(attId);
     final TagState captureDiv = createCaptureDiv(context, item, attId, itemUuid, itemVersion);
+    attDivState.setAccessibilityAttr(TagRenderer.ARIA_HIDDEN, String.valueOf(!defaultOpen));
 
     // Build Attachments
     final List<AttachmentRowDisplay> attachments =
@@ -342,7 +348,6 @@ public abstract class AbstractItemlikeListAttachmentDisplaySection<
 
     final TagState attDivState = createAttDivState(attId);
     final TagState captureDiv = createCaptureDiv(context, item, attId, itemUuid, itemVersion);
-
     final List<AttachmentRowDisplay> attachments =
         buildAttachmentRowDisplay(context, item, structured, attId);
     model.setAttachmentRows(attachments);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/myresource/MyResourceContributeSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/myresource/MyResourceContributeSection.java
@@ -77,6 +77,7 @@ import com.tle.web.sections.js.generic.function.PartiallyApply;
 import com.tle.web.sections.js.generic.function.RuntimeFunction;
 import com.tle.web.sections.render.HtmlRenderer;
 import com.tle.web.sections.render.Label;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TextLabel;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.Button;
@@ -108,7 +109,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.inject.Inject;
 
@@ -247,7 +250,10 @@ public class MyResourceContributeSection
 
     saveButton.setLabel(context, model.isEditing() ? LABEL_SAVE_EDIT : LABEL_UPLOAD);
     archiveOptionsDropDown.setRendererType(context, "bootstrapsplitdropdown");
-
+    Map<String, String> toggleAttrs = new HashMap<>();
+    toggleAttrs.put(
+        TagRenderer.ARIA_LABEL, archiveOptionsDropDown.getState(context).getLabelText());
+    archiveOptionsDropDown.getState(context).setAttribute("toggleAttrs", toggleAttrs);
     if (model.isEditing()) {
       final ItemId itemId = new ItemId(model.getEditItem());
       final FileAttachment attachment = getAttachment(context, itemId);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/renderer/SearchPortletRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/renderer/SearchPortletRenderer.java
@@ -42,6 +42,7 @@ import com.tle.web.sections.events.js.EventGenerator;
 import com.tle.web.sections.jquery.libraries.JQueryTextFieldHint;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
@@ -82,6 +83,7 @@ public class SearchPortletRenderer extends PortletContentRenderer<Object> {
 
   @Override
   public SectionRenderable renderHtml(RenderEventContext context) {
+    search.getState(context).setAccessibilityAttr(TagRenderer.ARIA_LABEL, TEXTFIELD_HINT.getText());
     return view.createResult("searchportlet.ftl", context);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
@@ -92,6 +92,7 @@ import com.tle.web.sections.js.generic.function.ExternallyDefinedFunction;
 import com.tle.web.sections.js.generic.function.IncludeFile;
 import com.tle.web.sections.js.generic.statement.FunctionCallStatement;
 import com.tle.web.sections.render.Label;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.Checkbox;
@@ -911,6 +912,9 @@ public class SearchQuerySection
   @Override
   public void addBlueBarResults(RenderContext context, BlueBarEvent event) {
     if (getSearchSettings().isSearchingShowNonLiveCheckbox()) {
+      includeNonLive
+          .getState(context)
+          .setAccessibilityAttr(TagRenderer.ARIA_LABEL, LABEL_NONLIVE.getText());
       event.addScreenOptions(
           new SettingsRenderer(
               LABEL_NONLIVE,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/dialog/EquellaDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/dialog/EquellaDialog.java
@@ -58,6 +58,7 @@ public abstract class EquellaDialog<S extends DialogModel> extends AbstractDialo
 
   private boolean alwaysShowFooter;
   private ElementId footerId;
+  private ElementId titleId;
 
   @Override
   protected SectionRenderable getDialogContents(RenderContext context) {
@@ -68,13 +69,15 @@ public abstract class EquellaDialog<S extends DialogModel> extends AbstractDialo
         this,
         getTemplateCloseFunction(),
         getContentBodyClass(context),
-        footerId);
+        footerId,
+        titleId);
   }
 
   @Override
   public void registered(String id, SectionTree tree) {
     super.registered(id, tree);
     footerId = new AppendedElementId(this, "footer");
+    titleId = new AppendedElementId(this, "title");
   }
 
   @Override
@@ -152,6 +155,10 @@ public abstract class EquellaDialog<S extends DialogModel> extends AbstractDialo
 
   public ElementId getFooterId() {
     return footerId;
+  }
+
+  public ElementId getTitleId() {
+    return titleId;
   }
 
   protected void setAlwaysShowFooter(boolean show) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/BootstrapSplitDropDownRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/BootstrapSplitDropDownRenderer.java
@@ -29,6 +29,7 @@ import com.tle.web.sections.standard.model.HtmlComponentState;
 import com.tle.web.sections.standard.model.HtmlListState;
 import com.tle.web.sections.standard.model.Option;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Render as button + dropdown as opposed to just a dropdown
@@ -89,6 +90,14 @@ public class BootstrapSplitDropDownRenderer extends BootstrapDropDownRenderer {
     }
     toggleButton.setNestedRenderable(caret());
     toggleButton.addClass("dropdown-toggle");
+
+    if (state.getAttribute("toggleAttrs") != null) {
+      Map<String, String> params = state.getAttribute("toggleAttrs");
+      params.forEach(
+          (key, value) -> {
+            toggleState.setAccessibilityAttr(key, value);
+          });
+    }
     writer.render(toggleButton);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/PagingSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/PagingSection.java
@@ -37,6 +37,7 @@ import com.tle.web.sections.generic.AbstractPrototypeSection;
 import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.js.generic.StatementHandler;
 import com.tle.web.sections.render.Label;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.Checkbox;
 import com.tle.web.sections.standard.Pager;
@@ -193,7 +194,10 @@ public class PagingSection<
     if (userPrefs.isSearchAttachment()) {
       attachmentSearch.setChecked(context, true);
     }
-
+    attachmentSearch
+        .getState(context)
+        .setAccessibilityAttr(TagRenderer.ARIA_LABEL, LABEL_ATTACHMENT_SEARCH.getText());
+    perPage.getState(context).setAccessibilityAttr(TagRenderer.ARIA_LABEL, LABEL_PERPAGE.getText());
     event.addScreenOptions(
         new SettingsRenderer(LABEL_PERPAGE, renderSection(context, perPage), "screen-option"));
     SearchSettings searchingSettings = getSearchSettings();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/SearchResultsActionsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/search/SearchResultsActionsSection.java
@@ -50,6 +50,7 @@ import com.tle.web.sections.js.generic.function.ExternallyDefinedFunction;
 import com.tle.web.sections.js.generic.function.IncludeFile;
 import com.tle.web.sections.render.HtmlRenderer;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.result.util.IconLabel.Icon;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.annotations.Component;
@@ -150,7 +151,6 @@ public class SearchResultsActionsSection<RE extends AbstractSearchResultsEvent<R
     if (model.isSearchDisabled()) {
       return null;
     }
-
     setupButton(sort, sortSections, showing, context);
     setupButton(filter, filterSections, showing, context);
 
@@ -177,6 +177,9 @@ public class SearchResultsActionsSection<RE extends AbstractSearchResultsEvent<R
         button.setClickHandler(context, new OverrideHandler(showFunc, buttonMode.toString()));
         state.setAttribute(Icon.class, Icon.DOWN);
       }
+      state.setAccessibilityAttr(TagRenderer.ARIA_CONTROL, ACTIONS_AJAX_ID);
+      state.setAccessibilityAttr(
+          TagRenderer.ARIA_EXPANDED, String.valueOf(!mode.equals(Showing.NONE)));
       getModel(context).addButton(button);
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
@@ -34,7 +34,7 @@ public abstract class AbstractElementRenderer extends AbstractComponentRenderer 
   protected void prepareFirstAttributes(SectionWriter writer, Map<String, String> attrs)
       throws IOException {
     super.prepareFirstAttributes(writer, attrs);
-    attrs.put("name", getName(writer)); // $NON-NLS-1$
+    attrs.put("name", getName(writer));
   }
 
   protected String getName(SectionInfo info) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/fancybox/FancyBoxDialogRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/fancybox/FancyBoxDialogRenderer.java
@@ -264,6 +264,7 @@ public class FancyBoxDialogRenderer extends AbstractComponentRenderer implements
     renderer.style = style;
     renderer.styleClasses = styleClasses;
     renderer.attrs = attrs;
+    renderer.setAttribute("role", "dialog");
     return renderer;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/DialogTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/DialogTemplate.java
@@ -30,6 +30,7 @@ import com.tle.web.sections.render.GenericTemplateResult;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.LabelRenderer;
 import com.tle.web.sections.render.SectionRenderable;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.render.TemplateRenderable;
 import com.tle.web.sections.render.TemplateResult;
 import com.tle.web.sections.result.util.KeyLabel;
@@ -60,7 +61,8 @@ public class DialogTemplate {
       AbstractDialog<?> dialog,
       JSHandler closeHandler,
       String contentBodyClass,
-      ElementId footerId) {
+      ElementId footerId,
+      ElementId titleId) {
     if (dialog.isModal()) {
       HtmlComponentState closeDialog = new HtmlComponentState(closeHandler);
       closeDialog.setId(dialog.getElementId(info) + "_close");
@@ -76,7 +78,7 @@ public class DialogTemplate {
     DialogTemplateModel model = new DialogTemplateModel();
     model.setPageTitle(new LabelRenderer(title));
     model.setFooterId(footerId.getElementId(info));
-
+    model.setTitleId(titleId.getElementId(info));
     model.setTemplate(result);
     model.setContentBodyClass(contentBodyClass);
 
@@ -84,7 +86,7 @@ public class DialogTemplate {
     if (footer != null && footer.exists(info)) {
       model.setFooter(footer);
     }
-
+    dialog.getState(info).setAccessibilityAttr(TagRenderer.ARIA_LABELLEDBY, model.getTitleId());
     return viewFactory.createResultWithModel("layouts/inner/dialog.ftl", model);
   }
 
@@ -95,6 +97,7 @@ public class DialogTemplate {
     private String contentBodyClass;
     private TemplateRenderable footer;
     private String footerId;
+    private String titleId;
 
     public String getContentBodyClass() {
       return contentBodyClass;
@@ -142,6 +145,14 @@ public class DialogTemplate {
 
     public void setFooterId(String footerId) {
       this.footerId = footerId;
+    }
+
+    public String getTitleId() {
+      return titleId;
+    }
+
+    public void setTitleId(String titleId) {
+      this.titleId = titleId;
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/WebControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/WebControl.java
@@ -43,7 +43,6 @@ public interface WebControl extends HTMLControl, Section, HtmlRenderer {
 
   CombinedDisableable getDisabler(SectionInfo info);
 
-  // Yes this is rubbish
   void doEditsIfRequired(SectionInfo info);
 
   void doReads(SectionInfo info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/standard/controls/EditBox.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/standard/controls/EditBox.java
@@ -43,6 +43,7 @@ import com.tle.web.sections.js.generic.function.AnonymousFunction;
 import com.tle.web.sections.js.generic.function.AssignableFunction;
 import com.tle.web.sections.js.generic.statement.ReturnStatement;
 import com.tle.web.sections.js.generic.statement.ScriptStatement;
+import com.tle.web.sections.render.TagRenderer;
 import com.tle.web.sections.standard.Link;
 import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
@@ -133,6 +134,9 @@ public class EditBox extends AbstractWebControl<EditBoxModel> implements SimpleV
           new OverrideHandler(
               new ScriptStatement(
                   "if(this.value.length > 8192) this.value = this.value.slice(0, 8192);")));
+    }
+    if (box.isMandatory()) {
+      field.getState(context).setAccessibilityAttr(TagRenderer.ARIA_REQUIRED, String.valueOf(true));
     }
     addDisabler(context, field);
     return viewFactory.createResult("editbox.ftl", context);

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/searching/SearchResult.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/searching/SearchResult.java
@@ -106,6 +106,9 @@ public class SearchResult<T extends SearchResult<T>> extends AbstractPage<T> {
   public String getStatus() {
     String statusLine = getDetailText("Status");
     int firstDivider = statusLine.indexOf('|');
+    if (resultPage.usingNewUI()) {
+      firstDivider = statusLine.indexOf("Last");
+    }
     if (firstDivider != -1) {
       statusLine = statusLine.substring(0, firstDivider);
     }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/searching/SearchResult.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/searching/SearchResult.java
@@ -106,12 +106,13 @@ public class SearchResult<T extends SearchResult<T>> extends AbstractPage<T> {
   public String getStatus() {
     String statusLine = getDetailText("Status");
     int firstDivider = statusLine.indexOf('|');
-    if (resultPage.usingNewUI()) {
+    if (resultPage.usingNewUI() && firstDivider == -1) {
       firstDivider = statusLine.indexOf("Last");
     }
     if (firstDivider != -1) {
       statusLine = statusLine.substring(0, firstDivider);
     }
+
     return statusLine.trim().toLowerCase();
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
#1432
 
After revisiting this issue the dropdown doesn’t need to announce its collapsed/uncollapsed state.

**BUT…..**

The fact that the within dropdown automatically expands as soon as it receives focus (pressing the tab key) violates https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior-receive-focus.html

So i made the dropdown only activate when the user:

Focuses on the element and presses the enter key (and the enter or esc key will close it)

The behaviour of the mouse if unchanged
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
