### PR TITLE
add role attribute to login error messages

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/view/logon/logon.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/logon/logon.ftl
@@ -6,20 +6,20 @@
 
 <div class="area">
 	<h2>${b.key("logon.title")}</h2>
-	
+
 	<#if m.failed??>
-		<p class="warning">${b.gkey(m.failed)}</p>
+		<p class="warning" role="alert">${b.gkey(m.failed)}</p>
 	</#if>
 	<#if m.error??>
-		<p class="warning">${b.key('logon.problems')}</p>
+		<p class="warning" role="alert">${b.key('logon.problems')}</p>
 		<p class="warning">${m.error?html}</p>
 	</#if>
 
 	<noscript>
-		<p class="warning">${b.key("logon.enablejs")}</p>
+		<p class="warning" role="alert">${b.key("logon.enablejs")}</p>
 	</noscript>
-	<p id="cookieWarning" class="warning" style="display: none">${b.key("logon.enablecookies")}</p>
-	
+	<p id="cookieWarning" class="warning" style="display: none" role="alert">${b.key("logon.enablecookies")}</p>
+
 	<p>
 		<label for="username">${b.key("logon.username")}</label>
 		<@textfield id="username" section=s.username autoSubmitButton=s.logonButton/>
@@ -32,7 +32,7 @@
 	<#if m.childSections??>
 		<@render m.childSections/>
 	</#if>
-	
+
 	<#list m.loginLinks as link>
 		<@render link />
 	</#list>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
#1432 
Very minor one here, just adding the role='alert' to error messages on the login page that I forgot the first time around 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
