### PR TITLE
#1479:  Remove jetty-utils dep

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -183,7 +183,6 @@ libraryDependencies ++= Seq(
   "org.dspace"             % "cql-java"          % "1.0",
   //  "org.dspace.oclc" % "oclc-srw" % "1.0.20080328",
   "org.omegat"                           % "jmyspell-core"                  % "1.0.0-beta-2",
-  "org.eclipse.jetty"                    % "jetty-util"                     % "8.1.7.v20120910",
   "org.freemarker"                       % "freemarker"                     % "2.3.23",
   "com.github.equella.legacy"            % "hurl"                           % "1.1",
   "org.javassist"                        % "javassist"                      % "3.18.2-GA",


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]


##### Description of change
#1479 - Removed the `jetty-utils` dependency.  It was needing an upgrade, but didn't look to be used anywhere.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
