### PR TITLE
Fix "no tree for xxx" error caused by favourite search links

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/bean/FavouriteSearch.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/bean/FavouriteSearch.java
@@ -18,7 +18,6 @@
 
 package com.tle.core.favourites.bean;
 
-import com.dytech.edge.web.WebConstants;
 import com.tle.beans.Institution;
 import java.util.Date;
 import javax.persistence.Column;
@@ -87,13 +86,6 @@ public class FavouriteSearch {
   }
 
   public String getUrl() {
-    // The value of 'url' starts with '/access' if the fav search was added in old oEQ versions,
-    // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
-    if (url != null
-        && url.startsWith(WebConstants.ACCESS_PATH)
-        && url.contains(WebConstants.SEARCHING_PAGE)) {
-      url = "/" + url.replaceFirst(WebConstants.ACCESS_PATH, "");
-    }
     return url;
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/bean/FavouriteSearch.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/bean/FavouriteSearch.java
@@ -18,6 +18,7 @@
 
 package com.tle.core.favourites.bean;
 
+import com.dytech.edge.web.WebConstants;
 import com.tle.beans.Institution;
 import java.util.Date;
 import javax.persistence.Column;
@@ -86,6 +87,11 @@ public class FavouriteSearch {
   }
 
   public String getUrl() {
+    // The value of 'url' starts with '/access' if the fav search was added in old oEQ versions,
+    // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
+    if (url != null && url.startsWith(WebConstants.ACCESS_PATH)) {
+      url = "/" + url.replaceFirst(WebConstants.ACCESS_PATH, "");
+    }
     return url;
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/bean/FavouriteSearch.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/bean/FavouriteSearch.java
@@ -89,7 +89,9 @@ public class FavouriteSearch {
   public String getUrl() {
     // The value of 'url' starts with '/access' if the fav search was added in old oEQ versions,
     // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
-    if (url != null && url.startsWith(WebConstants.ACCESS_PATH)) {
+    if (url != null
+        && url.startsWith(WebConstants.ACCESS_PATH)
+        && url.contains(WebConstants.SEARCHING_PAGE)) {
       url = "/" + url.replaceFirst(WebConstants.ACCESS_PATH, "");
     }
     return url;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -18,6 +18,7 @@
 
 package com.tle.core.favourites.service;
 
+import com.dytech.edge.web.WebConstants;
 import com.tle.beans.Institution;
 import com.tle.common.Check;
 import com.tle.common.institution.CurrentInstitution;
@@ -37,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.commons.lang.StringUtils;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,7 +70,23 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
   public void executeSearch(SectionInfo info, long id) {
     FavouriteSearch search = dao.getById(id);
     if (search != null) {
-      SectionInfo forward = info.createForwardForUri(search.getUrl());
+
+      String url = search.getUrl();
+      // The value of 'url' starts with '/access' if the fav search was added in old oEQ versions,
+      // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
+      if (url != null
+          && url.startsWith(WebConstants.ACCESS_PATH)
+          && StringUtils.indexOfAny(
+                  url,
+                  new String[] {
+                    WebConstants.SEARCHING_PAGE,
+                    WebConstants.HIERARCHY_PAGE,
+                    WebConstants.CLOUDSEARCH_PAGE
+                  })
+              > -1) {
+        url = "/" + url.replaceFirst(WebConstants.ACCESS_PATH, "");
+      }
+      SectionInfo forward = info.createForwardForUri(url);
       info.forwardAsBookmark(forward);
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -70,9 +70,9 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
   public void executeSearch(SectionInfo info, long id) {
     FavouriteSearch search = dao.getById(id);
     if (search != null) {
-
       String url = search.getUrl();
-      // The value of 'url' starts with '/access' if the fav search was added in old oEQ versions,
+      // When user favourites a normal search, cloud search or hierarchy search,
+      // the value of 'url' starts with '/access' if the fav search is added in old oEQ versions,
       // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
       if (url != null
           && url.startsWith(WebConstants.ACCESS_PATH)


### PR DESCRIPTION
#1280 
##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]

##### Description of change
After discussing with @mrblippy , we think the best fix is to check and rewrite the URL of favourite searches because it doesn't require data migration. Maybe there are different approaches, but some significant changes would be required. 

In terms of why the redirection Servlet not working, it is probably because clicking the favourite search link triggers a tree check before it sends the request. 


