### PR TITLE
Use APT provided Chromium Browser and Driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
-  - echo `google-chrome --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:
@@ -63,6 +62,9 @@ before_script:
   - which java javac
   - java -version
   - javac -version
+  # Diagnostics: Display browser versions
+  - google-chrome --version
+  - chromium-browser --version
 
 stages:
   - name: build and check

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ services:
   - postgresql
 addons:
   postgresql: "9.6"
-  chrome: beta
   apt:
     packages:
+      - chromium-browser
+      - chromium-chromedriver
       - ffmpeg
       - libimage-exiftool-perl
       - openjdk-8-jdk
@@ -51,10 +52,6 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
-  - curl -OL https://chromedriver.storage.googleapis.com/80.0.3987.16/chromedriver_linux64.zip
-  - unzip chromedriver_linux64.zip
-  - sudo apt-get purge google-chrome-stable # have to delete the stable version to force chromedriver to use the beta
-  - echo `google-chrome --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_install:
   - sudo ln -s /usr/bin/ffplay /usr/bin/avplay
   - sudo ln -s /usr/bin/ffprobe /usr/bin/avprobe
 install:
+  - echo `google-chrome --version`
   # retrieve full git history for automatic versioning
   - git fetch --unshallow
 before_script:

--- a/autotest/travis.conf
+++ b/autotest/travis.conf
@@ -3,6 +3,7 @@ server.password = autotestpassword
 
 webdriver.chrome {
   driver = "/usr/lib/chromium-browser/chromedriver"
+  bin = "/usr/bin/chromium-browser"
   headless = true
 }
 

--- a/autotest/travis.conf
+++ b/autotest/travis.conf
@@ -2,7 +2,7 @@ server.url = "http://localhost:8080/"
 server.password = autotestpassword
 
 webdriver.chrome {
-  driver = ${TRAVIS_BUILD_DIR}"/chromedriver"
+  driver = "/usr/lib/chromium-browser/chromedriver"
   headless = true
 }
 


### PR DESCRIPTION
#1401 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]

##### Description of change

As the latest stable version of Chromium Browser and Driver are available on Ubuntu Package, we don't use beta version of Chrome and download the Driver.

#1401 
