### PR TITLE
#1496 Apply XStream security configs

### DIFF
--- a/Source/Plugins/Core/com.equella.admin/src/com/dytech/edge/admin/wizard/WizardHelper.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/dytech/edge/admin/wizard/WizardHelper.java
@@ -22,13 +22,13 @@ import com.dytech.edge.admin.wizard.editor.Editor;
 import com.dytech.edge.admin.wizard.model.Control;
 import com.dytech.edge.wizard.TargetNode;
 import com.dytech.edge.wizard.beans.control.WizardControl;
-import com.thoughtworks.xstream.XStream;
 import com.tle.admin.schema.MultiTargetChooser;
 import com.tle.admin.schema.SchemaModel;
 import com.tle.admin.schema.SingleTargetChooser;
 import com.tle.admin.schema.TargetChooser;
 import com.tle.common.Check;
 import com.tle.common.i18n.CurrentLocale;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import java.awt.BorderLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -230,7 +230,7 @@ public final class WizardHelper {
   }
 
   public static String getXmlForComparison(Object wizard) {
-    return new XStream().toXML(wizard);
+    return XStreamSecurityManager.newXStream().toXML(wizard);
   }
 
   // ////// OLD STUFF //////////////////////////////////////////

--- a/Source/Plugins/Core/com.equella.admin/src/com/dytech/edge/admin/wizard/WizardTree.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/dytech/edge/admin/wizard/WizardTree.java
@@ -49,6 +49,7 @@ import com.tle.common.Check;
 import com.tle.common.applet.client.DialogUtils;
 import com.tle.common.applet.client.FileWorker;
 import com.tle.common.i18n.CurrentLocale;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.plugins.PluginService;
 import com.tle.core.remoting.RemoteItemDefinitionService;
 import java.awt.Component;
@@ -376,7 +377,7 @@ public class WizardTree extends JPanel
         final String controlXml =
             getCollectionService(Driver.instance()).importControl(Files.toByteArray(file));
 
-        final XStream xstream = new XStream();
+        final XStream xstream = XStreamSecurityManager.newXStream();
         final Set<String> pluginIds = getPluginIds(controlXml);
         final PluginService pluginService = Driver.instance().getPluginService();
 
@@ -499,7 +500,9 @@ public class WizardTree extends JPanel
         final ExportedControl ctl =
             getExportedControl(control, pluginService, driver.getVersion().getFull());
 
-        byte[] zipData = getCollectionService(driver).exportControl(new XStream().toXML(ctl));
+        byte[] zipData =
+            getCollectionService(driver)
+                .exportControl(XStreamSecurityManager.newXStream().toXML(ctl));
 
         ByteArrayInputStream stream = new ByteArrayInputStream(zipData);
         try (OutputStream out = new FileOutputStream(file)) {

--- a/Source/Plugins/Core/com.equella.admin/src/com/dytech/edge/admin/wizard/XStreamDataConverter.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/dytech/edge/admin/wizard/XStreamDataConverter.java
@@ -21,12 +21,13 @@ package com.dytech.edge.admin.wizard;
 import com.dytech.gui.adapters.TablePasteAdapter.DataConverter;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.core.util.CompositeClassLoader;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 
 public class XStreamDataConverter implements DataConverter {
   private final XStream xstream;
 
   public XStreamDataConverter(Class<?> klass) {
-    xstream = new XStream();
+    xstream = XStreamSecurityManager.newXStream();
     ClassLoader cl = xstream.getClassLoader();
     // I think they always are
     if (cl instanceof CompositeClassLoader) {

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/collection/summarydisplay/BasicConfig.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/collection/summarydisplay/BasicConfig.java
@@ -27,6 +27,7 @@ import com.tle.admin.schema.SchemaModel;
 import com.tle.beans.entity.itemdef.ItemDefinition;
 import com.tle.beans.entity.itemdef.SummarySectionsConfig;
 import com.tle.common.applet.client.ClientService;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -97,7 +98,7 @@ public class BasicConfig extends AbstractOnlyTitleConfig implements ActionListen
     super.load(element);
     if (element.getConfiguration() != null) {
       try {
-        XStream xstream = new XStream();
+        XStream xstream = XStreamSecurityManager.newXStream();
         HashMap<String, String> fromXML =
             (HashMap<String, String>) xstream.fromXML(element.getConfiguration());
 
@@ -136,7 +137,7 @@ public class BasicConfig extends AbstractOnlyTitleConfig implements ActionListen
       settings.put(TITLE_LENGTH_KEY, maxLengthTitle.getCurrentValue());
     }
 
-    XStream xstream = new XStream();
+    XStream xstream = XStreamSecurityManager.newXStream();
     String toXML = xstream.toXML(settings);
     element.setConfiguration(toXML);
     super.save(element);

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/collection/summarydisplay/DisplayNodesConfig.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/collection/summarydisplay/DisplayNodesConfig.java
@@ -29,6 +29,7 @@ import com.tle.beans.entity.itemdef.DisplayNode;
 import com.tle.beans.entity.itemdef.ItemDefinition;
 import com.tle.beans.entity.itemdef.SummarySectionsConfig;
 import com.tle.common.applet.client.ClientService;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.i18n.BundleCache;
 import java.awt.Component;
 import java.util.List;
@@ -42,7 +43,7 @@ public class DisplayNodesConfig extends AbstractOnlyTitleConfig {
   private XStream xstream;
 
   public DisplayNodesConfig() {
-    xstream = new XStream();
+    xstream = XStreamSecurityManager.newXStream();
     xstream.setClassLoader(getClass().getClassLoader());
   }
 

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/itemdefinition/ItemSummaryTemplateTab.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/itemdefinition/ItemSummaryTemplateTab.java
@@ -32,6 +32,7 @@ import com.tle.beans.entity.itemdef.SummaryDisplayTemplate;
 import com.tle.beans.entity.itemdef.SummarySectionsConfig;
 import com.tle.common.Check;
 import com.tle.common.i18n.CurrentLocale;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.plugins.PluginTracker;
 import java.awt.Component;
 import java.awt.event.KeyListener;
@@ -123,7 +124,7 @@ public class ItemSummaryTemplateTab extends AbstractItemdefTab {
         }
 
         if (section.getValue().equals("displayNodes")) {
-          xstream = new XStream();
+          xstream = XStreamSecurityManager.newXStream();
           xstream.setClassLoader(getClass().getClassLoader());
 
           Object fromXML = xstream.fromXML(section.getConfiguration());

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/streaming/XStreamSecurityManager.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/streaming/XStreamSecurityManager.java
@@ -1,0 +1,22 @@
+package com.tle.common.security.streaming;
+
+import com.thoughtworks.xstream.XStream;
+
+public class XStreamSecurityManager {
+  public static void applyPolicy(XStream xstream) {
+    XStream.setupDefaultSecurity(xstream);
+    // Anything you want to be XStream'd needs to be allowed here
+    xstream.allowTypesByWildcard(
+        new String[] {
+          "com.tle.**", "com.dytech.**",
+        });
+  }
+
+  // Helper method to have ALL XStream instances be covered by
+  // the oEQ policy(ies) in this manager.
+  public static XStream newXStream() {
+    XStream xs = new XStream();
+    applyPolicy(xs);
+    return xs;
+  }
+}

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/streaming/XStreamSecurityManager.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/streaming/XStreamSecurityManager.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.common.security.streaming;
 
 import com.thoughtworks.xstream.XStream;

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/core/xstream/TLEXStream.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/core/xstream/TLEXStream.java
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.io.xml.DomWriter;
 import com.thoughtworks.xstream.io.xml.XppDriver;
 import com.thoughtworks.xstream.mapper.Mapper;
 import com.thoughtworks.xstream.mapper.MapperWrapper;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -52,6 +53,7 @@ public class TLEXStream extends XStream {
     xppDriver = new XppDriver();
     registerConverter(new XMLDataConverter());
     this.disallowAdd = disallowAdd;
+    XStreamSecurityManager.applyPolicy(this);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/item/ItemSummaryApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/item/ItemSummaryApi.scala
@@ -23,6 +23,7 @@ import com.tle.beans.entity.itemdef.DisplayNode
 import com.tle.beans.item.{Item, ItemId, ItemPack}
 import com.tle.common.i18n.LangUtils
 import com.tle.common.security.SecurityConstants
+import com.tle.common.security.streaming.XStreamSecurityManager
 import com.tle.core.item.helper.ItemHelper
 import com.tle.exceptions.{AccessDeniedException, PrivilegeRequiredException}
 import com.tle.legacy.LegacyGuice
@@ -38,7 +39,7 @@ import scala.collection.JavaConverters._
 
 object ItemSummaryApi {
 
-  val xstream = new XStream()
+  val xstream = XStreamSecurityManager.newXStream()
   val Logger  = LoggerFactory.getLogger(getClass)
 
   def getItemSummary(uuid: String, version: Int): ItemSummary = {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/harvester/EQUELLAProtocol.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/harvester/EQUELLAProtocol.java
@@ -25,6 +25,7 @@ import com.tle.common.harvester.HarvesterException;
 import com.tle.common.harvester.HarvesterProfile;
 import com.tle.common.i18n.CurrentLocale;
 import com.tle.common.searching.Search;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.common.util.Dates;
 import com.tle.common.util.UtcDate;
 import com.tle.core.guice.Bind;
@@ -51,7 +52,7 @@ public class EQUELLAProtocol extends AbstractHarvesterProtocol {
   private static final Logger LOGGR = Logger.getLogger(EQUELLAProtocol.class);
   private static final String HARVESTER_END_POINT = "services/SoapHarvesterService";
 
-  private final XStream customAttachXstream = new XStream();
+  private final XStream customAttachXstream = XStreamSecurityManager.newXStream();
 
   @Inject private SoapClientFactory clientFactory;
   @Inject private FileSystemService fileSystemService;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/helper/AttachmentHelper.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/helper/AttachmentHelper.java
@@ -32,6 +32,7 @@ import com.tle.beans.item.attachments.LinkAttachment;
 import com.tle.beans.item.attachments.ZipAttachment;
 import com.tle.common.Check;
 import com.tle.common.security.Privilege;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.guice.Bind;
 import com.tle.core.item.ViewCountJavaDao;
 import java.util.ArrayList;
@@ -47,7 +48,7 @@ import javax.inject.Singleton;
 @Bind
 @Singleton
 public class AttachmentHelper extends AbstractHelper {
-  private final XStream customAttachXstream = new XStream();
+  private final XStream customAttachXstream = XStreamSecurityManager.newXStream();
   private final ItemXmlSecurity security;
 
   @Inject

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/search/searchset/virtualisation/ManualListVirtualiser.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/search/searchset/virtualisation/ManualListVirtualiser.java
@@ -21,6 +21,7 @@ package com.tle.core.search.searchset.virtualisation;
 import com.dytech.common.GeneralConstants;
 import com.thoughtworks.xstream.XStream;
 import com.tle.common.search.searchset.SearchSet;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.guice.Bind;
 import com.tle.core.search.VirtualisableAndValue;
 import java.util.Collection;
@@ -31,7 +32,7 @@ import javax.inject.Singleton;
 @Bind
 @Singleton
 public class ManualListVirtualiser implements SearchSetVirtualiser {
-  private static XStream xstream = new XStream();
+  private static XStream xstream = XStreamSecurityManager.newXStream();
 
   /**
    * For a hierarchical topic (hence searchSet.supportsHierachy), we do a matrixSearch to determine

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mets/importerexporters/CustomMetsAttachmentImporterExporter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mets/importerexporters/CustomMetsAttachmentImporterExporter.java
@@ -26,6 +26,7 @@ import com.tle.beans.item.attachments.AttachmentType;
 import com.tle.beans.item.attachments.CustomAttachment;
 import com.tle.beans.item.attachments.ItemNavigationNode;
 import com.tle.common.filesystem.handle.FileHandle;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.guice.Bind;
 import com.tle.mets.MetsIDElementInfo;
 import com.tle.web.sections.SectionInfo;
@@ -63,7 +64,7 @@ public class CustomMetsAttachmentImporterExporter extends AbstractMetsAttachment
     final CustomAttachment custom = (CustomAttachment) attachment;
 
     final PropBagEx xmlData = new PropBagEx();
-    final XStream x = new XStream();
+    final XStream x = XStreamSecurityManager.newXStream();
     xmlData.append("xstream", new PropBagEx(x.toXML(custom.getDataAttributesReadOnly())));
     xmlData.setNode("url", custom.getUrl());
     xmlData.setNode("uuid", custom.getUuid());
@@ -93,7 +94,7 @@ public class CustomMetsAttachmentImporterExporter extends AbstractMetsAttachment
       AttachmentAdder attachmentAdder) {
     final CustomAttachment custom = new CustomAttachment();
 
-    final XStream x = new XStream();
+    final XStream x = XStreamSecurityManager.newXStream();
     // need to use the first child
     PropBagEx mapXml = null;
     for (PropBagEx child : xmlData.getSubtree("xstream").iterator()) {

--- a/Source/Plugins/Core/com.equella.core/test/java/com/tle/ims/metadata/AbstractMetadataMapperTester.java
+++ b/Source/Plugins/Core/com.equella.core/test/java/com/tle/ims/metadata/AbstractMetadataMapperTester.java
@@ -9,10 +9,10 @@ import com.dytech.edge.ejb.helpers.metadata.mappers.PackageMapper;
 import com.dytech.edge.ejb.helpers.metadata.mappers.XPathMapper;
 import com.dytech.edge.ejb.helpers.metadata.mapping.Mapping;
 import com.google.common.base.Throwables;
-import com.thoughtworks.xstream.XStream;
 import com.tle.beans.entity.Schema;
 import com.tle.beans.entity.itemdef.MetadataMapping;
 import com.tle.beans.entity.itemdef.mapping.IMSMapping;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.xstream.XMLCompare;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,7 +49,7 @@ public abstract class AbstractMetadataMapperTester extends TestCase {
             new UnicodeReader(
                 getClass().getResourceAsStream("/" + folder + "/itemdef.xml"), "UTF-8");
         InputStream schemaIn = getClass().getResourceAsStream("/" + folder + "/schema.xml")) {
-      itemMapping = (MetadataMapping) new XStream().fromXML(mappingReader);
+      itemMapping = (MetadataMapping) XStreamSecurityManager.newXStream().fromXML(mappingReader);
 
       PropBagEx sxml = new PropBagEx(schemaIn);
       if (sxml.nodeExists("definition/xml")) {

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/equella/service/impl/InitialiserServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/equella/service/impl/InitialiserServiceImpl.java
@@ -24,6 +24,7 @@ import com.thoughtworks.xstream.hibernate.converter.*;
 import com.thoughtworks.xstream.hibernate.mapper.HibernateMapper;
 import com.thoughtworks.xstream.mapper.MapperWrapper;
 import com.tle.beans.IdCloneable;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.guice.Bind;
 import com.tle.core.hibernate.dao.AbstractHibernateDao;
 import com.tle.core.hibernate.equella.service.FieldProperty;
@@ -452,6 +453,7 @@ public class InitialiserServiceImpl extends AbstractHibernateDao implements Init
             return new HibernateMapper(next);
           }
         };
+    XStreamSecurityManager.applyPolicy(xstream);
     xstream.setClassLoader(classLoader);
     xstream.autodetectAnnotations(true);
     xstream.registerConverter(new HibernateProxyConverter());

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/xml/service/impl/XmlServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/xml/service/impl/XmlServiceImpl.java
@@ -22,6 +22,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.core.util.ClassLoaderReference;
 import com.thoughtworks.xstream.core.util.CompositeClassLoader;
 import com.thoughtworks.xstream.io.xml.XppDriver;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.guice.Bind;
 import com.tle.core.xml.service.XmlService;
 import java.io.Reader;
@@ -96,6 +97,7 @@ public final class XmlServiceImpl implements XmlService {
       autodetectAnnotations(true);
       registerConverter(new OldSingletonMapConverter(getMapper(), getReflectionProvider()));
       registerConverter(new OldSqlTimestampConverter());
+      XStreamSecurityManager.applyPolicy(this);
     }
 
     @Override

--- a/Source/Server/adminTool/src/com/tle/client/harness/ClientLauncher.java
+++ b/Source/Server/adminTool/src/com/tle/client/harness/ClientLauncher.java
@@ -23,9 +23,9 @@ import com.dytech.edge.common.Version;
 import com.dytech.gui.ComponentHelper;
 import com.dytech.gui.TableLayout;
 import com.dytech.gui.workers.GlassSwingWorker;
-import com.thoughtworks.xstream.XStream;
 import com.tle.admin.PluginServiceImpl;
 import com.tle.client.ListCookieHandler;
+import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.common.util.BlindSSLSocketFactory;
 import com.tle.core.plugins.PluginAwareObjectInputStream;
 import com.tle.core.plugins.PluginAwareObjectOutputStream;
@@ -266,7 +266,7 @@ public class ClientLauncher extends JFrame
     File f = new File(SERVER_XML);
     if (f.exists() && f.isFile()) {
       try (Reader reader = new BufferedReader(new FileReader(f))) {
-        config = (HarnessConfig) new XStream().fromXML(reader);
+        config = (HarnessConfig) XStreamSecurityManager.newXStream().fromXML(reader);
       } catch (IOException ex) {
         // Ignore this
       } catch (Error err) {
@@ -312,7 +312,7 @@ public class ClientLauncher extends JFrame
 
     // Write the configuration back to the file.
     try (Writer out = new BufferedWriter(new FileWriter(newFile))) {
-      new XStream().toXML(config, out);
+      XStreamSecurityManager.newXStream().toXML(config, out);
     } catch (Exception ex) {
       LOGGER.warn("Error saving server xml", ex);
     }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/adminconsole/AdminConsoleTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/adminconsole/AdminConsoleTest.java
@@ -105,7 +105,7 @@ public class AdminConsoleTest extends AbstractTest {
     // Write the configuration back to the file.
     try {
       Writer out = new BufferedWriter(new FileWriter(newFile));
-      new XStream().toXML(config, out);
+      new XStream().toXML(config, out); /* Test - Not a security risk */
     } catch (Exception e) {
       throw new Error(e);
     }


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
Due to #1496 

In testing 2010.1-RC2, I noticed the error in the logs:
```
Security framework of XStream not initialized, XStream is probably vulnerable.
```

Looking closer at the [XStream release notes](https://x-stream.github.io/changes.html), I found:
```
Add XStream.setupDefaultSecurity to initialize security framework with defaults of XStream 1.5.x.
Emit error warning if security framework has not been initialized and the XStream instance is vulnerable to known exploits.
```

I searched for all invocations of XStream and piped them through a new class `com.equella.base...XStreamSecurityManager` and applied a policy that any class that starts with `com.tle` or `com.dytech` can be XStream'd, as well as the default security rules given by XStream.  All other classes should be blocked.

I choose to centralize the policy of XStream security to stay consistent across the application.

Aiming for 2020.1.0 for this fix.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
