### PR TITLE
chore: update links and copyright year

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -1976,13 +1976,13 @@ footer.clusterinfo=This node\: {0}<br>Nodes in this cluster\: [{1}]
 footer.clustertaskleader=This node is the task leader
 footer.creativecommons=The data displayed in these search results are subject to MERLOT's adoption of the <a href\="http\://taste.merlot.org/acceptableuserpolicy.html\#cc">Creative Commons license</a>\: Attribution, Non Commercial, Derivative, Share-Alike (by-nc-sa).
 footer.link.community=<a href\="https\://groups.google.com/a/apereo.org/forum/\#\!forum/equella-users">User community</a>
-footer.link.copyright=<span>&copy; 2017 <a href\="https\://www.apereo.org/">Apereo</a></span>
+footer.link.copyright=<span>&copy; 2020 <a href\="https\://www.apereo.org/">Apereo</a></span>
 footer.link.credits=<a href\="licences.do">Credits</a>
-footer.link.home=<a href\="https\://equella.github.io/">Home</a>
+footer.link.home=<a href\="https\://openequella.github.io/">Home</a>
 footer.link.instcredits=<a href\="institutions.do?method\=credits">Credits</a>
 footer.link.rss=<a href\="https\://groups.google.com/a/apereo.org/forum/feed/equella-users/msgs/rss_v2_0.xml?num\=50" class\="icon rss"> title\="RSS">RSS</a>
 footer.link.twitter=<a href\="https\://twitter.com/equella" title\="Twitter" class\="icon twitter">Twitter</a>
-footer.thankyou=Thank you for using <a href\="https\://equella.github.io/">openEQUELLA</a>
+footer.thankyou=Thank you for using <a href\="https\://openequella.github.io/">openEQUELLA</a>
 footer.version=version
 freemarker.error.javascript=There was an error executing client side javascript for the ''{0}'' portlet
 freemarker.error.markup=There was an error in the freemarker\: <br>{0}


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
Updated the links to the documentation landing page in the footers to openequella.github.com and bumped the copyright year to 2020.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
