### PR TITLE
Release/2020.1.0 chore/update tomcat to 8 5 51

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/tomcat/service/impl/TomcatServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/tomcat/service/impl/TomcatServiceImpl.java
@@ -182,6 +182,7 @@ public class TomcatServiceImpl implements TomcatService, StartupBean, TomcatRest
       if (ajpPort != -1) {
         Connector connector = new Connector(useBio ? BIO_AJP : "AJP/1.3");
         connector.setPort(ajpPort);
+        connector.setAttribute("requiredSecret", false);
         connector.setAttribute("tomcatAuthentication", false);
         connector.setAttribute("packetSize", "65536");
         setConnector(connector);

--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -17,7 +17,7 @@ unmanagedClasspath in Runtime += (baseDirectory in LocalProject("learningedge_co
 
 val jacksonVersion   = "2.10.2"
 val axis2Version     = "1.6.2"
-val TomcatVersion    = "8.5.50"
+val TomcatVersion    = "8.5.51"
 val SwaggerVersion   = "1.5.24"
 val RestEasyVersion  = "3.5.0.Final"
 val simpledbaVersion = "0.1.9"


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
No-effective change to tomcat AJP connector to work with Tomcat 8.5.51.  This disables the mandatory secret for AJP connections.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
