### PR TITLE
style: normalize use of let, const, and interface

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/acl/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/acl/index.ts
@@ -69,7 +69,7 @@ function aclWorkers(actions: AclActions): AclWorkers {
 function aclReducerBuilder(
   actions: AclActions
 ): ReducerBuilder<PartialAclState, PartialAclState> {
-  let initialState: PartialAclState = {
+  const initialState: PartialAclState = {
     nodes: {}
   };
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/cloudcontrol/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/cloudcontrol/index.ts
@@ -61,18 +61,18 @@ interface Registration {
   unmount: (removed: Element) => void;
 }
 
-var registrations: {
+const registrations: {
   [key: string]: Registration | undefined;
 } = {};
 
-var listeners: ((doc: ItemState) => void)[] = [];
-var controlValidators: { validator: ControlValidator; ctrlId: string }[] = [];
-var commandQueue: CommandsPromise[] = [];
-var transformState: ((doc: XMLDocument) => XMLDocument) | null = null;
-var reloadState: boolean = false;
-var wizardIds: WizardIds;
-var currentState: Promise<VersionedItemState>;
-var latestXml: XMLDocument;
+let listeners: ((doc: ItemState) => void)[] = [];
+let controlValidators: { validator: ControlValidator; ctrlId: string }[] = [];
+let commandQueue: CommandsPromise[] = [];
+let transformState: ((doc: XMLDocument) => XMLDocument) | null = null;
+let reloadState = false;
+let wizardIds: WizardIds;
+let currentState: Promise<VersionedItemState>;
+let latestXml: XMLDocument;
 
 function resetGlobalState() {
   transformState = null;
@@ -87,7 +87,7 @@ function resetGlobalState() {
 const parser = new DOMParser();
 const serializer = new XMLSerializer();
 
-var activeElements: {
+let activeElements: {
   element: Element;
   removed: Registration;
 }[] = [];
@@ -129,7 +129,7 @@ const observer = new MutationObserver(function() {
     null
   );
   const res: Element[] = [];
-  for (var i = 0; i < liveElements.snapshotLength; i++) {
+  for (let i = 0; i < liveElements.snapshotLength; i++) {
     res.push(liveElements.snapshotItem(i) as Element);
   }
   activeElements = activeElements.filter(e => {
@@ -145,7 +145,7 @@ observer.observe(document, {
   subtree: true
 });
 
-var allValid = true;
+let allValid = true;
 
 $(window).bind("validate", () => allValid);
 
@@ -156,9 +156,9 @@ $(window).bind("presubmit", () => {
   let editXmlFunc: (doc: XMLDocument) => XMLDocument = x => x;
   let xmlEdited = false;
   controlValidators.forEach(({ validator, ctrlId }) => {
-    let valid = validator(
+    const valid = validator(
       (edit: (doc: XMLDocument) => XMLDocument) => {
-        let oldXmlFunc = editXmlFunc;
+        const oldXmlFunc = editXmlFunc;
         editXmlFunc = d => edit(oldXmlFunc(d));
         xmlEdited = true;
       },
@@ -176,7 +176,7 @@ $(window).bind("presubmit", () => {
   });
   if (xmlEdited) {
     latestXml = editXmlFunc(latestXml);
-    let xmlDoc = serializer.serializeToString(latestXml);
+    const xmlDoc = serializer.serializeToString(latestXml);
     $("<input>")
       .attr({ type: "hidden", name: "xmldoc", value: xmlDoc })
       .appendTo("#cloudState");
@@ -210,7 +210,7 @@ export const CloudControl: CloudControlRegisterImpl = {
   async sendBatch(state: VersionedItemState): Promise<VersionedItemState> {
     if (reloadState) {
       reloadState = false;
-      var nextState = await getState(wizardIds.wizId);
+      let nextState = await getState(wizardIds.wizId);
       if (nextState.stateVersion < state.stateVersion) {
         console.log(
           `Out of order state detected, already had ${state.stateVersion} but got ${nextState.stateVersion}`
@@ -225,7 +225,7 @@ export const CloudControl: CloudControlRegisterImpl = {
       return CloudControl.sendBatch(nextState);
     }
     let edits: ItemCommand[] = [];
-    let currentPromises: CommandsPromise[] = [];
+    const currentPromises: CommandsPromise[] = [];
     let xml;
     let newXml = state.xml;
     if (transformState) {
@@ -253,7 +253,7 @@ export const CloudControl: CloudControlRegisterImpl = {
             att = att.filter(at => at.uuid != change.uuid);
             break;
           case "edited":
-            var ind = att.findIndex(at => at.uuid == change.attachment.uuid);
+            const ind = att.findIndex(at => at.uuid == change.attachment.uuid);
             att[ind] = change.attachment;
             break;
         }
@@ -387,7 +387,7 @@ export const CloudControl: CloudControlRegisterImpl = {
 
 const missingControl: Registration = {
   mount: params => {
-    let errText = $(
+    const errText = $(
       `<div class="control ctrlinvalid"><p class="ctrlinvalidmessage">Failed to find registration for cloud control: "${params.vendorId}_${params.controlType}"</p></div>`
     );
     $(params.element).append(errText);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/cloudprovider/CloudProviderAddDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/cloudprovider/CloudProviderAddDialog.tsx
@@ -57,7 +57,7 @@ class CloudProviderAddDialog extends React.Component<
   };
 
   validateUrl = (): boolean => {
-    let url = this.state.cloudProviderUrl;
+    const url = this.state.cloudProviderUrl;
     if (url == "") {
       return true;
     } else {
@@ -80,7 +80,7 @@ class CloudProviderAddDialog extends React.Component<
   render() {
     const { open, onCancel, onRegister, classes } = this.props;
     const { cloudProviderUrl, disclaimerDialogOpen } = this.state;
-    let isUrlValid = this.validateUrl();
+    const isUrlValid = this.validateUrl();
     return (
       <div>
         <Dialog

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/cloudprovider/CloudProviderListPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/cloudprovider/CloudProviderListPage.tsx
@@ -110,7 +110,7 @@ class CloudProviderListPage extends React.Component<
 
   confirmDeleteCloudProvider = () => {
     if (this.state.deleteDetails) {
-      let id = this.state.deleteDetails.id;
+      const id = this.state.deleteDetails.id;
       this.cancelDeleteCloudProvider();
       deleteCloudProvider(id)
         .then(() => {
@@ -178,7 +178,7 @@ class CloudProviderListPage extends React.Component<
           createOnClick={this.registerCloudProvider}
         >
           {cloudProviders.map(cloudProvider => {
-            let secondaryAction = (
+            const secondaryAction = (
               <IconButton
                 onClick={() => {
                   this.deleteCloudProvider(cloudProvider);
@@ -187,7 +187,7 @@ class CloudProviderListPage extends React.Component<
                 <DeleteIcon />
               </IconButton>
             );
-            let icon = (
+            const icon = (
               <Avatar
                 src={cloudProvider.iconUrl}
                 alt={cloudProvider.description}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/cloudprovider/CloudProviderModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/cloudprovider/CloudProviderModule.ts
@@ -35,7 +35,7 @@ export function refreshCloudProvider(cloudProviderId: string): AxiosPromise {
 export function registerCloudProviderInit(
   cloudProviderUrl: string
 ): Promise<CloudProviderInitResponse> {
-  let params = {
+  const params = {
     url: cloudProviderUrl
   };
   return Axios.post<CloudProviderInitResponse>(

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/CourseSelect.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/CourseSelect.tsx
@@ -78,7 +78,7 @@ class CourseItems extends React.Component<CourseItemProps, CourseItemState> {
     const { courses } = this.state;
     const { getItemProps } = this.props;
     return courses.map((course: Course) => {
-      let itemProps = getItemProps({ item: course });
+      const itemProps = getItemProps({ item: course });
       return (
         <MenuItem {...itemProps} key={course.name} component="div">
           {courseToString(course)}
@@ -118,7 +118,7 @@ class CourseSelect extends React.Component<
     this.props.onCourseSelect(selectedItem);
   };
   handleInputChange = (event: any) => {
-    let inputValue = event.target.value;
+    const inputValue = event.target.value;
     this.setState({ inputValue });
     this.props.onCourseSelect(null);
   };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/SearchResult.tsx
@@ -56,7 +56,7 @@ class SearchResult extends React.Component<PropsWithStyles> {
         color="primary"
         variant="subtitle1"
         component={p => (
-          <Link {...p} to={to!}>
+          <Link {...p} to={to}>
             {this.props.primaryText}
           </Link>
         )}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/config.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/config.ts
@@ -9,5 +9,5 @@ export const Config: Config = {
   baseUrl:
     typeof document == "undefined"
       ? ""
-      : document.getElementsByTagName("base")[0].href!
+      : document.getElementsByTagName("base")[0].href
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/course/EditCourse.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/course/EditCourse.tsx
@@ -240,7 +240,7 @@ class EditCourse extends React.Component<Props, EditCourseState> {
 
   handleIntChange(stateFieldName: string) {
     return (event: React.ChangeEvent<HTMLInputElement>) => {
-      let val = event.target.value;
+      const val = event.target.value;
       let intVal: number | undefined = parseInt(val);
       if (!Number.isInteger(intVal)) {
         intVal = undefined;
@@ -370,7 +370,7 @@ class EditCourse extends React.Component<Props, EditCourseState> {
 
     let rules: TargetListEntry[] = [];
     if (security) {
-      rules = security!.rules;
+      rules = security.rules;
     }
 
     return (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/course/SearchCourse.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/course/SearchCourse.tsx
@@ -220,7 +220,7 @@ class SearchCourse extends React.Component<
               onDelete = () =>
                 this.setState({ confirmOpen: true, deleteDetails });
             }
-            var text = course.code + " - " + course.name;
+            let text = course.code + " - " + course.name;
             if (course.archived) {
               text = text + " (" + strings.archived + ")";
             }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/entity/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/entity/index.ts
@@ -240,7 +240,7 @@ function entityWorkers<E extends Entity>(
 function entityReducerBuilder<E extends Entity>(
   entityCrudActions: EntityCrudActions<E>
 ): ReducerBuilder<PartialEntityState<E>, PartialEntityState<E>> {
-  let initialEntityState: PartialEntityState<E> = {
+  const initialEntityState: PartialEntityState<E> = {
     query: "",
     loading: false
   };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -25,12 +25,12 @@ interface StateData {
   [key: string]: string[];
 }
 
-type FormUpdate = {
+interface FormUpdate {
   state: StateData;
   partial: boolean;
-};
+}
 
-type LegacyContent = {
+interface LegacyContent {
   html: { [key: string]: string };
   state: StateData;
   css?: string[];
@@ -44,7 +44,7 @@ type LegacyContent = {
   hideAppBar: boolean;
   preventUnload: boolean;
   userUpdated: boolean;
-};
+}
 
 export interface PageContent {
   contentId: string;
@@ -104,11 +104,10 @@ export const LegacyContent = React.memo(function LegacyContent({
   userUpdated
 }: LegacyContentProps) {
   const [content, setContent] = React.useState<PageContent>();
-  const baseUrl = (document.getElementsByTagName("base")[0] as HTMLBaseElement)
-    .href;
+  const baseUrl = document.getElementsByTagName("base")[0].href;
 
   function toRelativeUrl(url: string) {
-    let relUrl =
+    const relUrl =
       url.indexOf(baseUrl) == 0 ? url.substring(baseUrl.length) : url;
     return relUrl.indexOf("/") == 0 ? relUrl : "/" + relUrl;
   }
@@ -208,7 +207,7 @@ export const LegacyContent = React.memo(function LegacyContent({
       updateForm: function(formUpdate: FormUpdate) {
         setContent(content => {
           if (content) {
-            let newState = formUpdate.partial
+            const newState = formUpdate.partial
               ? { ...content.state, ...formUpdate.state }
               : formUpdate.state;
             return { ...content, state: newState };
@@ -220,10 +219,10 @@ export const LegacyContent = React.memo(function LegacyContent({
 
   React.useEffect(() => {
     if (enabled) {
-      let params = new URLSearchParams(search);
-      let urlValues = {};
+      const params = new URLSearchParams(search);
+      const urlValues = {};
       params.forEach((val, key) => {
-        let exVal = urlValues[key];
+        const exVal = urlValues[key];
         if (exVal) exVal.push(val);
         else urlValues[key] = [val];
       });
@@ -246,7 +245,7 @@ async function updateIncludes(
   js: string[],
   css?: string[]
 ): Promise<{ [url: string]: HTMLLinkElement }> {
-  let extraCss = await updateStylesheets(css);
+  const extraCss = await updateStylesheets(css);
   await loadMissingScripts(js);
   return extraCss;
 }
@@ -318,7 +317,7 @@ function loadMissingScripts(_scripts: string[]) {
       if (scriptSrcs[scriptUrl]) {
         return lastScript;
       } else {
-        let newScript = doc.createElement("script");
+        const newScript = doc.createElement("script");
         newScript.src = scriptUrl;
         newScript.async = false;
         head.appendChild(newScript);
@@ -369,16 +368,16 @@ function collectParams(
           if (!v.checked || v.disabled) return;
       }
     }
-    let ex = vals[v.name];
+    const ex = vals[v.name];
     if (ex) {
       ex.push(v.value);
     } else vals[v.name] = [v.value];
   });
   form.querySelectorAll("select").forEach((v: HTMLSelectElement) => {
     for (let i = 0; i < v.length; i++) {
-      let o = v[i] as HTMLOptionElement;
+      const o = v[i] as HTMLOptionElement;
       if (o.selected) {
-        let ex = vals[v.name];
+        const ex = vals[v.name];
         if (ex) {
           ex.push(o.value);
         } else vals[v.name] = [o.value];

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContentRenderer.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContentRenderer.tsx
@@ -18,8 +18,8 @@ export function LegacyContentRenderer({
 }: PageContent) {
   const classes = useStyles();
 
-  let { body, crumbs, upperbody } = html;
-  let extraClass = (function() {
+  const { body, crumbs, upperbody } = html;
+  const extraClass = (function() {
     switch (fullscreenMode) {
       case "YES":
       case "YES_WITH_TOOLBAR":
@@ -33,7 +33,7 @@ export function LegacyContentRenderer({
         }
     }
   })();
-  let mainContent = (
+  const mainContent = (
     <div className={`content ${extraClass}`}>
       {crumbs && <JQueryDiv id="breadcrumbs" html={crumbs} />}
       {upperbody && <JQueryDiv html={upperbody} />}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeModule.ts
@@ -61,8 +61,8 @@ export function unMarshallPreLoginNotice(
 }
 
 export function uploadPreLoginNoticeImage(file: any): AxiosPromise {
-  let imageBlob: Blob = file.blob();
-  let name: string = encodeURIComponent(file.filename());
+  const imageBlob: Blob = file.blob();
+  const name: string = encodeURIComponent(file.filename());
   return axios.put(PRE_LOGIN_NOTICE_IMAGE_API_URL + name, imageBlob, {
     headers: { "content-type": imageBlob.type }
   });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -96,7 +96,7 @@ class PreLoginNoticeConfigurator extends React.Component<
   componentDidMount = () => {
     getPreLoginNotice()
       .then((response: AxiosResponse<PreLoginNotice>) => {
-        let preLoginNotice: PreLoginNotice = unMarshallPreLoginNotice(
+        const preLoginNotice: PreLoginNotice = unMarshallPreLoginNotice(
           response.data
         );
         if (preLoginNotice.notice != undefined) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -38,8 +38,8 @@ export function templatePropsForLegacy({
   fullscreenMode,
   menuMode
 }: PageContent): TemplateProps {
-  let soHtml = html["so"];
-  let menuExtra = soHtml ? (
+  const soHtml = html["so"];
+  const menuExtra = soHtml ? (
     <ScreenOptions optionsHtml={soHtml} contentId={contentId} key={contentId} />
   ) : (
     undefined

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -290,7 +290,7 @@ export const Template = React.memo(function Template({
 
   React.useEffect(() => {
     const classList = window.document.getElementsByTagName("html")[0].classList;
-    var remove = "fullscreen-toolbar";
+    let remove = "fullscreen-toolbar";
     switch (fullscreenMode) {
       case "YES":
         classList.add("fullscreen");
@@ -394,7 +394,7 @@ export const Template = React.memo(function Template({
           return item.route ? (
             <Link {...props} to={item.route} />
           ) : (
-            <a {...props} href={item.href!} />
+            <a {...props} href={item.href} />
           );
         }}
         key={ind}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
@@ -161,9 +161,9 @@ class ThemePage extends React.Component<
   };
 
   handleImageChange = (e: HTMLInputElement) => {
-    let reader = new FileReader();
+    const reader = new FileReader();
     if (e.files != null) {
-      let file = e.files[0];
+      const file = e.files[0];
       reader.readAsDataURL(file);
       reader.onloadend = () => {
         this.setState({

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/encodequery.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/encodequery.ts
@@ -15,7 +15,7 @@ export function encodeQuery(params: {
   }
   for (const key in params) {
     if (params.hasOwnProperty(key)) {
-      var paramValue = params[key];
+      const paramValue = params[key];
       if (typeof paramValue != "undefined") {
         if (typeof paramValue == "object") {
           paramValue.forEach(element => addOne(key, element));

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -1,6 +1,6 @@
 import { sprintf } from "sprintf-js";
 
-declare var bundle: any;
+declare let bundle: any;
 
 export interface Sizes {
   zero: string;
@@ -44,7 +44,7 @@ export function prepLangStrings<A>(prefix: string, strings: A): A {
   if (typeof bundle == "undefined") return strings;
   const overrideVal = (prefix: string, val: any) => {
     if (typeof val == "object") {
-      let newOut = {};
+      const newOut = {};
       for (const key in val) {
         if (val.hasOwnProperty(key)) {
           newOut[key] = overrideVal(prefix + "." + key, val[key]);
@@ -52,7 +52,7 @@ export function prepLangStrings<A>(prefix: string, strings: A): A {
       }
       return newOut;
     } else {
-      var overriden = bundle[prefix];
+      const overriden = bundle[prefix];
       if (overriden != undefined) {
         return overriden;
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "cross-env-shell \"./coursier bootstrap com.geirsson:scalafmt-cli_2.12:1.5.1 -f -o node_modules/.bin/scalafmt && ./coursier bootstrap com.google.googlejavaformat:google-java-format:1.7 -f -o node_modules/.bin/google-java-format\"",
     "format:scala": "find . -name \"*.scala\" -o -name \"*.sbt\" | xargs scalafmt",
     "format:java": "find . -name \"*.java\" | xargs google-java-format -r",
-    "format:ts": "eslint \"Source/Plugins/Core/com.equella.core/js/**/*.{js,ts,tsx}\"",
+    "format:ts": "eslint --fix \"Source/Plugins/Core/com.equella.core/js/**/*.{js,ts,tsx}\"",
     "check:scala": "find . -name '*.scala' -o -name '*.sbt' | xargs scalafmt --test",
     "check:java": "find . -name '*.java' | xargs google-java-format -n --set-exit-if-changed",
     "check:ts": "eslint \"Source/Plugins/Core/com.equella.core/js/**/*.{js,ts,tsx}\"",
@@ -50,6 +50,27 @@
     ],
     "env": {
       "jquery": true
-    }
+    },
+    "overrides": [
+      {
+        "files": [
+          "Source/Plugins/Core/com.equella.core/js/tsrc/**/*.{ts,tsx}"
+        ],
+        "parserOptions": {
+          "project": "Source/Plugins/Core/com.equella.core/js/tsconfig.json"
+        },
+        "rules": {
+          "no-var": "error",
+          "prefer-const": "error",
+          "@typescript-eslint/consistent-type-definitions": [
+            "error",
+            "interface"
+          ],
+          "@typescript-eslint/no-inferrable-types": "error",
+          "@typescript-eslint/no-unnecessary-type-assertion": "error",
+          "@typescript-eslint/prefer-optional-chain": "error"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

builds on #1557 
Sets a preference for using `let` and `const` over `var` in ts files.
Sets a preference for using `interface` over `type` for defining object structures.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
