### PR TITLE
build: switch typescript into strict mode

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsconfig.json
+++ b/Source/Plugins/Core/com.equella.core/js/tsconfig.json
@@ -12,11 +12,8 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "noErrorTruncation": true,
+    "strict": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "baseUrl": ".",
     "paths": {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -32,6 +32,10 @@ export function formatSize(size: number, strings: Sizes): string {
   return sprintf(format, size);
 }
 
+interface LanguageStrings {
+  [key: string]: string | LanguageStrings;
+}
+
 /**
  * Add prefix to language strings
  *
@@ -40,23 +44,26 @@ export function formatSize(size: number, strings: Sizes): string {
  *
  * TODO: replace with https://github.com/formatjs/react-intl
  */
-export function prepLangStrings<A>(prefix: string, strings: A): A {
+export function prepLangStrings(
+  prefix: string,
+  strings: LanguageStrings | string
+): LanguageStrings | string {
   if (typeof bundle == "undefined") return strings;
-  const overrideVal = (prefix: string, val: any) => {
-    if (typeof val == "object") {
-      let newOut = {};
+  const overrideVal = (prefix: string, val: LanguageStrings | string) => {
+    if (typeof val == "string") {
+      var overriden = bundle[prefix];
+      if (overriden != undefined) {
+        return overriden;
+      }
+      return val;
+    } else {
+      let newOut: LanguageStrings = {};
       for (const key in val) {
         if (val.hasOwnProperty(key)) {
           newOut[key] = overrideVal(prefix + "." + key, val[key]);
         }
       }
       return newOut;
-    } else {
-      var overriden = bundle[prefix];
-      if (overriden != undefined) {
-        return overriden;
-      }
-      return val;
     }
   };
   return overrideVal(prefix, strings);
@@ -68,7 +75,7 @@ export function initStrings() {
   }
 }
 
-export const languageStrings = {
+export const languageStrings: LanguageStrings = {
   cp: {
     title: "Cloud providers",
     cloudprovideravailable: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

Enabling --strict enables --noImplicitAny, --noImplicitThis, --alwaysStrict, --strictBindCallApply, --strictNullChecks, --strictFunctionTypes and --strictPropertyInitialization

remove optional included automatically in --strict as well as an unneeded error suppression option.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
