### PR TITLE
Feature/rest api for enabling general filer

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/settings/standard/SearchSettings.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/settings/standard/SearchSettings.java
@@ -74,11 +74,7 @@ public class SearchSettings implements ConfigurationProperties {
   @Property(key = "search.defaultsort")
   private String defaultSearchSort;
 
-  @Property(key = "search.ownerfilter")
-  private boolean ownerFilter = true;
-
-  @Property(key = "search.datemodifiedfilter")
-  private boolean dateModifiedFilter = true;
+  @JsonIgnore private GeneralFilter generalFilter = new GeneralFilter();
 
   // The REST endpoints for this was split into two - one for general search settings,
   // and one for filters - so we don't want this included in the general search
@@ -233,19 +229,33 @@ public class SearchSettings implements ConfigurationProperties {
     this.fileCountDisabled = fileCountDisabled;
   }
 
-  public boolean isOwnerFilter() {
-    return ownerFilter;
+  public GeneralFilter getGeneralFilter() {
+    return generalFilter;
   }
 
-  public void setOwnerFilter(boolean ownerFilter) {
-    this.ownerFilter = ownerFilter;
-  }
+  public static class GeneralFilter implements ConfigurationProperties {
+    private static final long serialVersionUID = 1L;
 
-  public boolean isDateModifiedFilter() {
-    return dateModifiedFilter;
-  }
+    @Property(key = "search.ownerfilter")
+    private boolean ownerFilter = true;
 
-  public void setDateModifiedFilter(boolean dateModifiedFilter) {
-    this.dateModifiedFilter = dateModifiedFilter;
+    @Property(key = "search.datemodifiedfilter")
+    private boolean dateModifiedFilter = true;
+
+    public boolean isOwnerFilter() {
+      return ownerFilter;
+    }
+
+    public void setOwnerFilter(boolean ownerFilter) {
+      this.ownerFilter = ownerFilter;
+    }
+
+    public boolean isDateModifiedFilter() {
+      return dateModifiedFilter;
+    }
+
+    public void setDateModifiedFilter(boolean dateModifiedFilter) {
+      this.dateModifiedFilter = dateModifiedFilter;
+    }
   }
 }

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/settings/standard/SearchSettings.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/settings/standard/SearchSettings.java
@@ -74,6 +74,12 @@ public class SearchSettings implements ConfigurationProperties {
   @Property(key = "search.defaultsort")
   private String defaultSearchSort;
 
+  @Property(key = "search.ownerfilter")
+  private boolean ownerFilter = true;
+
+  @Property(key = "search.datemodifiedfilter")
+  private boolean dateModifiedFilter = true;
+
   // The REST endpoints for this was split into two - one for general search settings,
   // and one for filters - so we don't want this included in the general search
   // settings.
@@ -225,5 +231,21 @@ public class SearchSettings implements ConfigurationProperties {
 
   public void setFileCountDisabled(boolean fileCountDisabled) {
     this.fileCountDisabled = fileCountDisabled;
+  }
+
+  public boolean isOwnerFilter() {
+    return ownerFilter;
+  }
+
+  public void setOwnerFilter(boolean ownerFilter) {
+    this.ownerFilter = ownerFilter;
+  }
+
+  public boolean isDateModifiedFilter() {
+    return dateModifiedFilter;
+  }
+
+  public void setDateModifiedFilter(boolean dateModifiedFilter) {
+    this.dateModifiedFilter = dateModifiedFilter;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/SearchFilterResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/SearchFilterResource.scala
@@ -23,7 +23,7 @@ import com.dytech.edge.common.Constants
 import com.tle.beans.mime.MimeEntry
 import com.tle.common.Check
 import com.tle.common.settings.standard.SearchSettings
-import com.tle.common.settings.standard.SearchSettings.SearchFilter
+import com.tle.common.settings.standard.SearchSettings.{GeneralFilter, SearchFilter}
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.ApiErrorResponse
 import com.tle.web.api.settings.SettingsApiHelper.{loadSettings, updateSettings}
@@ -34,8 +34,6 @@ import javax.ws.rs.{DELETE, GET, POST, PUT, Path, PathParam, Produces, QueryPara
 import org.jboss.resteasy.annotations.cache.NoCache
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
-case class GeneralFilter(ownerFilterEnabled: Boolean, dateModifiedFilterEnabled: Boolean)
 
 @NoCache
 @Path("settings/")
@@ -168,7 +166,7 @@ class SearchFilterResource {
     val searchSettings = loadSettings(new SearchSettings)
     Response
       .ok()
-      .entity(GeneralFilter(searchSettings.isOwnerFilter, searchSettings.isDateModifiedFilter))
+      .entity(searchSettings.getGeneralFilter)
       .build()
   }
 
@@ -176,18 +174,20 @@ class SearchFilterResource {
   @Path("search/general-filter")
   @ApiOperation(
     value = "Update status of general filters",
-    notes = "This endpoint is used to update the status of Owner filter and Date-modified filer."
+    notes = "This endpoint is used to update the status of Owner filter and Date-modified filer.",
+    response = classOf[GeneralFilter]
   )
-  def updateOwnerFilter(
+  def updateGeneralFilter(
       @ApiParam(required = true) @QueryParam("enableOwnerFilter") enableOwnerFilter: Boolean,
       @ApiParam(required = true) @QueryParam("enableDateModifiedFilter") enableDateModifiedFilter: Boolean)
     : Response = {
     searchPrivProvider.checkAuthorised()
     val searchSettings = loadSettings(new SearchSettings)
-    searchSettings.setOwnerFilter(enableOwnerFilter)
-    searchSettings.setDateModifiedFilter(enableDateModifiedFilter)
+    val generalFilter  = searchSettings.getGeneralFilter
+    generalFilter.setOwnerFilter(enableOwnerFilter)
+    generalFilter.setDateModifiedFilter(enableDateModifiedFilter)
     updateSettings(searchSettings)
-    Response.noContent().build()
+    Response.ok().entity(generalFilter).build()
   }
 
   private def getFilterById(filterId: UUID,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/SearchFilterResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/SearchFilterResource.scala
@@ -46,12 +46,12 @@ class SearchFilterResource {
   @GET
   @Path("search/filter")
   @ApiOperation(
-    value = "List search filters",
-    notes = "This endpoint is used to retrieve all search filters.",
+    value = "List MIME type filters",
+    notes = "This endpoint is used to retrieve all MIME type filters.",
     response = classOf[SearchFilter],
     responseContainer = "List"
   )
-  def listSearchFilters: Response = {
+  def listMimeTypeFilters: Response = {
     searchPrivProvider.checkAuthorised()
     val filters = loadSettings(new SearchSettings).getFilters
     Response.ok().entity(filters).build()
@@ -60,11 +60,12 @@ class SearchFilterResource {
   @GET
   @Path("search/filter/{uuid}")
   @ApiOperation(
-    value = "Retrieve a search filter",
-    notes = "This endpoint is used to retrieve one search filter.",
+    value = "Retrieve a MIME type filter",
+    notes = "This endpoint is used to retrieve one MIME type filter.",
     response = classOf[SearchFilter]
   )
-  def getSearchFilter(@ApiParam(value = "filter UUID") @PathParam("uuid") uuid: UUID): Response = {
+  def getMimeTypeFilter(
+      @ApiParam(value = "filter UUID") @PathParam("uuid") uuid: UUID): Response = {
     searchPrivProvider.checkAuthorised()
     val searchSettings = loadSettings(new SearchSettings)
 
@@ -77,12 +78,12 @@ class SearchFilterResource {
   @POST
   @Path("search/filter")
   @ApiOperation(
-    value = "Add a search filter",
+    value = "Add a MIME type filter",
     notes =
-      "This endpoint is used to add a search filter. A JSON object representing the new filter is returned if operation is successful.",
+      "This endpoint is used to add a MIME type filter. A JSON object representing the new filter is returned if operation is successful.",
     response = classOf[SearchFilter]
   )
-  def addSearchFilter(
+  def addMimeTypeFilter(
       @ApiParam(value = "filter name", required = true) @QueryParam("name") name: String,
       @ApiParam(value = "filter types", required = true) @QueryParam("mimeTypes") mimeTypes: java.util.List[
         String]): Response = {
@@ -106,12 +107,12 @@ class SearchFilterResource {
   @PUT
   @Path("search/filter/{uuid}")
   @ApiOperation(
-    value = "Update a search filter",
+    value = "Update a MIME type filter",
     notes =
-      "This endpoint is used to update a search filter. A JSON object representing the updated filter is returned if operation is successful.",
+      "This endpoint is used to update a MIME type filter. A JSON object representing the updated filter is returned if operation is successful.",
     response = classOf[SearchFilter]
   )
-  def updateSearchFilter(
+  def updateMimeTypeFilter(
       @ApiParam(value = "filter UUID") @PathParam("uuid") uuid: UUID,
       @ApiParam(value = "filter name", required = true) @QueryParam("name") name: String,
       @ApiParam(value = "filter types", required = true) @QueryParam("mimeTypes") mimeTypes: java.util.List[
@@ -136,10 +137,10 @@ class SearchFilterResource {
   @DELETE
   @Path("search/filter/{uuid}")
   @ApiOperation(
-    value = "Delete a search filter",
-    notes = "This endpoint is used to delete a search filter.",
+    value = "Delete a MIME type filter",
+    notes = "This endpoint is used to delete a MIME type filter.",
   )
-  def deleteSearchFilters(
+  def deleteMimeTypeFilter(
       @ApiParam(value = "filter UUID") @PathParam("uuid") uuid: UUID): Response = {
     searchPrivProvider.checkAuthorised()
     val searchSettings = loadSettings(new SearchSettings)


### PR DESCRIPTION
#1337 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

* Created a new class called `GeneralFilter` to represent both Owner filter and Date-modified filer, as an inner class of `SearchSetting`. 
* Created a GET and PUT REST APIs to support enabling and disabling the two filters.
* Tests for the new REST APIs.
* Properly rename some Scala methods related to the MIME type filters.

PUT: the response is the updated GeneralFilter
![Screenshot from 2020-03-23 16-39-33](https://user-images.githubusercontent.com/47203811/77286433-537bdd00-6d27-11ea-9b3b-f3c9a0fb2586.png)

GET: the response is a GeneralFilter
![Screenshot from 2020-03-23 16-39-52](https://user-images.githubusercontent.com/47203811/77286441-570f6400-6d27-11ea-9ab0-9eb4a21b2998.png)

Here is how these two settings are stored in database
![image](https://user-images.githubusercontent.com/47203811/77286647-ce44f800-6d27-11ea-8372-34b0a613ce07.png)
