### PR TITLE
Codebuild: Use .nvmrc to control Node versions

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - env | sort | grep -vi -e key -e secret -e password
       - setupBuild
-      - nvm install # version from nvmrc
+      - . $NVM_DIR/nvm.sh && nvm install # version from nvmrc
       - npm config set unsafe-perm true
   install:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,8 +10,8 @@ phases:
     commands:
       - env | sort | grep -vi -e key -e secret -e password
       - setupBuild
+      - nvm install # version from nvmrc
       - npm config set unsafe-perm true
-      - npm install -g npm@5.6.0
   install:
     commands:
       - service postgresql start


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included - NA
- [ ] screenshots are included showing significant UI changes - NA
- [ ] documentation is changed or added - NA

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
This was recently added to the Travis/OSS build (#1539), so we need it to match in the Edalex Codebuild.

Need to wait and see now if Codebuild agrees with the change. I did spin up the Codebuild docker image locally and try the commands first, so :crossed_fingers: .


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
