### PR TITLE
docs(contributing): add links to tools used to setup pre-commit hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,8 @@ Each formatter has various IDE plugins, in particular IntelliJ is well supported
 
 #### Pre-commit hook
 
-openEQUELLA provides a script to set up git pre-commit hooks to format the code
-you have modified before commiting. To set it up you must run the installer once
-(from the root dir):
+openEQUELLA provides [a script to set up git pre-commit hooks](https://github.com/typicode/husky) to [format the code](#code-formatters) you have [modified before committing](https://github.com/okonet/lint-staged).
+To set it up you must run the installer once (from the root dir):
 
 ```bash
 npm install


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] documentation is changed or added

##### Description of change

adds links to documentation for tooling used for creating pre-commit hooks and linting staged files.

related to https://github.com/openequella/openEQUELLA/pull/1556#issuecomment-602939419

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
