### PR TITLE
Add the configuration of Owner filter and Date modified filter

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/settings/standard/SearchSettings.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/settings/standard/SearchSettings.java
@@ -56,6 +56,12 @@ public class SearchSettings implements ConfigurationProperties {
   @Property(key = "search.disableVideos")
   private boolean searchingDisableVideos;
 
+  @Property(key = "search.disableOwnerFilter")
+  private boolean searchingDisableOwnerFilter;
+
+  @Property(key = "search.disableDateModifiedFilter")
+  private boolean searchingDisableDateModifiedFilter;
+
   @Property(key = "gallery.filecount.disabled")
   private boolean fileCountDisabled;
 
@@ -225,5 +231,21 @@ public class SearchSettings implements ConfigurationProperties {
 
   public void setFileCountDisabled(boolean fileCountDisabled) {
     this.fileCountDisabled = fileCountDisabled;
+  }
+
+  public boolean isSearchingDisableOwnerFilter() {
+    return searchingDisableOwnerFilter;
+  }
+
+  public void setSearchingDisableOwnerFilter(boolean searchingDisableOwnerFilter) {
+    this.searchingDisableOwnerFilter = searchingDisableOwnerFilter;
+  }
+
+  public boolean isSearchingDisableDateModifiedFilter() {
+    return searchingDisableDateModifiedFilter;
+  }
+
+  public void setSearchingDisableDateModifiedFilter(boolean searchingDisableDateModifiedFilter) {
+    this.searchingDisableDateModifiedFilter = searchingDisableDateModifiedFilter;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/SearchSettingsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/SearchSettingsModule.ts
@@ -6,6 +6,8 @@ export interface SearchSettings {
   searchingShowNonLiveCheckbox: boolean;
   searchingDisableGallery: boolean;
   searchingDisableVideos: boolean;
+  searchingDisableOwnerFilter: boolean;
+  searchingDisableDateModifiedFilter: boolean;
   fileCountDisabled: boolean;
   defaultSearchSort: SortOrder;
   authenticateFeedsByDefault: boolean;
@@ -80,6 +82,8 @@ export const defaultSearchSettings: SearchSettings = {
   searchingShowNonLiveCheckbox: false,
   searchingDisableGallery: false,
   searchingDisableVideos: false,
+  searchingDisableOwnerFilter: false,
+  searchingDisableDateModifiedFilter: false,
   fileCountDisabled: false,
   defaultSearchSort: SortOrder.RANK,
   authenticateFeedsByDefault: false,

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/SearchSettingApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/SearchSettingApiTest.java
@@ -24,6 +24,8 @@ public class SearchSettingApiTest extends AbstractRestApiTest {
   private static final String SHOW_NON_LIVE = "searchingShowNonLiveCheckbox";
   private static final String AUTHENTICATE_FEEDS = "authenticateFeedsByDefault";
 
+  private static final String DISABLE_OWNER_FILTER = "searchingDisableOwnerFilter";
+  private static final String DISABLE_DATE_MODIFIED_FILTER = "searchingDisableDateModifiedFilter";
   private static final String DISABLE_IMAGE = "searchingDisableGallery";
   private static final String DISABLE_VIDEO = "searchingDisableVideos";
   private static final String DISABLE_FILE_COUNT = "fileCountDisabled";
@@ -72,6 +74,8 @@ public class SearchSettingApiTest extends AbstractRestApiTest {
     assertFalse(initialSearchSettings.get(DISABLE_IMAGE).asBoolean());
     assertFalse(initialSearchSettings.get(DISABLE_VIDEO).asBoolean());
     assertFalse(initialSearchSettings.get(DISABLE_FILE_COUNT).asBoolean());
+    assertFalse(initialSearchSettings.get(DISABLE_OWNER_FILTER).asBoolean());
+    assertFalse(initialSearchSettings.get(DISABLE_DATE_MODIFIED_FILTER).asBoolean());
 
     assertEquals(initialSearchSettings.get(TITLE_BOOST).asInt(), 5);
     assertEquals(initialSearchSettings.get(DESCRIPTION_BOOST).asInt(), 3);
@@ -89,6 +93,8 @@ public class SearchSettingApiTest extends AbstractRestApiTest {
     newSearchSettings.put(DISABLE_IMAGE, true);
     newSearchSettings.put(DISABLE_VIDEO, true);
     newSearchSettings.put(DISABLE_FILE_COUNT, true);
+    newSearchSettings.put(DISABLE_OWNER_FILTER, true);
+    newSearchSettings.put(DISABLE_DATE_MODIFIED_FILTER, true);
 
     newSearchSettings.put(TITLE_BOOST, 4);
     newSearchSettings.put(DESCRIPTION_BOOST, 4);
@@ -109,6 +115,8 @@ public class SearchSettingApiTest extends AbstractRestApiTest {
     assertTrue(updatedSearchSettings.get(DISABLE_IMAGE).asBoolean());
     assertTrue(updatedSearchSettings.get(DISABLE_VIDEO).asBoolean());
     assertTrue(updatedSearchSettings.get(DISABLE_FILE_COUNT).asBoolean());
+    assertTrue(updatedSearchSettings.get(DISABLE_OWNER_FILTER).asBoolean());
+    assertTrue(updatedSearchSettings.get(DISABLE_DATE_MODIFIED_FILTER).asBoolean());
 
     assertEquals(updatedSearchSettings.get(TITLE_BOOST).asInt(), 4);
     assertEquals(updatedSearchSettings.get(DESCRIPTION_BOOST).asInt(), 4);


### PR DESCRIPTION
#1337 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

As discussed, add two boolean flags to 'SearchSettings' for the configuration of Owner filter and Date-modified filter.
Also update the tsx 'SearchSettings' interface.

![Screenshot from 2020-03-24 17-02-55](https://user-images.githubusercontent.com/47203811/77394052-88a13180-6df2-11ea-90b8-671903759be9.png)


