### PR TITLE
Follow ups to GhostCat - AJP connector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/tomcat/guice/TomcatModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/tomcat/guice/TomcatModule.java
@@ -28,6 +28,11 @@ public class TomcatModule extends MandatoryConfigModule {
     bindInt("http.port", -1);
     bindInt("https.port", -1);
     bindInt("ajp.port", -1);
+    bindProp("ajp.address", "127.0.0.1");
+    // Makes sense for this to be in mandatory-config, but we have to provide a default, non-null
+    // value
+    bindProp("ajp.secret", "ignore");
+    bindBoolean("ajp.secret.required", true);
     bindInt("tomcat.max.threads", -2);
     install(new TomcatOptionalModule());
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/tomcat/service/impl/TomcatServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/tomcat/service/impl/TomcatServiceImpl.java
@@ -84,6 +84,18 @@ public class TomcatServiceImpl implements TomcatService, StartupBean, TomcatRest
   private int ajpPort;
 
   @Inject
+  @Named("ajp.address")
+  private String ajpAddress;
+
+  @Inject
+  @Named("ajp.secret")
+  private String ajpSecret;
+
+  @Inject
+  @Named("ajp.secret.required")
+  private boolean ajpSecretRequired;
+
+  @Inject
   @Named("tomcat.max.threads")
   private int maxThreads;
 
@@ -182,9 +194,13 @@ public class TomcatServiceImpl implements TomcatService, StartupBean, TomcatRest
       if (ajpPort != -1) {
         Connector connector = new Connector(useBio ? BIO_AJP : "AJP/1.3");
         connector.setPort(ajpPort);
-        connector.setAttribute("requiredSecret", false);
+        if (!ajpSecret.equals("ignore")) {
+          connector.setAttribute("secret", ajpSecret);
+        }
+        connector.setAttribute("secretRequired", ajpSecretRequired);
         connector.setAttribute("tomcatAuthentication", false);
         connector.setAttribute("packetSize", "65536");
+        connector.setAttribute("address", ajpAddress);
         setConnector(connector);
       }
 

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ name := "Equella"
 equellaMajor in ThisBuild := 2020
 equellaMinor in ThisBuild := 2
 equellaPatch in ThisBuild := 0
-equellaStream in ThisBuild := "AlphaC"
+equellaStream in ThisBuild := "Alpha"
 equellaBuild in ThisBuild := buildConfig.value.getString("build.buildname")
 
 version := {

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ name := "Equella"
 equellaMajor in ThisBuild := 2020
 equellaMinor in ThisBuild := 2
 equellaPatch in ThisBuild := 0
-equellaStream in ThisBuild := "Alpha"
+equellaStream in ThisBuild := "AlphaC"
 equellaBuild in ThisBuild := buildConfig.value.getString("build.buildname")
 
 version := {


### PR DESCRIPTION
#1533 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
2020.1.0 included tomcat 8.5.51 , and subsequently broke the AJP connector.

This PR fixes the AJP connector with the following:
`mandatory-config.properties` :
`ajp.secret.required` - it should be set to `false` for now.  Default is `true` since it's more secure
`ajp.address` - Default is `127.0.0.1`

Another configuration, `ajp.secret` , was added in, but should be considered a beta feature. The default value `ignore` of `ajp.secret` will do just that.

I am waiting to test `ajp.secret` until httpd 2.4.42+ is released into the repos - currently looks like it doesn't have full approval of the community.  It would be appreciated if folks in the community can confirm `ajp.secret` works with a different web server, and then `ajp.secret` can move out of beta.

Support for ajp secret in httpd 2.4.42 :  https://www.apachelounge.com/viewtopic.php?t=8448
Issues with 2.4.42 / 2.4.43 : https://www.apachelounge.com/viewtopic.php?t=8441

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
