### PR TITLE
Bugfix/control samesite for cookies

### DIFF
--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -4786,6 +4786,11 @@
     <parameter id="url-pattern" value="/*" />
     <parameter id="order" value="800" />
   </extension>
+  <extension plugin-id="com.tle.web.core" point-id="webFilter" id="sameSiteFilter">
+    <parameter id="bean" value="bean:com.tle.web.core.filter.SameSiteFilter" />
+    <parameter id="url-pattern" value="/*" />
+    <parameter id="order" value="850" />
+  </extension>
   <extension plugin-id="com.tle.web.core" point-id="webServlet" id="doNotServeServlet">
     <parameter id="bean" value="bean:com.tle.web.core.servlet.DoNotServeServlet" />
     <parameter id="url-pattern" value="/WEB-INF/*" />

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
@@ -41,18 +41,15 @@ public class SameSiteFilter extends AbstractWebFilter {
       Collection<String> headers = response.getHeaders(HttpHeaders.SET_COOKIE);
       boolean firstHeader = true;
       for (String header : headers) {
-        LOGGER.info("Add SameSite=none to cookie: " + header);
         if (firstHeader) {
           response.setHeader(
-              HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=none"));
+              HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=None"));
           firstHeader = false;
           continue;
         }
         response.addHeader(
-            HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=none"));
+            HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=None"));
       }
-    } else {
-      LOGGER.debug("Not secure so not adding SameSite attribute.");
     }
     return FilterResult.FILTER_CONTINUE;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.core.filter;
+
+import com.tle.core.guice.Bind;
+import com.tle.web.dispatcher.AbstractWebFilter;
+import com.tle.web.dispatcher.FilterResult;
+import java.io.IOException;
+import java.util.Collection;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.log4j.Logger;
+
+@Bind
+public class SameSiteFilter extends AbstractWebFilter {
+
+  private static final Logger LOGGER = Logger.getLogger(SameSiteFilter.class);
+
+  @Override
+  public FilterResult filterRequest(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    if (request.isSecure()) {
+      Collection<String> headers = response.getHeaders(HttpHeaders.SET_COOKIE);
+      boolean firstHeader = true;
+      for (String header : headers) {
+        LOGGER.info("Add SameSite=none to cookie: " + header);
+        if (firstHeader) {
+          response.setHeader(
+              HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=none"));
+          firstHeader = false;
+          continue;
+        }
+        response.addHeader(
+            HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=none"));
+      }
+    } else {
+      LOGGER.debug("Not secure so not adding SameSite attribute.");
+    }
+    return FilterResult.FILTER_CONTINUE;
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
@@ -27,12 +27,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
-import org.apache.log4j.Logger;
 
 @Bind
 public class SameSiteFilter extends AbstractWebFilter {
-
-  private static final Logger LOGGER = Logger.getLogger(SameSiteFilter.class);
 
   @Override
   public FilterResult filterRequest(HttpServletRequest request, HttpServletResponse response)


### PR DESCRIPTION
#1458 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] screenshots are included showing significant UI changes

##### Description of change

Create a new filter to add the SameSite attribute and `secure` flag to JSESSIONID cookie.

![image](https://user-images.githubusercontent.com/47203811/77723680-3f94eb80-7045-11ea-8ed4-bfb614df550b.png)



