### PR TITLE
Add search filter category

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -3651,7 +3651,7 @@ sessiontitle.tle_scrapbookpicker=Embed a resource attachment
 setting.searchpage.title=Search page
 setting.searchpage.desc=Configure options for the search page
 setting.searchfilter.title=Search filters
-setting.searchfilter.desc=configuration of MIME type searches
+setting.searchfilter.desc=Configure filter visibility and add filters based on resource MIME types
 setting.description=Manage Dashboard portlets
 setting.title=Dashboard
 settings.apikey.help=Enter your Google account API Key above. API Keys can be obtained from the <a href\="https\://console.developers.google.com/project">developer console</a> of your Google Account. For more detailed instructions please see the openEQUELLA documentation.

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -3650,6 +3650,8 @@ sessiontitle.tle_reslinker=Link to a resource
 sessiontitle.tle_scrapbookpicker=Embed a resource attachment
 setting.searchpage.title=Search page
 setting.searchpage.desc=Configure options for the search page
+setting.searchfilter.title=Search filters
+setting.searchfilter.desc=configuration of MIME type searches
 setting.description=Manage Dashboard portlets
 setting.title=Dashboard
 settings.apikey.help=Enter your Google account API Key above. API Keys can be obtained from the <a href\="https\://console.developers.google.com/project">developer console</a> of your Google Account. For more detailed instructions please see the openEQUELLA documentation.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
@@ -173,6 +173,13 @@ object SettingsList {
                                             "page/searchsettings",
                                             searchPrivProvider.isAuthorised)
 
+  val searchFilterSettings = CoreSettingsPage("searchpage",
+                                              Searching,
+                                              "setting.searchfilter.title",
+                                              "setting.searchfilter.desc",
+                                              "page/searchfiltersettings",
+                                              searchPrivProvider.isAuthorised)
+
   val htmlEditorSettings = CoreSettingsPage("htmleditor",
                                             General,
                                             "htmledit.settings.title",
@@ -204,6 +211,7 @@ object SettingsList {
     uiSettings,
     loginNoticeSettings,
     searchPageSettings,
+    searchFilterSettings,
     cloudProviderSettings,
     CoreSettingsPage("shortcuts",
                      General,


### PR DESCRIPTION
#1337 

##### Checklist

- [x] the [contributor license agreement] is signed
- [x] commit message follows [commit guidelines]
- [x] screenshots are included showing significant UI changes

##### Description of change

Create a new sub-category called Search filters under the new ‘Search’ category.
The Setting filter page will be developed in a different PR.
Also, I wonder if we need to change the description of this category (provided by Cath) because not only the MIME type filter but also the Owner filter and Date-modified filter will be included in the page.

![Screenshot from 2020-03-30 11-00-52](https://user-images.githubusercontent.com/47203811/77864760-3c347680-7276-11ea-821d-fd78bf4ac65d.png)

