### PR TITLE
types: check typescript types during check process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,9 @@ jobs:
     - stage: build and check
       script:
         - cd Source/Plugins/Core/com.equella.core/js
-        - npm ci
+        - npm install-ci
         - cd ../../../../..
-        - npm ci
+        - npm install-ci
         - npm run check
         - sbt headerCheck checkJavaCodeStyle
       name: Check headers, code style and static analysis
@@ -109,7 +109,10 @@ jobs:
       script: sbt test
       name: Unit test
     - stage: build and check
-      script: cd Source/Plugins/Core/com.equella.core/js && npm install && npm test; cd -
+      script:
+        - cd Source/Plugins/Core/com.equella.core/js
+        - npm install-ci-test
+        - cd ../../../../..
       name: Jest test
     - stage: build and check
       script: ci/import-export-tool-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,11 @@ jobs:
   include:
     - stage: build and check
       script:
-        - npm install && npm run check
+        - cd Source/Plugins/Core/com.equella.core/js
+        - npm ci
+        - cd ../../../../..
+        - npm ci
+        - npm run check
         - sbt headerCheck checkJavaCodeStyle
       name: Check headers, code style and static analysis
       after_failure: ci/s3cp.sh target/checkstyle-report.html $S3_DEST_BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
       script:
         - cd Source/Plugins/Core/com.equella.core/js
         - npm install-ci
-        - cd ../../../../..
+        - cd -
         - npm install-ci
         - npm run check
         - sbt headerCheck checkJavaCodeStyle
@@ -112,7 +112,7 @@ jobs:
       script:
         - cd Source/Plugins/Core/com.equella.core/js
         - npm install-ci-test
-        - cd ../../../../..
+        - cd -
       name: Jest test
     - stage: build and check
       script: ci/import-export-tool-build.sh

--- a/Source/Plugins/Core/com.equella.core/js/tsconfig.json
+++ b/Source/Plugins/Core/com.equella.core/js/tsconfig.json
@@ -8,6 +8,7 @@
     "inlineSources": true,
     "allowJs": true,
     "checkJs": true,
+    "skipLibCheck": true,
     "jsx": "react",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/cloudcontrol/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/cloudcontrol/index.ts
@@ -57,7 +57,7 @@ interface CommandsPromise {
 }
 
 interface Registration {
-  mount: (api: ControlApi<object>) => void;
+  mount: (api: ControlApi<any>) => void;
   unmount: (removed: Element) => void;
 }
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/entity/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/entity/index.ts
@@ -79,7 +79,7 @@ export interface EntityState<E extends Entity> extends PartialEntityState<E> {
 }
 
 function baseValidate<E extends Entity>(entity: E): IDictionary<string> {
-  const validationErrors: any = {};
+  const validationErrors: IDictionary<string> = {};
   if (!entity.name) {
     validationErrors["name"] = "Name is required";
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/entity/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/entity/index.ts
@@ -79,7 +79,7 @@ export interface EntityState<E extends Entity> extends PartialEntityState<E> {
 }
 
 function baseValidate<E extends Entity>(entity: E): IDictionary<string> {
-  const validationErrors = {};
+  const validationErrors: any = {};
   if (!entity.name) {
     validationErrors["name"] = "Name is required";
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -260,12 +260,16 @@ function updateStylesheets(
   const doc = window.document;
   const insertPoint = doc.getElementById("_dynamicInsert")!;
   const head = doc.getElementsByTagName("head")[0];
-  let current = insertPoint.previousElementSibling as HTMLLinkElement;
+  let current = insertPoint.previousElementSibling;
   const existingSheets: { [index: string]: HTMLLinkElement } = {};
 
-  while (current != null && current.tagName == "LINK") {
+  while (
+    current != null &&
+    current.tagName == "LINK" &&
+    current instanceof HTMLLinkElement
+  ) {
     existingSheets[current.href] = current;
-    current = current.previousElementSibling as HTMLLinkElement;
+    current = current.previousElementSibling;
   }
   const cssPromises = sheets.reduce((lastLink, cssUrl) => {
     if (existingSheets[cssUrl]) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -176,7 +176,7 @@ export const LegacyContent = React.memo(function LegacyContent({
   }
 
   React.useEffect(() => {
-    window["EQ"] = {
+    (window as { [key: string]: any })["EQ"] = {
       event: stdSubmit(true),
       eventnv: stdSubmit(false),
       postAjax(
@@ -220,7 +220,7 @@ export const LegacyContent = React.memo(function LegacyContent({
   React.useEffect(() => {
     if (enabled) {
       const params = new URLSearchParams(search);
-      const urlValues = {};
+      const urlValues: { [index: string]: string[] } = {};
       params.forEach((val, key) => {
         const exVal = urlValues[key];
         if (exVal) exVal.push(val);
@@ -259,12 +259,12 @@ function updateStylesheets(
   const doc = window.document;
   const insertPoint = doc.getElementById("_dynamicInsert")!;
   const head = doc.getElementsByTagName("head")[0];
-  let current = insertPoint.previousElementSibling;
-  const existingSheets = {};
+  let current = insertPoint.previousElementSibling as HTMLLinkElement;
+  const existingSheets: { [index: string]: HTMLLinkElement } = {};
 
   while (current != null && current.tagName == "LINK") {
-    existingSheets[(current as HTMLLinkElement).href] = current;
-    current = current.previousElementSibling;
+    existingSheets[current.href] = current;
+    current = current.previousElementSibling as HTMLLinkElement;
   }
   const cssPromises = sheets.reduce((lastLink, cssUrl) => {
     if (existingSheets[cssUrl]) {
@@ -306,30 +306,33 @@ function loadMissingScripts(_scripts: string[]) {
     const doc = window.document;
     const head = doc.getElementsByTagName("head")[0];
     const scriptTags = doc.getElementsByTagName("script");
-    const scriptSrcs = {};
+    const scriptSrcs: { [index: string]: boolean } = {};
     for (let i = 0; i < scriptTags.length; i++) {
       const scriptTag = scriptTags[i];
       if (scriptTag.src) {
         scriptSrcs[scriptTag.src] = true;
       }
     }
-    const lastScript = scripts.reduce((lastScript, scriptUrl) => {
-      if (scriptSrcs[scriptUrl]) {
-        return lastScript;
-      } else {
-        const newScript = doc.createElement("script");
-        newScript.src = scriptUrl;
-        newScript.async = false;
-        head.appendChild(newScript);
-        return newScript;
-      }
-    }, null);
+    const lastScript = scripts.reduce<HTMLScriptElement>(
+      (lastScript: HTMLScriptElement, scriptUrl) => {
+        if (scriptSrcs[scriptUrl]) {
+          return lastScript;
+        } else {
+          const newScript = doc.createElement("script");
+          newScript.src = scriptUrl;
+          newScript.async = false;
+          head.appendChild(newScript);
+          return newScript;
+        }
+      },
+      new HTMLScriptElement()
+    );
     if (!lastScript) resolve();
     else {
       lastScript.addEventListener("load", resolve, false);
       lastScript.addEventListener(
         "error",
-        err => {
+        () => {
           console.error(`Failed to load script: ${lastScript.src}`);
           resolve();
         },
@@ -344,7 +347,7 @@ function collectParams(
   command: string | null,
   args: string[]
 ) {
-  const vals = {};
+  const vals: { [index: string]: string[] } = {};
   if (command) {
     vals["event__"] = [command];
   }
@@ -358,21 +361,23 @@ function collectParams(
     }
     vals["eventp__" + i] = [outval];
   });
-  form.querySelectorAll("input,textarea").forEach((v: HTMLInputElement) => {
-    if (v.type) {
-      switch (v.type) {
-        case "button":
-          return;
-        case "checkbox":
-        case "radio":
-          if (!v.checked || v.disabled) return;
+  form
+    .querySelectorAll<HTMLInputElement>("input,textarea")
+    .forEach((v: HTMLInputElement) => {
+      if (v.type) {
+        switch (v.type) {
+          case "button":
+            return;
+          case "checkbox":
+          case "radio":
+            if (!v.checked || v.disabled) return;
+        }
       }
-    }
-    const ex = vals[v.name];
-    if (ex) {
-      ex.push(v.value);
-    } else vals[v.name] = [v.value];
-  });
+      const ex = vals[v.name];
+      if (ex) {
+        ex.push(v.value);
+      } else vals[v.name] = [v.value];
+    });
   form.querySelectorAll("select").forEach((v: HTMLSelectElement) => {
     for (let i = 0; i < v.length; i++) {
       const o = v[i] as HTMLOptionElement;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -8,6 +8,7 @@ declare global {
   interface Window {
     _trigger: any;
     eval: any;
+    EQ: { [index: string]: any };
   }
   const _trigger: any;
 }
@@ -176,7 +177,7 @@ export const LegacyContent = React.memo(function LegacyContent({
   }
 
   React.useEffect(() => {
-    (window as { [key: string]: any })["EQ"] = {
+    window["EQ"] = {
       event: stdSubmit(true),
       eventnv: stdSubmit(false),
       postAjax(
@@ -313,7 +314,7 @@ function loadMissingScripts(_scripts: string[]) {
         scriptSrcs[scriptTag.src] = true;
       }
     }
-    const lastScript = scripts.reduce<HTMLScriptElement>(
+    const lastScript = scripts.reduce(
       (lastScript: HTMLScriptElement, scriptUrl) => {
         if (scriptSrcs[scriptUrl]) {
           return lastScript;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -315,7 +315,7 @@ function loadMissingScripts(_scripts: string[]) {
       }
     }
     const lastScript = scripts.reduce(
-      (lastScript: HTMLScriptElement, scriptUrl) => {
+      (lastScript: HTMLScriptElement | null, scriptUrl) => {
         if (scriptSrcs[scriptUrl]) {
           return lastScript;
         } else {
@@ -326,7 +326,7 @@ function loadMissingScripts(_scripts: string[]) {
           return newScript;
         }
       },
-      new HTMLScriptElement()
+      null
     );
     if (!lastScript) resolve();
     else {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -212,12 +212,16 @@ class PreLoginNoticeConfigurator extends React.Component<
     );
   };
 
-  handleScheduleTypeSelectionChange = (event: ChangeEvent, value: string) => {
+  handleScheduleTypeSelectionChange = (
+    event: ChangeEvent<{}>,
+    value: string
+  ) => {
     this.setState(
       {
         current: {
           ...this.state.current,
-          scheduleSettings: ScheduleTypeSelection[value]
+          scheduleSettings:
+            ScheduleTypeSelection[value as ScheduleTypeSelection]
         }
       },
       () => this.setPreventNav()

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -70,12 +70,14 @@ export function prepLangStrings(
 }
 
 export function initStrings() {
-  for (const key in languageStrings) {
+  for (const key of Object.keys(languageStrings) as Array<
+    keyof typeof languageStrings
+  >) {
     prepLangStrings(key, languageStrings[key]);
   }
 }
 
-export const languageStrings: LanguageStrings = {
+export const languageStrings = {
   cp: {
     title: "Cloud providers",
     cloudprovideravailable: {

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -4786,6 +4786,11 @@
     <parameter id="url-pattern" value="/*" />
     <parameter id="order" value="800" />
   </extension>
+  <extension plugin-id="com.tle.web.core" point-id="webFilter" id="sameSiteFilter">
+    <parameter id="bean" value="bean:com.tle.web.core.filter.SameSiteFilter" />
+    <parameter id="url-pattern" value="/*" />
+    <parameter id="order" value="850" />
+  </extension>
   <extension plugin-id="com.tle.web.core" point-id="webServlet" id="doNotServeServlet">
     <parameter id="bean" value="bean:com.tle.web.core.servlet.DoNotServeServlet" />
     <parameter id="url-pattern" value="/WEB-INF/*" />

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/SameSiteFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.core.filter;
+
+import com.tle.core.guice.Bind;
+import com.tle.web.dispatcher.AbstractWebFilter;
+import com.tle.web.dispatcher.FilterResult;
+import java.io.IOException;
+import java.util.Collection;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+@Bind
+public class SameSiteFilter extends AbstractWebFilter {
+
+  @Override
+  public FilterResult filterRequest(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    if (request.isSecure()) {
+      Collection<String> headers = response.getHeaders(HttpHeaders.SET_COOKIE);
+      boolean firstHeader = true;
+      for (String header : headers) {
+        if (firstHeader) {
+          response.setHeader(
+              HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=None"));
+          firstHeader = false;
+          continue;
+        }
+        response.addHeader(
+            HttpHeaders.SET_COOKIE, String.format("%s; %s", header, "SameSite=None"));
+      }
+    }
+    return FilterResult.FILTER_CONTINUE;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,9 +1012,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:java": "find . -name '*.java' | xargs google-java-format -n --set-exit-if-changed",
     "check:md": "remark -q -f -u remark-validate-links -u remark-lint-no-dead-urls --ignore-pattern NOTICE.md .",
     "check:ts": "eslint \"Source/Plugins/Core/com.equella.core/js/**/*.{js,ts,tsx}\"",
+    "check:ts-types": "tsc --noEmit --project \"Source/Plugins/Core/com.equella.core/js/tsconfig.json\"",
     "check": "run-s check:*",
     "format": "run-s format:*"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-eslint": "10.1.0",
     "cross-env": "5.2.1",
     "eslint": "6.8.0",
-    "eslint-config-prettier": "6.10.0",
+    "eslint-config-prettier": "6.10.1",
     "eslint-config-react-app": "5.2.1",
     "eslint-plugin-flowtype": "4.6.0",
     "eslint-plugin-import": "2.20.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

Parcel does not check types

> Parcel performs no type checking. You can use `tsc --noEmit` to have typescript check your files.

https://parceljs.org/typeScript.html

This sets up type checks as part of a new `check:ts-types` step.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
