### PR TITLE
Add search boosting settings menu option

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme: Theme) => {
     },
     progress: {
       display: "flex",
-      marginTop: theme.spacing.unit * 4,
+      marginTop: theme.spacing(4),
       justifyContent: "center"
     }
   };

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -3654,6 +3654,8 @@ setting.searchfilter.title=Search filters
 setting.searchfilter.desc=Configure filter visibility and add filters based on resource MIME types
 setting.contentindexing.title=Content indexing
 setting.contentindexing.desc=Web page indexing settings
+setting.searchboosting.title=Search terms boosting
+setting.searchboosting.desc=Search term boosting settings
 setting.description=Manage Dashboard portlets
 setting.title=Dashboard
 settings.apikey.help=Enter your Google account API Key above. API Keys can be obtained from the <a href\="https\://console.developers.google.com/project">developer console</a> of your Google Account. For more detailed instructions please see the openEQUELLA documentation.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
@@ -180,6 +180,13 @@ object SettingsList {
                                                  "page/contentindexsettings",
                                                  searchPrivProvider.isAuthorised)
 
+  val searchBoostingSettings = CoreSettingsPage("searchboosting",
+                                                Searching,
+                                                "setting.searchboosting.title",
+                                                "setting.searchboosting.desc",
+                                                "page/searchboostingsettings",
+                                                searchPrivProvider.isAuthorised)
+
   val searchFilterSettings = CoreSettingsPage("searchpage",
                                               Searching,
                                               "setting.searchfilter.title",
@@ -219,6 +226,7 @@ object SettingsList {
     loginNoticeSettings,
     searchPageSettings,
     contentIndexingSettings,
+    searchBoostingSettings,
     searchFilterSettings,
     cloudProviderSettings,
     CoreSettingsPage("shortcuts",

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
@@ -173,12 +173,14 @@ object SettingsList {
                                             "page/searchsettings",
                                             searchPrivProvider.isAuthorised)
 
-  val contentIndexingSettings = CoreSettingsPage("searchpage",
-                                                 Searching,
-                                                 "setting.contentindexing.title",
-                                                 "setting.contentindexing.desc",
-                                                 "page/contentindexsettings",
-                                                 searchPrivProvider.isAuthorised)
+  val contentIndexingSettings = CoreSettingsPage(
+    "contentindexing",
+    Searching,
+    "setting.contentindexing.title",
+    "setting.contentindexing.desc",
+    "page/contentindexsettings",
+    searchPrivProvider.isAuthorised
+  )
 
   val searchBoostingSettings = CoreSettingsPage("searchboosting",
                                                 Searching,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#1337 
This is just adding the settings menu option, the page is still blank.
![image](https://user-images.githubusercontent.com/24543345/78750526-c1750500-79b3-11ea-9f53-51dfb62e9314.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
