### PR TITLE
types: replace any in course select

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/CourseSelect.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/CourseSelect.tsx
@@ -117,8 +117,8 @@ class CourseSelect extends React.Component<
     this.setState({ inputValue: courseToString(selectedItem) });
     this.props.onCourseSelect(selectedItem);
   };
-  handleInputChange = (event: any) => {
-    const inputValue = event.target.value;
+  handleInputChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const inputValue = event.currentTarget.value;
     this.setState({ inputValue });
     this.props.onCourseSelect(null);
   };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

the type is representing a form event on an input element.
This also replaces `event.target` with `event.currentTarget` which in this case is the same.
But `currentTarget` has the advantage that it is known ahead of time, and therefore can be statically typed.
See https://stackoverflow.com/a/10086501


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
