### PR TITLE
Basic auth endpoint for REST

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
@@ -81,8 +81,8 @@ class Auth {
       "This is to logout sessions which were setup with the /api/auth/login endpoint, and will do so based on the JSESSIONID cookie."
   )
   def logout(@Context req: HttpServletRequest): Response = {
+    LegacyGuice.userSessionService.reenableSessionUse()
     val us = LegacyGuice.userService
-    us.logoutURI(CurrentUser.getUserState, null)
     us.logoutToGuest(us.getWebAuthenticationDetails(req), false)
     Response.ok().build()
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
@@ -1,0 +1,78 @@
+package com.tle.web.api.auth
+
+import com.tle.common.i18n.CurrentLocale
+import com.tle.common.usermanagement.user.{CurrentUser, WebAuthenticationDetails}
+import com.tle.exceptions.{
+  AccountExpiredException,
+  AuthenticationException,
+  BadCredentialsException
+}
+import com.tle.legacy.LegacyGuice
+import com.tle.web.resources.{PluginResourceHelper, ResourcesService}
+import io.swagger.annotations.{Api, ApiOperation}
+import javax.servlet.http.HttpServletRequest
+import javax.ws.rs.core.{Context, Response}
+import javax.ws.rs.{POST, PUT, Path, QueryParam}
+
+@Api("Authentication")
+@Path("auth")
+class Auth {
+  val RESOURCE_HELPER: PluginResourceHelper =
+    ResourcesService.getResourceHelper(classOf[Auth])
+
+  /**
+    * Provide simple username / password login as per a legacy oEQ form based authentication but for
+    * use with REST APIs - possible the start of an authenticated Single Page App. This basically
+    * mimics the existing form based login logic.
+    *
+    * @see com.tle.web.login.LogonSection#authenticate(SectionInfo)
+    */
+  @POST
+  @Path("login")
+  @ApiOperation(
+    value = "Login as a normal user.",
+    notes =
+      "Provides a means to establish a simple cookie based (JSESSIONID) session, for easy use of the REST API for user based operations.",
+    response = classOf[String]
+  )
+  def login(@Context req: HttpServletRequest,
+            @QueryParam("username") username: String,
+            @QueryParam("password") password: String): Response = {
+    LegacyGuice.userSessionService.reenableSessionUse()
+
+    val us                                = LegacyGuice.userService
+    val wad                               = us.getWebAuthenticationDetails(req)
+    def lfr(messageKey: String): Response = loginFailedResponse(wad, username, messageKey)
+
+    try {
+      us.login(username, password, wad, true)
+      Response.ok().build()
+    } catch {
+      case _: BadCredentialsException => lfr("logon.invalid")
+      case e: AccountExpiredException => loginFailedResponse(wad, username, e.getMessage)
+      case _: AuthenticationException => lfr("logon.problems")
+    }
+  }
+
+  @PUT
+  @Path("logout")
+  @ApiOperation(
+    value = "Logout the current session.",
+    notes =
+      "This is to logout sessions which were setup with the /api/auth/login endpoint, and will do so based on the JSESSIONID cookie."
+  )
+  def logout(@Context req: HttpServletRequest): Response = {
+    val us = LegacyGuice.userService
+    us.logoutURI(CurrentUser.getUserState, null)
+    us.logoutToGuest(us.getWebAuthenticationDetails(req), false)
+    Response.ok().build()
+  }
+
+  def loginFailedResponse(wad: WebAuthenticationDetails,
+                          username: String,
+                          message: String): Response = {
+    LegacyGuice.auditLogService.logUserFailedAuthentication(username, wad)
+    val msg = CurrentLocale.get(RESOURCE_HELPER.key(message))
+    Response.status(401, msg).entity(msg).build()
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
@@ -58,9 +58,10 @@ class Auth {
             @QueryParam("password") password: String): Response = {
     LegacyGuice.userSessionService.reenableSessionUse()
 
-    val us                                = LegacyGuice.userService
-    val wad                               = us.getWebAuthenticationDetails(req)
-    def lfr(messageKey: String): Response = loginFailedResponse(wad, username, messageKey)
+    val us  = LegacyGuice.userService
+    val wad = us.getWebAuthenticationDetails(req)
+    def lfr(messageKey: String): Response =
+      loginFailedResponse(wad, username, CurrentLocale.get(RESOURCE_HELPER.key(messageKey)))
 
     try {
       us.login(username, password, wad, true)
@@ -90,7 +91,6 @@ class Auth {
                           username: String,
                           message: String): Response = {
     LegacyGuice.auditLogService.logUserFailedAuthentication(username, wad)
-    val msg = CurrentLocale.get(RESOURCE_HELPER.key(message))
-    Response.status(401, msg).entity(msg).build()
+    Response.status(401, message).entity(message).build()
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/auth/Auth.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.auth
 
 import com.tle.common.i18n.CurrentLocale

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -24,6 +24,7 @@ import com.tle.cal.web.service.CALWebServiceImpl;
 import com.tle.common.scripting.service.ScriptingService;
 import com.tle.core.accessibility.AccessibilityModeService;
 import com.tle.core.activation.service.ActivationService;
+import com.tle.core.auditlog.AuditLogService;
 import com.tle.core.encryption.EncryptionService;
 import com.tle.core.events.services.EventService;
 import com.tle.core.freetext.service.FreeTextService;
@@ -146,6 +147,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static UserPreferenceService userPreferenceService;
 
   @Inject public static UserService userService;
+
+  @Inject public static AuditLogService auditLogService;
 
   @Inject public static LanguageService languageService;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
@@ -113,8 +113,8 @@ public class RestEasyServlet extends HttpServletDispatcher implements MapperExte
     PluginBeanLocator coreLocator = pluginService.getBeanLocator("com.equella.core");
     Set<Class<?>> classes = application.getClasses();
 
-	  registry.addSingletonResource(new Auth());
-	  classes.add(Auth.class);
+    registry.addSingletonResource(new Auth());
+    classes.add(Auth.class);
     registry.addSingletonResource(new CloudProviderApi());
     classes.add(CloudProviderApi.class);
     registry.addSingletonResource(new SettingsResource());

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
@@ -37,6 +37,7 @@ import com.tle.core.plugins.PluginTracker;
 import com.tle.core.services.user.UserSessionService;
 import com.tle.web.DebugSettings;
 import com.tle.web.api.LegacyContentApi;
+import com.tle.web.api.auth.Auth;
 import com.tle.web.api.cloudprovider.CloudProviderApi;
 import com.tle.web.api.institution.AclResource;
 import com.tle.web.api.institution.GdprResource;
@@ -112,6 +113,8 @@ public class RestEasyServlet extends HttpServletDispatcher implements MapperExte
     PluginBeanLocator coreLocator = pluginService.getBeanLocator("com.equella.core");
     Set<Class<?>> classes = application.getClasses();
 
+	  registry.addSingletonResource(new Auth());
+	  classes.add(Auth.class);
     registry.addSingletonResource(new CloudProviderApi());
     classes.add(CloudProviderApi.class);
     registry.addSingletonResource(new SettingsResource());

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AuthApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AuthApiTest.java
@@ -19,70 +19,74 @@ import org.testng.annotations.Test;
 @TestInstitution("rest")
 public class AuthApiTest {
 
-	private static final TestConfig TEST_CONFIG = new TestConfig(AuthApiTest.class);
-	private static final String USERNAME = "AutoTest";
-	private static final String PASSWORD = "automated";
-	private static final String API_ENDPOINT = TEST_CONFIG.getInstitutionUrl() + "api/auth";
+  private static final TestConfig TEST_CONFIG = new TestConfig(AuthApiTest.class);
+  private static final String USERNAME = "AutoTest";
+  private static final String PASSWORD = "automated";
+  private static final String API_ENDPOINT = TEST_CONFIG.getInstitutionUrl() + "api/auth";
 
-	private final HttpClient httpClient = new HttpClient();
+  private final HttpClient httpClient = new HttpClient();
 
-	@Test
-	public void successfulLoginTest() throws IOException {
-		final HttpMethod method = buildLoginMethod(USERNAME, PASSWORD);
+  @Test
+  public void successfulLoginTest() throws IOException {
+    final HttpMethod method = buildLoginMethod(USERNAME, PASSWORD);
 
-		final int statusCode = makeClientRequest(method);
-		assertEquals(statusCode, HttpStatus.SC_OK, "Attempt to login failed.");
-		assertTrue(hasAuthenticatedSession(),
-			"After a successful login, the session is still a guest session.");
-	}
+    final int statusCode = makeClientRequest(method);
+    assertEquals(statusCode, HttpStatus.SC_OK, "Attempt to login failed.");
+    assertTrue(
+        hasAuthenticatedSession(),
+        "After a successful login, the session is still a guest session.");
+  }
 
-	@Test(dependsOnMethods = "successfulLoginTest")
-	public void successfulLogoutTest() throws IOException {
-		assertTrue(hasAuthenticatedSession()); // Ensure we're starting the test already logged in
-		final String logoutEndpoint = API_ENDPOINT + "/logout";
-		final HttpMethod method = new PutMethod(logoutEndpoint);
+  @Test(dependsOnMethods = "successfulLoginTest")
+  public void successfulLogoutTest() throws IOException {
+    assertTrue(hasAuthenticatedSession()); // Ensure we're starting the test already logged in
+    final String logoutEndpoint = API_ENDPOINT + "/logout";
+    final HttpMethod method = new PutMethod(logoutEndpoint);
 
-		final int statusCode = makeClientRequest(method);
-		assertEquals(statusCode, HttpStatus.SC_OK,
-			"Attempt to logout failed. (Server said: " + method.getResponseBodyAsString() + ")");
-		assertFalse(hasAuthenticatedSession(), "After logout, still has a non-guest session.");
-	}
+    final int statusCode = makeClientRequest(method);
+    assertEquals(
+        statusCode,
+        HttpStatus.SC_OK,
+        "Attempt to logout failed. (Server said: " + method.getResponseBodyAsString() + ")");
+    assertFalse(hasAuthenticatedSession(), "After logout, still has a non-guest session.");
+  }
 
-	@Test(dependsOnMethods = "successfulLogoutTest")
-	public void invalidCredentialsTest() throws IOException {
-		final HttpMethod method = buildLoginMethod("oof", "foo");
+  @Test(dependsOnMethods = "successfulLogoutTest")
+  public void invalidCredentialsTest() throws IOException {
+    final HttpMethod method = buildLoginMethod("oof", "foo");
 
-		final int statusCode = makeClientRequest(method);
-		assertEquals(statusCode, HttpStatus.SC_UNAUTHORIZED,
-			"Incorrect response for (what should be a) failed authentication.");
-		assertFalse(hasAuthenticatedSession(),
-			"A valid session has been established, even though we authenticated with rubbish credentials.");
-	}
+    final int statusCode = makeClientRequest(method);
+    assertEquals(
+        statusCode,
+        HttpStatus.SC_UNAUTHORIZED,
+        "Incorrect response for (what should be a) failed authentication.");
+    assertFalse(
+        hasAuthenticatedSession(),
+        "A valid session has been established, even though we authenticated with rubbish credentials.");
+  }
 
-	private int makeClientRequest(HttpMethod method) throws IOException {
-		return httpClient.executeMethod(method);
-	}
+  private int makeClientRequest(HttpMethod method) throws IOException {
+    return httpClient.executeMethod(method);
+  }
 
-	private HttpMethod buildLoginMethod(String username, String password) {
-		final String loginEndpoint = API_ENDPOINT + "/login";
-		final NameValuePair[] queryVals = {
-			new NameValuePair("username", username),
-			new NameValuePair("password", password)};
-		final HttpMethod method = new PostMethod(loginEndpoint);
-		method.setQueryString(queryVals);
-		return method;
-	}
+  private HttpMethod buildLoginMethod(String username, String password) {
+    final String loginEndpoint = API_ENDPOINT + "/login";
+    final NameValuePair[] queryVals = {
+      new NameValuePair("username", username), new NameValuePair("password", password)
+    };
+    final HttpMethod method = new PostMethod(loginEndpoint);
+    method.setQueryString(queryVals);
+    return method;
+  }
 
-	private boolean hasAuthenticatedSession() throws IOException {
-		final String userDetailsEndpoint =
-			TEST_CONFIG.getInstitutionUrl() + "api/content/currentuser";
-		final HttpMethod method = new GetMethod(userDetailsEndpoint);
-		if (makeClientRequest(method) != HttpStatus.SC_OK) {
-			throw new RuntimeException(
-				"Failed to check authentication status, HTTP response code:" + method
-					.getStatusCode());
-		}
-		String userDetails = method.getResponseBodyAsString();
-		return !userDetails.contains("\"id\":\"guest\"");
-	}
+  private boolean hasAuthenticatedSession() throws IOException {
+    final String userDetailsEndpoint = TEST_CONFIG.getInstitutionUrl() + "api/content/currentuser";
+    final HttpMethod method = new GetMethod(userDetailsEndpoint);
+    if (makeClientRequest(method) != HttpStatus.SC_OK) {
+      throw new RuntimeException(
+          "Failed to check authentication status, HTTP response code:" + method.getStatusCode());
+    }
+    String userDetails = method.getResponseBodyAsString();
+    return !userDetails.contains("\"id\":\"guest\"");
+  }
 }

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AuthApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AuthApiTest.java
@@ -1,0 +1,88 @@
+package io.github.openequella.rest;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.tle.webtests.framework.TestConfig;
+import com.tle.webtests.framework.TestInstitution;
+import java.io.IOException;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.NameValuePair;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.testng.annotations.Test;
+
+@TestInstitution("rest")
+public class AuthApiTest {
+
+	private static final TestConfig TEST_CONFIG = new TestConfig(AuthApiTest.class);
+	private static final String USERNAME = "AutoTest";
+	private static final String PASSWORD = "automated";
+	private static final String API_ENDPOINT = TEST_CONFIG.getInstitutionUrl() + "api/auth";
+
+	private final HttpClient httpClient = new HttpClient();
+
+	@Test
+	public void successfulLoginTest() throws IOException {
+		final HttpMethod method = buildLoginMethod(USERNAME, PASSWORD);
+
+		final int statusCode = makeClientRequest(method);
+		assertEquals(statusCode, HttpStatus.SC_OK, "Attempt to login failed.");
+		assertTrue(hasAuthenticatedSession(),
+			"After a successful login, the session is still a guest session.");
+	}
+
+	@Test(dependsOnMethods = "successfulLoginTest")
+	public void successfulLogoutTest() throws IOException {
+		assertTrue(hasAuthenticatedSession()); // Ensure we're starting the test already logged in
+		final String logoutEndpoint = API_ENDPOINT + "/logout";
+		final HttpMethod method = new PutMethod(logoutEndpoint);
+
+		final int statusCode = makeClientRequest(method);
+		assertEquals(statusCode, HttpStatus.SC_OK,
+			"Attempt to logout failed. (Server said: " + method.getResponseBodyAsString() + ")");
+		assertFalse(hasAuthenticatedSession(), "After logout, still has a non-guest session.");
+	}
+
+	@Test(dependsOnMethods = "successfulLogoutTest")
+	public void invalidCredentialsTest() throws IOException {
+		final HttpMethod method = buildLoginMethod("oof", "foo");
+
+		final int statusCode = makeClientRequest(method);
+		assertEquals(statusCode, HttpStatus.SC_UNAUTHORIZED,
+			"Incorrect response for (what should be a) failed authentication.");
+		assertFalse(hasAuthenticatedSession(),
+			"A valid session has been established, even though we authenticated with rubbish credentials.");
+	}
+
+	private int makeClientRequest(HttpMethod method) throws IOException {
+		return httpClient.executeMethod(method);
+	}
+
+	private HttpMethod buildLoginMethod(String username, String password) {
+		final String loginEndpoint = API_ENDPOINT + "/login";
+		final NameValuePair[] queryVals = {
+			new NameValuePair("username", username),
+			new NameValuePair("password", password)};
+		final HttpMethod method = new PostMethod(loginEndpoint);
+		method.setQueryString(queryVals);
+		return method;
+	}
+
+	private boolean hasAuthenticatedSession() throws IOException {
+		final String userDetailsEndpoint =
+			TEST_CONFIG.getInstitutionUrl() + "api/content/currentuser";
+		final HttpMethod method = new GetMethod(userDetailsEndpoint);
+		if (makeClientRequest(method) != HttpStatus.SC_OK) {
+			throw new RuntimeException(
+				"Failed to check authentication status, HTTP response code:" + method
+					.getStatusCode());
+		}
+		String userDetails = method.getResponseBodyAsString();
+		return !userDetails.contains("\"id\":\"guest\"");
+	}
+}

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -131,6 +131,7 @@ tests:
       - com.tle.webtests.test.webservices.rest.TasksApiTest
       - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
       - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
+      - io.github.openequella.rest.AuthApiTest
       - com.tle.webtests.test.webservices.soap.Soap51Test
       - com.tle.webtests.test.webservices.soap.SoapServicesTest
       - com.tle.webtests.test.webservices.OAIEndpointTest

--- a/autotest/OldTests/testng-travis-webservices.yaml
+++ b/autotest/OldTests/testng-travis-webservices.yaml
@@ -28,6 +28,7 @@ tests:
       - com.tle.webtests.test.webservices.rest.TasksApiTest
       - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
       - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
+      - io.github.openequella.rest.AuthApiTest
       - com.tle.webtests.test.webservices.soap.Soap51Test
       - com.tle.webtests.test.webservices.soap.SoapServicesTest
       - com.tle.webtests.test.webservices.OAIEndpointTest


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes - NA
- [ ] documentation is changed or added - kinda of (apidocs)

##### Description of change

Provides a simple REST auth endpoint for user (and cookie) based authentication (rather than token / OAuth), utilising existing authentication and authorization mechanisms as referenced from the current form based authentication process.

Testing was a little interesting, as this did not really fit within the current oEQ REST testing paradigm. So I also pushed this out into it's own package (including root package reflecting current situation).

#1656 

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
