### PR TITLE
Enable New UI when open tsx pages from Old UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/UISettings.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/UISettings.scala
@@ -56,4 +56,7 @@ object UISettingsJava {
     UISettings.getUISettings.map(_.getOrElse(UISettings.defaultSettings))
   }
 
+  def updateUISettings(in: UISettings): Unit = RunWithDB.executeWithPostCommit(
+    SettingsDB.ensureEditSystem(UISettings.setUISettings(in))
+  )
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -34,7 +34,7 @@ import com.tle.web.sections.jquery.libraries.JQueryCore
 import com.tle.web.sections.js.generic.expression.ObjectExpression
 import com.tle.web.sections.js.generic.function.IncludeFile
 import com.tle.web.sections.render._
-import com.tle.web.settings.UISettings
+import com.tle.web.settings.{NewUISettings, UISettings, UISettingsJava}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 
@@ -144,6 +144,14 @@ object RenderNewTemplate {
       if (DebugSettings.isDevMode) parseEntryHtml(htmlPage)
       else htmlBundleCache.computeIfAbsent(htmlPage, parseEntryHtml)
     context.preRender(scriptPreRender)
+
+    val newUISettings = UISettingsJava.getUISettings.newUI
+    // When new layout is to be rendered but New UI is still not enabled,
+    // update UI setting to enable New UI.
+    if (isNewLayout(context) && !newUISettings.enabled) {
+      UISettingsJava.updateUISettings(
+        UISettings(NewUISettings(enabled = true, newSearch = newUISettings.newSearch)))
+    }
     renderReact(context, viewFactory, renderData, body.body().toString)
   }
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
When open New UI pages from Old UI, the UI setting does not get updated so New UI is still not enabled. But all the pages are rendered in new UI. This PR aims to fix this issue. I have not added any test for this yet.

`SettingsResource` is the reference for how to update UI Setting.
