### PR TITLE
Fix FavouriteItemsTest that fails frequently on GHA

### DIFF
--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/MenuSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/MenuSection.java
@@ -46,7 +46,9 @@ public class MenuSection extends AbstractPage<MenuSection> {
   }
 
   public <T extends AbstractPage<T>> T clickMenu(String title, T page) {
-    findLink(title).click();
+    WebElement link = findLink(title);
+    page.getWaiter().until(ExpectedConditions.elementToBeClickable(link));
+    link.click();
     return page.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/MenuSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/MenuSection.java
@@ -42,7 +42,9 @@ public class MenuSection extends AbstractPage<MenuSection> {
   }
 
   private WebElement findLink(String title) {
-    return driver.findElement(linkByText(title));
+    By textLink = linkByText(title);
+    waiter.until(ExpectedConditions.visibilityOfElementLocated(textLink));
+    return driver.findElement(textLink);
   }
 
   public <T extends AbstractPage<T>> T clickMenu(String title, T page) {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

`testAutoLoggedIn`, which is part of `FavouriteItemsTest`, has been failing quite frequently on GHA. Since the error is  `NoSuchElementException` and the test is really simple, the first attempt to fix this issue is adding a explicit wait.
