### PR TITLE
Contribution wizard lost metadata fix

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
@@ -54,6 +54,7 @@ import com.tle.web.template.Breadcrumbs;
 import com.tle.web.template.Decorations;
 import com.tle.web.template.Decorations.MenuMode;
 import com.tle.web.viewurl.ItemSectionInfo;
+import com.tle.web.wizard.WebWizardPage;
 import com.tle.web.wizard.WizardExceptionHandler;
 import com.tle.web.wizard.WizardService;
 import com.tle.web.wizard.WizardState;
@@ -303,9 +304,8 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
 
   void validateMandatoryFields(SectionInfo info, WizardState state) {
     PagesSection ps = info.lookupSection(PagesSection.class);
-    wizardService
-        .getWizardPages(state)
-        .stream().filter(WebWizardPage::isViewable)
+    wizardService.getWizardPages(state).stream()
+        .filter(WebWizardPage::isViewable)
         .forEach(p -> wizardService.ensureInitialisedPage(info, p, ps.getReloadFunction(), true));
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
@@ -305,11 +305,7 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
     PagesSection ps = info.lookupSection(PagesSection.class);
     wizardService
         .getWizardPages(state)
-        .forEach(
-            p -> {
-              if (p.isViewable()) {
-                wizardService.ensureInitialisedPage(info, p, ps.getReloadFunction(), true);
-              }
-            });
+        .stream().filter(WebWizardPage::isViewable)
+        .forEach(p -> wizardService.ensureInitialisedPage(info, p, ps.getReloadFunction(), true));
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
@@ -305,6 +305,11 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
     PagesSection ps = info.lookupSection(PagesSection.class);
     wizardService
         .getWizardPages(state)
-        .forEach(p -> wizardService.ensureInitialisedPage(info, p, ps.getReloadFunction(), true));
+        .forEach(
+            p -> {
+              if (p.isViewable()) {
+                wizardService.ensureInitialisedPage(info, p, ps.getReloadFunction(), true);
+              }
+            });
   }
 }


### PR DESCRIPTION
To ensure metadata attributed to hidden pages is not wiped by the
mandatory field check.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines]

##### Description of change
#1678 
The lost metadata was caused by the mandatory fields check - it would initialize all pages of a wizard. Since wizards can have visibility scripting, this caused issues with hidden pages initializing when they shouldn't, which wipes their metadata. 
Surrounding this initialisation with a check against isViewable() solves the issue whilst retaining mandatory field checking. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
