### PR TITLE
chore: Unpin NPM deps for oeq-ts-rest-api

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/package-lock.json
+++ b/Source/Plugins/Core/com.equella.core/js/package-lock.json
@@ -3110,10 +3110,10 @@
     "@openequella/rest-api-client": {
       "version": "file:../../../../../oeq-ts-rest-api",
       "requires": {
-        "axios": "0.19.2",
-        "axios-cookiejar-support": "1.0.0",
-        "tough-cookie": "4.0.0",
-        "typescript-is": "0.16.0"
+        "axios": "^0.19.2",
+        "axios-cookiejar-support": "^1.0.0",
+        "tough-cookie": "^4.0.0",
+        "typescript-is": "^0.16.0"
       },
       "dependencies": {
         "@babel/runtime": {

--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -28,17 +28,17 @@
     "trailingComma": "es5"
   },
   "dependencies": {
-    "axios": "0.19.2",
-    "axios-cookiejar-support": "1.0.0",
-    "tough-cookie": "4.0.0",
-    "typescript-is": "0.16.0"
+    "axios": "^0.19.2",
+    "axios-cookiejar-support": "^1.0.0",
+    "tough-cookie": "^4.0.0",
+    "typescript-is": "^0.16.0"
   },
   "devDependencies": {
     "@types/jest": "25.2.1",
     "@types/tough-cookie": "4.0.0",
     "@typescript-eslint/eslint-plugin": "2.31.0",
     "@typescript-eslint/parser": "2.31.0",
-    "eslint": "^6.8.0",
+    "eslint": "6.8.0",
     "jest": "25.5.4",
     "rollup": "2.9.1",
     "rollup-plugin-typescript2": "0.27.1",

--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/jest": "25.2.1",
-    "@types/tough-cookie": "4.0.0",
+    "@types/tough-cookie": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "2.31.0",
     "@typescript-eslint/parser": "2.31.0",
     "eslint": "6.8.0",


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included - NA
- [ ] screenshots are included showing significant UI changes - NA
- [ ] documentation is changed or added - NA

##### Description of change

So as to comply with recommendations by renovate at:
https://docs.renovatebot.com/dependency-pinning/#so-whats-best

First raised as part of #1722 

Manual testing of oEQ is still fine, and so is the execution of the npm run test for this module.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
