### PR TITLE
build: removes esModuleInterop

### DIFF
--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -18,7 +18,7 @@
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
     "format": "eslint --fix \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
-    "prepare": "rollup --config"
+    "prepare": "npm run build"
   },
   "peerDependencies": {},
   "prettier": {

--- a/oeq-ts-rest-api/rollup.config.js
+++ b/oeq-ts-rest-api/rollup.config.js
@@ -9,16 +9,14 @@ export default {
       file: pkg.main,
       format: 'cjs',
       exports: 'named',
-      sourcemap: true
+      sourcemap: true,
     },
     {
       file: pkg.module,
       format: 'es',
       exports: 'named',
-      sourcemap: true
-    }
+      sourcemap: true,
+    },
   ],
-  plugins: [
-    typescript({ typescript: ttypescript, clean: true }),
-  ],
+  plugins: [typescript({ typescript: ttypescript, clean: true })],
 };

--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -1,6 +1,6 @@
 import Axios, { AxiosResponse, AxiosError } from 'axios';
 import axiosCookieJarSupport from 'axios-cookiejar-support';
-import tough from 'tough-cookie';
+import * as tough from 'tough-cookie';
 import { repackageError } from './Errors';
 
 // So that cookies work when used in non-browser (i.e. Node/Jest) type environments. And seeing

--- a/oeq-ts-rest-api/tsconfig.json
+++ b/oeq-ts-rest-api/tsconfig.json
@@ -19,7 +19,6 @@
       "*": ["src/*", "node_modules/*"]
     },
     "jsx": "react",
-    "esModuleInterop": true,
     "plugins": [
       { "transform": "typescript-is/lib/transform-inline/transformer" }
     ]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

esModuleInterop has cascading effects, using it here means any libraries that depend on it must also use esModuleInterop.
In this case it was a small enough change that it can be removed, and downstream adopter(s) can choose to use interop or not.

~externalizing the node_modules means that downstream bundlers will need to resolve the `import` or `require` statements for packages which are dependencies, like Axios.
This allows downstream builds to automatically deduplicate dependencies which may be used by multiple packages.~
_edit_: it looks like because the commonjs resolver isn't included, rollup can't find any of the node modules anyway and it's behavior is to keep the import and soft error, meaning external isn't needed.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
