### PR TITLE
Add support to the REST Client for retrieval of schemas

### DIFF
--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "rollup --config --watch",
     "build": "rollup --config",
-    "test": "jest",
+    "test": "jest --no-cache",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
     "format": "eslint --fix \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
     "prepare": "rollup --config"

--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -15,10 +15,11 @@ const catchHandler = (error: AxiosError | Error): never => {
 
 export const GET = <T>(
   path: string,
-  validator?: (data: unknown) => boolean
+  validator?: (data: unknown) => boolean,
+  queryParams?: object
 ): Promise<T> =>
   axios
-    .get<T>(path)
+    .get<T>(path, {params: queryParams})
     .then((response: AxiosResponse<T>) => {
       if (validator && !validator(response.data)) {
         // If a validator is provided, but it fails to validate the provided data...

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -1,0 +1,71 @@
+import * as Security from './Security';
+import { is } from 'typescript-is';
+
+export type i18nString = string;
+
+export type I18nStrings = Record<string, string>;
+
+export interface User {
+  id: string;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  emailAddress?: string;
+}
+
+export interface EntityLock {
+  uuid: string;
+  owner: User;
+  links: Record<string, string>;
+}
+
+export interface BaseEntityExport {
+  exportVersion: string;
+  lock: EntityLock;
+}
+
+export interface BaseEntityReadOnly {
+  granted: string[];
+}
+
+export interface BaseEntity {
+  uuid: string;
+  // Attempted to use Date here, but it broke checks with typescript-is. But Date could be used
+  // post processing
+  modifiedDate?: string;
+  createdDate?: string;
+  owner?: User;
+  name: i18nString;
+  nameStrings: I18nStrings;
+  description?: i18nString;
+  descriptionStrings?: I18nStrings;
+  security?: Security.BaseEntitySecurity;
+  exportDetails?: BaseEntityExport;
+  readonly?: BaseEntityReadOnly;
+  links: Record<string, string>;
+}
+
+export interface PagedResult<T> {
+  start: number;
+  length: number;
+  available: number;
+  results: T[];
+  resumptionToken?: string;
+}
+
+/**
+ * Helper function for a standard validator for BaseEntity instances via typescript-is.
+ *
+ * @param instance An instance to validate.
+ */
+export const isBaseEntity = (instance: unknown): boolean =>
+  is<BaseEntity>(instance);
+
+/**
+ * Helper function for a standard validator for BaseEntity  instances wrapped in a PagedResult
+ * via typescript-is.
+ *
+ * @param instance An instance to validate.
+ */
+export const isPagedBaseEntity = (instance: unknown): boolean =>
+  is<PagedResult<BaseEntity>>(instance);

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -54,14 +54,6 @@ export interface PagedResult<T> {
 }
 
 /**
- * Helper function for a standard validator for BaseEntity instances via typescript-is.
- *
- * @param instance An instance to validate.
- */
-export const isBaseEntity = (instance: unknown): boolean =>
-  is<BaseEntity>(instance);
-
-/**
  * Helper function for a standard validator for BaseEntity  instances wrapped in a PagedResult
  * via typescript-is.
  *

--- a/oeq-ts-rest-api/src/Errors.ts
+++ b/oeq-ts-rest-api/src/Errors.ts
@@ -1,15 +1,29 @@
 import { AxiosError } from 'axios';
+import { is } from 'typescript-is';
+
+export interface ErrorResponse {
+  code: number;
+  error: string;
+  error_description: string;
+}
 
 export class ApiError extends Error {
   constructor(message: string, public status?: number) {
     super(message);
     this.status = status;
   }
+
+  errorResponse?: ErrorResponse;
 }
 
 export const repackageError = (error: AxiosError | Error): Error => {
   if ('isAxiosError' in error) {
-    return new ApiError(error.message, error.response?.status);
+    const apiError = new ApiError(error.message, error.response?.status);
+    if (is<ErrorResponse>(error.response?.data)) {
+      apiError.errorResponse = error.response?.data;
+    }
+
+    return apiError;
   } else {
     return error;
   }

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -1,0 +1,112 @@
+import * as Common from './Common';
+import { GET } from './AxiosInstance';
+import { is } from 'typescript-is';
+
+export interface Citation {
+  name: string;
+  transformation: string;
+}
+
+export interface SchemaNode {
+  children: Record<string, SchemaNode>;
+  indexed: boolean;
+  field: boolean;
+  nested: boolean;
+  type: string;
+}
+
+export interface Schema extends Common.BaseEntity {
+  namePath: string;
+  descriptionPath: string;
+  /**
+   * Typically a tree of objects representing an XML schema - so first entry is normally "xml".
+   */
+  definition: Record<string, unknown>;
+}
+
+export interface EquellaSchema extends Schema {
+  citations: Citation[];
+  exportTransformsMap: Record<string, string>;
+  importTransformsMap: Record<string, string>;
+  ownerUuid: string;
+  serializedDefinition: string;
+}
+
+/**
+ * Query params for listing of schemas. All are optional!
+ */
+export interface ListSchemaParams {
+  /**
+   * Search name and description
+   */
+  q?: string;
+  /**
+   * Privilege(s) to filter by
+   */
+  privilege?: string[];
+  /**
+   * Resumption token for paging
+   */
+  resumptionToken?: string;
+  /**
+   * Number of results
+   */
+  length?: number;
+  /**
+   * Return full entity (needs VIEW or EDIT privilege)
+   */
+  full?: boolean;
+}
+
+/**
+ * Helper function for a standard validator for EquellaSchema instances via typescript-is.
+ *
+ * @param instance An instance to validate.
+ */
+export const isEquellaSchema = (instance: unknown): boolean =>
+  is<EquellaSchema>(instance);
+
+/**
+ * Helper function for a standard validator for EquellaSchema instances wrapped in a PagedResult
+ * via typescript-is.
+ *
+ * @param instance An instance to validate.
+ */
+export const isPagedEquellaSchema = (instance: unknown): boolean =>
+  is<Common.PagedResult<EquellaSchema>>(instance);
+
+const SCHEMA_ROOT_PATH = '/schema';
+
+/**
+ * List all available schemas which the currently authenticated user has access to. Results can
+ * be customised based on params, and if the `full` param is specified then the return value is
+ * actually EquellaSchema with all details.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param params Query parameters to customize (and/or page) result
+ */
+export const listSchemas = (
+  apiBasePath: string,
+  params: ListSchemaParams | null
+): Promise<Common.PagedResult<Common.BaseEntity>> => {
+  // Only if the `full` param is specified do you get a whole Schema definition, otherwise
+  // it's the bare minimum of BaseEntity.
+  const validator = params?.full
+    ? isPagedEquellaSchema
+    : Common.isPagedBaseEntity;
+
+  return GET<Common.PagedResult<Common.BaseEntity>>(
+    apiBasePath + SCHEMA_ROOT_PATH,
+    validator,
+    params ?? undefined
+  );
+};
+
+export const getSchema = (
+  apiBasePath: string,
+  uuid: string
+): Promise<EquellaSchema> =>
+  GET<EquellaSchema>(
+    apiBasePath + `${SCHEMA_ROOT_PATH}/${uuid}`,
+    isEquellaSchema
+  );

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -102,6 +102,12 @@ export const listSchemas = (
   );
 };
 
+/**
+ * Get details of a specific schema as specified by the provided UUID.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param uuid UUID of the schema to be retrieved.
+ */
 export const getSchema = (
   apiBasePath: string,
   uuid: string

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -79,7 +79,7 @@ const SCHEMA_ROOT_PATH = '/schema';
  */
 export const listSchemas = (
   apiBasePath: string,
-  params: ListSchemaParams | null
+  params?: ListSchemaParams
 ): Promise<Common.PagedResult<Common.BaseEntity>> => {
   // Only if the `full` param is specified do you get a whole Schema definition, otherwise
   // it's the bare minimum of BaseEntity.

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -7,14 +7,6 @@ export interface Citation {
   transformation: string;
 }
 
-export interface SchemaNode {
-  children: Record<string, SchemaNode>;
-  indexed: boolean;
-  field: boolean;
-  nested: boolean;
-  type: string;
-}
-
 export interface Schema extends Common.BaseEntity {
   namePath: string;
   descriptionPath: string;

--- a/oeq-ts-rest-api/src/Security.ts
+++ b/oeq-ts-rest-api/src/Security.ts
@@ -1,0 +1,10 @@
+export interface TargetListEntry {
+  granted: boolean;
+  override: boolean;
+  privilege: string;
+  who: string;
+}
+
+export interface BaseEntitySecurity {
+  rules: TargetListEntry[];
+}

--- a/oeq-ts-rest-api/src/index.ts
+++ b/oeq-ts-rest-api/src/index.ts
@@ -1,4 +1,7 @@
 export * as Auth from './Auth';
+export * as Common from './Common'
 export * as LegacyContent from './LegacyContent';
 export * as Errors from './Errors';
+export * as Schema from './Schema';
+export * as Security from './Security';
 export * as Settings from './Settings';

--- a/oeq-ts-rest-api/test/schema.test.ts
+++ b/oeq-ts-rest-api/test/schema.test.ts
@@ -35,15 +35,28 @@ describe('Retrieving schemas', () => {
   });
 });
 
-it('Should be possible to retrieve a known schema', () => {
-  expect.assertions(2);
-  const targetUuid = '71a27a31-d6b0-4681-b124-6db410ed420b';
+describe('Retrieval of a specific schema', () => {
+  it('Should be possible to retrieve a known schema', () => {
+    expect.assertions(2);
+    const targetUuid = '71a27a31-d6b0-4681-b124-6db410ed420b';
 
-  return OEQ.Schema.getSchema(TC.API_PATH, targetUuid).then(
-    (result: EquellaSchema) => {
-      expect(result.uuid).toBe(targetUuid);
-      // Better make sure we got a schema
-      expect(result.definition).toBeTruthy();
-    }
-  );
+    return OEQ.Schema.getSchema(TC.API_PATH, targetUuid).then(
+      (result: EquellaSchema) => {
+        expect(result.uuid).toBe(targetUuid);
+        // Better make sure we got a schema
+        expect(result.definition).toBeTruthy();
+      }
+    );
+  });
+
+  it('Should result in a 404 when attempting to retrieve an unknown UUID', () => {
+    expect.assertions(2);
+
+    return OEQ.Schema.getSchema(TC.API_PATH, 'fake-uuid').catch(
+      (error: OEQ.Errors.ApiError) => {
+        expect(error.status).toBe(404);
+        expect(error.errorResponse).toBeTruthy();
+      }
+    );
+  });
 });

--- a/oeq-ts-rest-api/test/schema.test.ts
+++ b/oeq-ts-rest-api/test/schema.test.ts
@@ -1,0 +1,49 @@
+import * as OEQ from '../src';
+import * as TC from './TestConfig';
+import { EquellaSchema } from '../src/Schema';
+
+beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
+
+afterAll(() => OEQ.Auth.logout(TC.API_PATH, true));
+
+describe('Retrieving schemas', () => {
+  it('should be possible get schemas with no params', () => {
+    expect.assertions(2);
+
+    return OEQ.Schema.listSchemas(TC.API_PATH, null).then(
+      (pagedResult: OEQ.Common.PagedResult<OEQ.Common.BaseEntity>) => {
+        expect(pagedResult.length).toBeGreaterThan(0);
+        expect(pagedResult.length).toEqual(pagedResult.results.length);
+      }
+    );
+  });
+
+  it('should be possible to get schemas customised with params', () => {
+    expect.assertions(3);
+    const howMany = 2;
+
+    return OEQ.Schema.listSchemas(TC.API_PATH, {
+      length: howMany,
+      full: true,
+    }).then((pagedResult: OEQ.Common.PagedResult<OEQ.Common.BaseEntity>) => {
+      const result = pagedResult as OEQ.Common.PagedResult<EquellaSchema>;
+      expect(result.results.length).toBe(howMany);
+      // confirm that `full` returned additional information
+      expect(result.results[0].createdDate).toBeTruthy();
+      expect(result.results[0].definition).toBeTruthy();
+    });
+  });
+});
+
+it('Should be possible to retrieve a known schema', () => {
+  expect.assertions(2);
+  const targetUuid = '71a27a31-d6b0-4681-b124-6db410ed420b';
+
+  return OEQ.Schema.getSchema(TC.API_PATH, targetUuid).then(
+    (result: EquellaSchema) => {
+      expect(result.uuid).toBe(targetUuid);
+      // Better make sure we got a schema
+      expect(result.definition).toBeTruthy();
+    }
+  );
+});

--- a/oeq-ts-rest-api/test/schema.test.ts
+++ b/oeq-ts-rest-api/test/schema.test.ts
@@ -10,7 +10,7 @@ describe('Retrieving schemas', () => {
   it('should be possible get schemas with no params', () => {
     expect.assertions(2);
 
-    return OEQ.Schema.listSchemas(TC.API_PATH, null).then(
+    return OEQ.Schema.listSchemas(TC.API_PATH).then(
       (pagedResult: OEQ.Common.PagedResult<OEQ.Common.BaseEntity>) => {
         expect(pagedResult.length).toBeGreaterThan(0);
         expect(pagedResult.length).toEqual(pagedResult.results.length);


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes - NA
- [ ] documentation is changed or added - NA

##### Description of change

This adds support to the REST Client to be able to simply:

* List available schemas (`listSchemas`); and
* Get a specific schema (`getSchema(uuid)`).

It also includes a slight improvement to the error handling to include the standard oEQ error response within `ApiError`.

But this was painful! First, what one sees in the Swagger/apidocs for the expected models returned is mostly wrong. And the same goes if you niavely look at the method signature in the code for an endpoint.

oEQ does a whole lot of customisation for its responses, so even though the method signature might say it will return a certain type, that can not be relied on - and in the case of listing schemas is mostly wrong (it says `SchemaBean` but you with really get either a stripped down `BaseEntityBean` or the more full fledged `EquellaSchemaBean`). Further, there are even some properties which are returned in the payload (e.g. `links`) which is purely synthetic and added dynamically via an internal `Map` - via `AbstractExtendableBean`.

All that means a few things:

1. Not attempting to force the route of codegen based on an OpenAPI or Swagger spec was the right course - indeed even attempting to codegen off the method signatures would've been folly; and
2. The models you see in this PR have been excruciatingly hand rolled, and sometimes are loser in typing then we'd ideally like; and
3. Although enforcing runtime types with `typescript-is` is hard, it does seem to be paying off and very much warranted with this module - and will pay dividends when we run the tests as part of the CI.

One last note: You'll see the NPM `test` script now calls Jest with `--no-cache`. This was due to finding inconsistent results, where sometimes IDEs (VS Code / IntelliJ) would show the tests as passing or failing, but the terminal would say the opposite. I guess that the codegen being done by `typescript-is` was being cached, and hence triggered the confusing results (the failures were always around the typechecking). Although this option is said to double the execution time, for now I'm willing to take the hit for sake of accuracy - it's hard enough divining the types as it is. (It still takes < 5sec to run the tests.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
