### PR TITLE
Add schema retrieval to SchemaModule.ts

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/getSchemaUuidResp.js
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/getSchemaUuidResp.js
@@ -1,0 +1,195 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+exports.getSchemaUuidResp = {
+  uuid: "f028746b-0346-fe7e-a223-a2db1240140c",
+  name: "CAL Guide Schema",
+  nameStrings: {
+    en: "CAL Guide Schema",
+  },
+  description:
+    "testing the creation of a CAL schema as demonstrated by the CAL configuration guide",
+  descriptionStrings: {
+    en:
+      "testing the creation of a CAL schema as demonstrated by the CAL configuration guide",
+  },
+  modifiedDate: "2014-04-04T12:56:52.870+11:00",
+  createdDate: "2012-03-14T17:33:05.767+11:00",
+  owner: {
+    id: "adfcaf58-241b-4eca-9740-6a26d1c3dd58",
+  },
+  security: {
+    rules: [],
+  },
+  namePath: "/item/itembody/name",
+  descriptionPath: "/item/itembody/description",
+  definition: {
+    xml: {
+      item: {
+        itembody: {
+          name: {
+            _indexed: true,
+            _field: true,
+            _type: "text",
+          },
+          description: {
+            _indexed: true,
+            _type: "text",
+          },
+        },
+        copyright: {
+          "@parenttype": {
+            _nested: true,
+            _type: "text",
+          },
+          issue: {
+            type: {
+              _indexed: true,
+              _type: "text",
+            },
+            value: {
+              _indexed: true,
+              _type: "text",
+            },
+          },
+          "@type": {
+            _nested: true,
+            _type: "text",
+          },
+          isbn: {
+            _indexed: true,
+            _field: true,
+            _type: "text",
+          },
+          abstract: {
+            _indexed: true,
+            _type: "text",
+          },
+          title: {
+            _indexed: true,
+            _field: true,
+            _type: "text",
+          },
+          volume: {
+            _indexed: true,
+            _type: "text",
+          },
+          pages: {
+            _type: "text",
+          },
+          issn: {
+            _indexed: true,
+            _field: true,
+            _type: "text",
+          },
+          publication: {
+            year: {
+              _type: "text",
+            },
+            place: {
+              _indexed: true,
+              _field: true,
+              _type: "text",
+            },
+          },
+          publisher: {
+            _type: "text",
+          },
+          editors: {
+            editor: {
+              _indexed: true,
+              _field: true,
+              _type: "text",
+            },
+          },
+          authors: {
+            author: {
+              _indexed: true,
+              _field: true,
+              _type: "text",
+            },
+          },
+          portions: {
+            portion: {
+              number: {
+                _type: "text",
+              },
+              topics: {
+                topic: {
+                  _indexed: true,
+                  _type: "text",
+                },
+              },
+              abstract: {
+                _indexed: true,
+                _type: "text",
+              },
+              title: {
+                _indexed: true,
+                _field: true,
+                _type: "text",
+              },
+              sections: {
+                section: {
+                  copyrightstatus: {
+                    _type: "text",
+                  },
+                  pages: {
+                    _type: "text",
+                  },
+                  attachment: {
+                    _type: "text",
+                  },
+                  illustration: {
+                    _type: "text",
+                  },
+                  type: {
+                    _type: "text",
+                  },
+                },
+              },
+              authors: {
+                author: {
+                  _indexed: true,
+                  _field: true,
+                  _type: "text",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  citations: [
+    {
+      name: "Harvard",
+      transformation: "harvard.xsl",
+    },
+  ],
+  exportTransformsMap: {},
+  importTransformsMap: {
+    "Z39.50 to Book": "MODS_z3950_to_book-20071212-1.xslt",
+  },
+  ownerUuid: "adfcaf58-241b-4eca-9740-6a26d1c3dd58",
+  serializedDefinition:
+    '<xml><item><copyright><type attribute="true" type="text"/><parenttype attribute="true" type="text"/><title field="true" search="true" type="text"/><abstract search="true" type="text"/><isbn field="true" search="true" type="text"/><authors><author field="true" search="true" type="text"/></authors><editors><editor field="true" search="true" type="text"/></editors><issn field="true" search="true" type="text"/><issue><type search="true" type="text"/><value search="true" type="text"/></issue><volume search="true" type="text"/><publisher type="text"/><publication><year type="text"/><place field="true" search="true" type="text"/></publication><pages type="text"/><portions><portion><title field="true" search="true" type="text"/><authors><author field="true" search="true" type="text"/></authors><abstract search="true" type="text"/><number type="text"/><topics><topic search="true" type="text"/></topics><sections><section><pages type="text"/><attachment type="text"/><type type="text"/><copyrightstatus type="text"/><illustration type="text"/></section></sections></portion></portions></copyright><itembody><name field="true" search="true" type="text"/><description search="true" type="text"/></itembody></item></xml>',
+  links: {
+    self:
+      "http://localhost:8080/rest/api/schema/f028746b-0346-fe7e-a223-a2db1240140c",
+  },
+};

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/getSchemasResp.js
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/getSchemasResp.js
@@ -1,0 +1,94 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+exports.getSchemasResp = {
+  start: 0,
+  length: 5,
+  available: 5,
+  results: [
+    {
+      uuid: "f028746b-0346-fe7e-a223-a2db1240140c",
+      name: "CAL Guide Schema",
+      nameStrings: {
+        en: "CAL Guide Schema",
+      },
+      readonly: {
+        granted: ["LIST_SCHEMA"],
+      },
+      links: {
+        self:
+          "http://localhost:8080/rest/api/schema/f028746b-0346-fe7e-a223-a2db1240140c",
+      },
+    },
+    {
+      uuid: "8d6cf2dd-6166-2e2d-f8bb-129de8b90d3d",
+      name: "Controls Schema",
+      nameStrings: {
+        en: "Controls Schema",
+      },
+      readonly: {
+        granted: ["LIST_SCHEMA"],
+      },
+      links: {
+        self:
+          "http://localhost:8080/rest/api/schema/8d6cf2dd-6166-2e2d-f8bb-129de8b90d3d",
+      },
+    },
+    {
+      uuid: "d9aba963-4648-e497-d62b-fc1ddf2d0199",
+      name: "Basic Schema",
+      nameStrings: {
+        en: "Basic Schema",
+      },
+      readonly: {
+        granted: ["LIST_SCHEMA"],
+      },
+      links: {
+        self:
+          "http://localhost:8080/rest/api/schema/d9aba963-4648-e497-d62b-fc1ddf2d0199",
+      },
+    },
+    {
+      uuid: "71a27a31-d6b0-4681-b124-6db410ed420b",
+      name: "Simple schema",
+      nameStrings: {
+        en: "Simple schema",
+      },
+      readonly: {
+        granted: ["LIST_SCHEMA"],
+      },
+      links: {
+        self:
+          "http://localhost:8080/rest/api/schema/71a27a31-d6b0-4681-b124-6db410ed420b",
+      },
+    },
+    {
+      uuid: "87e848e3-675b-4ec6-8008-1326a5a45368",
+      name: "Attachment Schema",
+      nameStrings: {
+        en: "Attachment Schema",
+      },
+      readonly: {
+        granted: ["LIST_SCHEMA"],
+      },
+      links: {
+        self:
+          "http://localhost:8080/rest/api/schema/87e848e3-675b-4ec6-8008-1326a5a45368",
+      },
+    },
+  ],
+};

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/schema/SchemaModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/schema/SchemaModule.test.ts
@@ -44,3 +44,21 @@ describe("SchemaModule", () => {
       expect(copyrightNode.children?.length).toEqual(14);
     }));
 });
+
+describe("pathForNode", () => {
+  const schemaDefinition = {
+    child1: { child2: { child3: { _type: "text" } } },
+  };
+  const testSchema = SchemaModule.buildSchemaTree(schemaDefinition, "xml");
+  const testNode = testSchema.children![0].children![0].children![0];
+
+  it("should correctly generate an oEQ path by default", () =>
+    expect(SchemaModule.pathForNode(testNode)).toEqual(
+      "/child1/child2/child3"
+    ));
+
+  it("should correctly include the XML prefix if desired", () =>
+    expect(SchemaModule.pathForNode(testNode, false)).toEqual(
+      "/xml/child1/child2/child3"
+    ));
+});

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/schema/SchemaModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/schema/SchemaModule.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as SchemaModule from "../../../tsrc/schema/SchemaModule";
+import { getSchemasResp } from "../../../__mocks__/getSchemasResp";
+import { getSchemaUuidResp } from "../../../__mocks__/getSchemaUuidResp";
+import * as OEQ from "@openequella/rest-api-client";
+
+jest.mock("@openequella/rest-api-client");
+(OEQ.Schema.listSchemas as jest.Mock<
+  Promise<OEQ.Common.PagedResult<OEQ.Common.BaseEntity>>
+>).mockResolvedValue(getSchemasResp);
+(OEQ.Schema.getSchema as jest.Mock<
+  Promise<OEQ.Schema.EquellaSchema>
+>).mockResolvedValue(getSchemaUuidResp);
+
+describe("SchemaModule", () => {
+  it("should be able to provide a list of schemas", () =>
+    SchemaModule.schemaListSummary().then((schemas) => {
+      expect(schemas.size).toEqual(5);
+    }));
+
+  it("should be able to retrieve the schema for a specified UUID", () =>
+    SchemaModule.schemaTree("unused due to mocked response").then((schema) => {
+      const itemNode = schema.children![0];
+      const copyrightNode = itemNode.children![1];
+      expect(itemNode.name).toEqual("item");
+      expect(itemNode.children?.length).toEqual(2);
+      expect(copyrightNode.name).toEqual("copyright");
+      expect(copyrightNode.children?.length).toEqual(14);
+    }));
+});


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes - NA
- [x] documentation is changed or added

##### Description of change

This adds a method to retrieve a specific schema (based on UUID) and generate a basic tree structure. It also provides a method to build the node path for a specified node.

The generated structure currently doesn't include the extra fields for leaf nodes (_type, _indexed, _field) as we wont yet be using them. But we can easily come back and add them when/if we need them.

I've included tests with the REST calls mocked out - including for the previous function rushed through to retrieve a list of schemas. They're basic, but at least give us some coverage for now.

I believe this completes the work needed for SchemaModule, (including related schema work in the REST client). So everything should be in place for @SammyIsConfused to finish off the schema browser.

#1337 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
