### PR TITLE
chore: Make sourcemaps work

### DIFF
--- a/.idea/typescript-compiler.xml
+++ b/.idea/typescript-compiler.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="TypeScriptCompiler">
-    <option name="recompileOnChanges" value="true" />
-  </component>
-</project>

--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -14,10 +14,10 @@
   "scripts": {
     "install": "cross-env-shell \"psc-package install && mkdirp ${npm_package_config_devlang} ${npm_package_config_buildlang}\"",
     "clean": "rm -rf target/ output/ node_modules/ bower_components/ .cache/ .psc-package/ .pulp-cache/",
-    "dev": "pulp build && cross-env-shell parcel watch --no-autoinstall --public-url=./reactjs/ --out-dir=${npm_package_config_devjs} entrydev/*.html entrydev/scripts/*.js",
-    "dev:build": "run-s bundleps && cross-env-shell parcel build --public-url=./reactjs/ --out-dir=${npm_package_config_devjs} entrybuild/*.html entrybuild/scripts/*.js",
+    "dev": "pulp build && cross-env-shell parcel watch --no-autoinstall --public-url=. --out-dir=${npm_package_config_devjs} entrydev/*.html entrydev/scripts/*.js",
+    "dev:build": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_devjs} entrybuild/*.html entrybuild/scripts/*.js",
     "build": "npm-run-all build:*",
-    "build:bundles": "run-s bundleps && cross-env-shell parcel build --public-url=./reactjs/ --out-dir=${npm_package_config_dist} entrybuild/*.html entrybuild/scripts/*.js",
+    "build:bundles": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_dist} entrybuild/*.html entrybuild/scripts/*.js",
     "build:langbundle": "cross-env-shell parcel build target/genlang.js --no-minify --no-source-maps --target node --out-dir=target/tools && cross-env-shell \"node target/tools/genlang.js > ${npm_package_config_buildlang}/jsbundle.json\"",
     "compileps": "pulp build",
     "bundleps": "npm-run-all compileps && npm-run-all --parallel bundleps:*",

--- a/Source/Plugins/Core/com.equella.core/js/tsconfig.json
+++ b/Source/Plugins/Core/com.equella.core/js/tsconfig.json
@@ -18,7 +18,7 @@
     "noUnusedLocals": true,
     "baseUrl": ".",
     "paths": {
-      "~*": ["./entrybuild/*"]
+      "~*": ["./entrybuild/*", "./tsrc/*"]
     }
   },
   "include": [

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -61,17 +61,18 @@ object RenderNewTemplate {
   }
 
   def parseEntryHtml(filename: String): (PreRenderable, Document) = {
-    val inpStream = getClass.getResourceAsStream(s"/web/reactjs/$filename")
+    val reactJsPath = "reactjs/"
+    val inpStream   = getClass.getResourceAsStream(s"/web/$reactJsPath$filename")
     if (inpStream == null) sys.error(s"Failed to find $filename react html bundle")
     val htmlDoc = Jsoup.parse(inpStream, "UTF-8", "")
     inpStream.close()
-    val links   = htmlDoc.getElementsByTag("link").asScala
-    val scripts = htmlDoc.getElementsByTag("script").asScala
-    scripts.foreach { e =>
-      if (e.hasAttr("src")) {
-        e.attr("src", r.url(e.attr("src")))
+    htmlDoc.getElementsByTag("script").asScala.foreach { e =>
+      val srcAttrKey = "src"
+      if (e.hasAttr(srcAttrKey)) {
+        e.attr(srcAttrKey, r.url(reactJsPath + e.attr(srcAttrKey)))
       }
     }
+    val links = htmlDoc.getElementsByTag("link").asScala
     val prerender: PreRenderable = info => {
       info.preRender(JQueryCore.PRERENDER)
       supportIEPolyFills(info)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included - NA
- [ ] screenshots are included showing significant UI changes - NA
- [ ] documentation is changed or added - NA

##### Description of change

Due to some runtime tweaking of paths etc, although the sourcemaps are
generated with `npm run dev:build` they didn't work - as the sourcemap
retrieval resulted in a 404. This meant you couldn't do TS/React level
debugging in browser or IDE. With this update, you now can.

I also removed the IntelliJ typescript-compiler.xml file to stop
IntelliJ spitting out duplicate .js and .jsx files alongside the .ts and
.tsx. (I may have done this on another branch too.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
