### PR TITLE
Fix last known user constraint violation issue

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/user/UserInfoBackup.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/user/UserInfoBackup.java
@@ -35,11 +35,7 @@ import org.hibernate.annotations.AccessType;
  */
 @Entity
 @AccessType("field")
-@Table(
-    uniqueConstraints = {
-      @UniqueConstraint(columnNames = {"username", "institutionId"}),
-      @UniqueConstraint(columnNames = {"uniqueId", "institutionId"})
-    })
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"uniqueId", "institutionId"})})
 public class UserInfoBackup implements UserBean {
   private static final long serialVersionUID = 1L;
 

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6020,6 +6020,11 @@
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.CreateFacetedSearchClassificationTable" />
     <parameter id="date" value="2020-04-22" />
   </extension>
+  <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint">
+    <parameter id="id" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
+    <parameter id="date" value="2020-06-10" />
+  </extension>
   <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="domainObjects">
     <parameter id="class" value="com.tle.core.integration.beans.AuditLogLms" />
   </extension>

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -79,6 +79,7 @@
 /com.tle.core.entity.services.migration.v20192.unknownuser.lastowner=Add last owner to item
 /com.tle.core.entity.services.migration.v20192.unknownuser.alluser=Create a new table for all users
 /com.tle.core.entity.services.migration.v20202.facetedsearch.classification=Create a new table for faceted search classification
+/com.tle.core.entity.services.migration.v20202.removelastknownuserconstraint=Remove last known user composite constraint (username and institution ID)
 /com.tle.core.entity.services.query.contains={0} is {1}
 /com.tle.core.entity.services.query.date.after={0} after {1}
 /com.tle.core.entity.services.query.date.before={0} before {1}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20202/RemoveLastKnownUserConstraint.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20202/RemoveLastKnownUserConstraint.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.institution.migration.v20202;
 
 import com.google.inject.Singleton;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20202/RemoveLastKnownUserConstraint.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20202/RemoveLastKnownUserConstraint.java
@@ -1,0 +1,80 @@
+package com.tle.core.institution.migration.v20202;
+
+import com.google.inject.Singleton;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import com.tle.core.guice.Bind;
+import com.tle.core.hibernate.impl.HibernateMigrationHelper;
+import com.tle.core.migration.AbstractHibernateSchemaMigration;
+import com.tle.core.migration.MigrationInfo;
+import com.tle.core.migration.MigrationResult;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.hibernate.Query;
+import org.hibernate.annotations.AccessType;
+import org.hibernate.classic.Session;
+
+@Bind
+@Singleton
+public class RemoveLastKnownUserConstraint extends AbstractHibernateSchemaMigration {
+  private static final String TABLE_NAME = "user_info_backup";
+  private static final String COLUMN_NAME = "username";
+  private static final String TEMP_COLUMN_NAME = "username1";
+
+  @Override
+  protected List<String> getAddSql(HibernateMigrationHelper helper) {
+    List<String> sql = new ArrayList<String>();
+    // Rename column username to username1 and add a new column named username.
+    sql.addAll(helper.getRenameColumnSQL(TABLE_NAME, COLUMN_NAME, TEMP_COLUMN_NAME));
+    sql.addAll(helper.getAddColumnsSQL(TABLE_NAME, COLUMN_NAME));
+    return sql;
+  }
+
+  @Override
+  protected void executeDataMigration(
+      HibernateMigrationHelper helper, MigrationResult result, Session session) throws Exception {
+    // Copy data from username1 to username.
+    Query query =
+        session.createQuery("UPDATE UserInfoBackup SET " + COLUMN_NAME + " = " + TEMP_COLUMN_NAME);
+    query.executeUpdate();
+  }
+
+  @Override
+  protected int countDataMigrations(HibernateMigrationHelper helper, Session session) {
+    return 1;
+  }
+
+  @Override
+  protected List<String> getDropModifySql(HibernateMigrationHelper helper) {
+    // Drop username1.
+    return helper.getDropColumnSQL(TABLE_NAME, TEMP_COLUMN_NAME);
+  }
+
+  @Override
+  public MigrationInfo createMigrationInfo() {
+    return new MigrationInfo(
+        "com.tle.core.entity.services.migration.v20202.removelastknownuserconstraint");
+  }
+
+  @Override
+  protected Class<?>[] getDomainClasses() {
+    return new Class<?>[] {FakeUserInfoBackup.class};
+  }
+
+  @Entity(name = "UserInfoBackup")
+  @AccessType("field")
+  public static class FakeUserInfoBackup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @XStreamOmitField
+    long id;
+
+    @Column public String username;
+
+    @Column public String username1;
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
@@ -133,8 +133,8 @@ public class UserServiceImpl
   private boolean useXForwardedFor;
 
   @Override
-  public UserInfoBackup findUserInfoBackup(String username) {
-    return userInfoBackupDao.findUserInfoBackup(username);
+  public UserInfoBackup findUserInfoBackup(String userUniqueId) {
+    return userInfoBackupDao.findUserInfoBackup(userUniqueId);
   }
 
   @Transactional


### PR DESCRIPTION
#1619 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Removing the composite constraint (username and institution ID) from table `user_info_backup` allows users to login with a user account that was deleted but recreated later with the same username and different user id. 

![image](https://user-images.githubusercontent.com/47203811/84341604-dbff7080-abe6-11ea-8909-0c4a87256eb5.png)


