### PR TITLE
chore: reconfigure renovate bot - more throughput and automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   "prHourlyLimit": 2,
   "packageRules": [
     {
+      "depTypeList": ["devDependencies"],
+      "automerge": true
+    },
+    {
       "packagePatterns": ["^com.fasterxml.jackson"],
       "groupName": "Jackson (XML) packages"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "extends": ["config:base", ":masterIssue"],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 20,
   "rebaseStalePrs": false,
-  "prHourlyLimit": 1,
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "packagePatterns": ["^com.fasterxml.jackson"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": ["config:base", ":masterIssue"],
   "prConcurrentLimit": 20,
-  "rebaseStalePrs": false,
   "prHourlyLimit": 2,
   "packageRules": [
     {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

This makes the following changes to the renovate config:

* Increase PR limit from 10 to 20
* Allow a maximum of 2 PRs per hour (used to be 1)
* Enable automerging - devDependencies only
* Remove no longer supported config option

I think this would be worthwhile, as we have an increasing number of 'stuck' PRs so it'd be good to have some more headroom to progress the backlog. Further, with better CI it seems a good time to start trialling automerging.

For now automerging is just limited to devDependencies, on the premise they should be rather safe to bump along but require frequent updates and we should be able to see the value.

I have validated the config with:

    npx -p renovate renovate-config-validator

(And indeed, it was with that I discovered with had a no longer supported option - so I removed that.)

But as a result, this is not so much waiting on a green build, as just acceptance from the community before merging.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
