### PR TITLE
Integrate search page with search result component

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchResult.stories.tsx
@@ -18,8 +18,7 @@
 import * as React from "react";
 import * as mockData from "../../__mocks__/searchresult_mock_data";
 import SearchResult from "../../tsrc/search/components/SearchResult";
-import { action } from "@storybook/addon-actions";
-import { object } from "@storybook/addon-knobs";
+import { number, object, text } from "@storybook/addon-knobs";
 
 export default {
   title: "SerachResult",
@@ -28,21 +27,93 @@ export default {
 
 export const BasicSearchResultComponent = () => (
   <SearchResult
-    resultData={object("resultData", mockData.basicSearchObj)}
-    onClick={action("onClick")}
+    name={text("name", mockData.basicSearchObj.name!)}
+    uuid={text("uuid", mockData.basicSearchObj.uuid)}
+    description={text("description", mockData.basicSearchObj.description!)}
+    displayFields={object("display fields", [
+      ...mockData.basicSearchObj.displayFields,
+    ])}
+    modifiedDate={object("modified date", mockData.basicSearchObj.modifiedDate)}
+    createdDate={object("created date", mockData.basicSearchObj.createdDate)}
+    status={text("item status", mockData.basicSearchObj.status)}
+    displayOptions={object(
+      "display options",
+      mockData.basicSearchObj.displayOptions
+    )}
+    attachments={object("attachments", [
+      ...mockData.basicSearchObj.attachments,
+    ])}
+    links={object("links", mockData.basicSearchObj.links)}
+    collectionId={text("collection ID", mockData.basicSearchObj.collectionId)}
+    commentCount={number("comment count", mockData.basicSearchObj.commentCount)}
+    thumbnail={text("thumbnail", mockData.basicSearchObj.thumbnail)}
   />
 );
 
 export const AttachmentSearchResultComponent = () => (
   <SearchResult
-    resultData={object("resultData", mockData.attachSearchObj)}
-    onClick={action("onClick")}
+    name={text("name", mockData.attachSearchObj.name!)}
+    uuid={text("uuid", mockData.attachSearchObj.uuid)}
+    description={text("description", mockData.attachSearchObj.description!)}
+    displayFields={object("display fields", [
+      ...mockData.attachSearchObj.displayFields,
+    ])}
+    modifiedDate={object(
+      "modified date",
+      mockData.attachSearchObj.modifiedDate
+    )}
+    createdDate={object("created date", mockData.attachSearchObj.createdDate)}
+    status={text("item status", mockData.attachSearchObj.status)}
+    displayOptions={object(
+      "display options",
+      mockData.attachSearchObj.displayOptions
+    )}
+    attachments={object("attachments", [
+      ...mockData.attachSearchObj.attachments,
+    ])}
+    links={object("links", mockData.attachSearchObj.links)}
+    collectionId={text("collection ID", mockData.attachSearchObj.collectionId)}
+    commentCount={number(
+      "comment count",
+      mockData.attachSearchObj.commentCount
+    )}
+    thumbnail={text("thumbnail", mockData.attachSearchObj.thumbnail)}
   />
 );
 
 export const CustomMetadataSearchResultComponent = () => (
   <SearchResult
-    resultData={object("resultData", mockData.customMetaSearchObj)}
-    onClick={action("onClick")}
+    name={text("name", mockData.customMetaSearchObj.name!)}
+    uuid={text("uuid", mockData.customMetaSearchObj.uuid)}
+    description={text("description", mockData.customMetaSearchObj.description!)}
+    displayFields={object("display fields", [
+      ...mockData.customMetaSearchObj.displayFields,
+    ])}
+    modifiedDate={object(
+      "modified date",
+      mockData.customMetaSearchObj.modifiedDate
+    )}
+    createdDate={object(
+      "created date",
+      mockData.customMetaSearchObj.createdDate
+    )}
+    status={text("item status", mockData.customMetaSearchObj.status)}
+    displayOptions={object(
+      "display options",
+      mockData.customMetaSearchObj.displayOptions
+    )}
+    attachments={object("attachments", [
+      ...mockData.customMetaSearchObj.attachments,
+    ])}
+    links={object("links", mockData.customMetaSearchObj.links)}
+    collectionId={text(
+      "collection ID",
+      mockData.customMetaSearchObj.collectionId
+    )}
+    commentCount={number(
+      "comment count",
+      mockData.customMetaSearchObj.commentCount
+    )}
+    thumbnail={text("thumbnail", mockData.customMetaSearchObj.thumbnail)}
   />
 );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -35,11 +35,6 @@ import {
 import SearchIcon from "@material-ui/icons/Search";
 import { searchItems } from "./SearchModule";
 import * as OEQ from "@openequella/rest-api-client";
-import {
-  defaultSearchSettings,
-  getSearchSettingsFromServer,
-  SearchSettings,
-} from "../settings/Search/SearchSettingsModule";
 import SearchResult from "./components/SearchResult";
 import { generateFromError } from "../api/errors";
 
@@ -50,8 +45,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   >([]);
 
   /**
-   * What is done in this hook include: updating the page title, retrieving search settings, and
-   * doing a default search.
+   * Update the page title and do a default search.
    */
   useEffect(() => {
     updateTemplate((tp) => ({

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -61,14 +61,12 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       ...templateDefaults(searchStrings.title)(tp),
     }));
 
-    getSearchSettingsFromServer()
-      .then((settings: SearchSettings) => {
-        setSearchSettings(settings);
-        search({
-          status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
-        });
-      })
-      .catch((error: Error) => handleError(error));
+    getSearchSettingsFromServer().then((settings: SearchSettings) => {
+      setSearchSettings(settings);
+      search({
+        status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
+      });
+    });
   }, []);
 
   const handleError = (error: Error) => {
@@ -80,11 +78,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
    * @param params Search criteria
    */
   const search = (params?: OEQ.Search.SearchParams): void => {
-    searchItems(
-      params
-    ).then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) =>
-      setSearchResultItems(items.results)
-    );
+    searchItems(params)
+      .then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) =>
+        setSearchResultItems(items.results)
+      )
+      .catch((error: Error) => handleError(error));
   };
 
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -48,9 +48,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const [searchResultItems, setSearchResultItems] = useState<
     OEQ.Search.SearchResultItem[]
   >([]);
-  const [searchSettings, setSearchSettings] = useState<SearchSettings>(
-    defaultSearchSettings
-  );
 
   /**
    * What is done in this hook include: updating the page title, retrieving search settings, and
@@ -61,11 +58,8 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       ...templateDefaults(searchStrings.title)(tp),
     }));
 
-    getSearchSettingsFromServer().then((settings: SearchSettings) => {
-      setSearchSettings(settings);
-      search({
-        status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
-      });
+    search({
+      status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
     });
   }, []);
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -94,11 +94,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   );
 
   return (
-    <Grid container direction={"column"} spacing={2}>
+    <Grid container direction="column" spacing={2}>
       <Grid item xs={9}>
         <Card>
           <IconButton>
-            <SearchIcon fontSize={"large"} />
+            <SearchIcon fontSize="large" />
           </IconButton>
           <TextField />
         </Card>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -79,10 +79,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchResults = searchResultItems.map(
     (item: OEQ.Search.SearchResultItem) => (
       <ListItem key={item.uuid}>
-        <SearchResult
-          resultData={item}
-          onClick={() => (window.location.href = item.links.view)}
-        />
+        <SearchResult {...item} />
       </ListItem>
     )
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -158,9 +158,9 @@ export default function SearchResult({
   );
 
   const customDisplayMetadata = displayFields.map(
-    (element: OEQ.Search.DisplayFields) => {
+    (element: OEQ.Search.DisplayFields, index: number) => {
       return (
-        <ListItem disableGutters dense>
+        <ListItem disableGutters dense key={element.name + index}>
           <Typography
             component="span"
             variant="body2"
@@ -225,7 +225,7 @@ export default function SearchResult({
     <ListItem onClick={onClick} alignItems="flex-start" button key={uuid}>
       {thumbnail(displayOptions?.disableThumbnail ?? false)}
       <ListItemText
-        primary={name}
+        primary={name ?? uuid}
         secondary={
           <>
             <Typography className={classes.itemDescription}>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -83,26 +83,17 @@ const useStyles = makeStyles((theme: Theme) => {
   };
 });
 
-export interface SearchResultProps {
-  resultData: OEQ.Search.SearchResultItem;
-  /**
-   * Function will be invoked when the SearchResult list item is clicked
-   */
-  onClick: () => void;
-}
 export default function SearchResult({
-  resultData: {
-    name,
-    uuid,
-    description,
-    displayFields,
-    modifiedDate,
-    status,
-    displayOptions,
-    attachments,
-  },
-  onClick,
-}: SearchResultProps) {
+  name,
+  uuid,
+  description,
+  displayFields,
+  modifiedDate,
+  status,
+  displayOptions,
+  attachments,
+  links,
+}: OEQ.Search.SearchResultItem) {
   const classes = useStyles();
 
   const searchResultStrings = languageStrings.searchpage.searchresult;
@@ -222,10 +213,10 @@ export default function SearchResult({
   };
 
   return (
-    <ListItem onClick={onClick} alignItems="flex-start" button key={uuid}>
+    <ListItem alignItems="flex-start" key={uuid}>
       {thumbnail(displayOptions?.disableThumbnail ?? false)}
       <ListItemText
-        primary={name ?? uuid}
+        primary={<a href={links.view}> {name ?? uuid} </a>}
         secondary={
           <>
             <Typography className={classes.itemDescription}>

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -124,7 +124,16 @@ export interface Attachment {
   /**
    * Links to the attachment.
    */
-  links: Record<string, string>;
+  links: {
+    /**
+     * The URL of viewing this attachment.
+     */
+    view: string;
+    /**
+     * The URL of viewing this attachment's thumbnail.
+     */
+    thumbnail: string;
+  };
 }
 
 /**
@@ -182,7 +191,16 @@ export interface SearchResultItem {
   /**
    * Links to an item.
    */
-  links: Record<string, string>;
+  links: {
+    /**
+     * The URL of viewing this item.
+     */
+    view: string;
+    /**
+     * The REST API path used to get details of this item.
+     */
+    self: string;
+  };
 }
 
 const SEARCH2_API_PATH = '/search2';

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -126,11 +126,11 @@ export interface Attachment {
    */
   links: {
     /**
-     * The URL of viewing this attachment.
+     * The URL for viewing this attachment.
      */
     view: string;
     /**
-     * The URL of viewing this attachment's thumbnail.
+     * The URL for viewing this attachment's thumbnail.
      */
     thumbnail: string;
   };
@@ -193,11 +193,11 @@ export interface SearchResultItem {
    */
   links: {
     /**
-     * The URL of viewing this item.
+     * The URL for viewing this item.
      */
     view: string;
     /**
-     * The REST API path used to get details of this item.
+     * The REST API path used to get this item's details.
      */
     self: string;
   };


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Integrate search page with search result component and search module.

When opening the search page, search settings are retrieved first.  Then, a default search is done so that a list of items are displayed. 

To match the existing functionality in old Search UI, a couple of things are considered.
1. The default sort order is handled on server side (view `getOrderType` in `DefaultSearch.java` to get more details)  so client does not need to implement it again.
2. The default item status is 'live' and 'review' and it's handled on client.

![image](https://user-images.githubusercontent.com/47203811/85243997-bd229900-b486-11ea-86bc-dd349169fbbe.png)

