### PR TITLE
chore: Remove unused org.javassist:javassist

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -188,7 +188,6 @@ libraryDependencies ++= Seq(
   "org.omegat"                           % "jmyspell-core"                  % "1.0.0-beta-2",
   "org.freemarker"                       % "freemarker"                     % "2.3.23",
   "com.github.equella.legacy"            % "hurl"                           % "1.1",
-  "org.javassist"                        % "javassist"                      % "3.18.2-GA",
   "org.jboss.resteasy"                   % "resteasy-jaxrs"                 % RestEasyVersion,
   "org.jboss.spec.javax.annotation"      % "jboss-annotations-api_1.2_spec" % "1.0.2.Final",
   "org.jboss.logging"                    % "jboss-logging"                  % "3.4.1.Final",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

It would appear this may have just been added from conversion of the old
Ivy setup which didn't do transitive dependencies (so all had to be
managed explicitly in XML files). Having removed it, all still built and
ran via sbt cleanrun.

In response to https://github.com/openequella/openEQUELLA/pull/1698
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
