### PR TITLE
Fix AttachFile icon size in SearchResult component

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme: Theme) => {
       marginBottom: theme.spacing(2),
     },
     attachmentIcon: {
-      paddingRight: theme.spacing(2),
+      marginRight: theme.spacing(2),
     },
   };
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1306

**Before fix**
![icon small](https://user-images.githubusercontent.com/4625498/85367595-e4539600-b56c-11ea-976e-a7dabd81a0cc.PNG)

**After fix**
![icon](https://user-images.githubusercontent.com/4625498/85367299-57a8d800-b56c-11ea-9a14-be81f0fe654a.PNG)


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
