### PR TITLE
chore(ci): Prepackage coverage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,8 +255,15 @@ jobs:
           ./sbt -jvm-opts autotest/.jvmopts "project autotest" \
             coverageReport
 
+      # To save significant time on file upload, we first tar up the directory
+      # as it contains > 10k files and the artefact upload was taking almost
+      # 1hr.
+      - name: Package Coverage Report
+        run: |
+          tar cvf coverage_report.tar autotest/target/coverage-report/
+
       - name: Save Coverage Report
         uses: actions/upload-artifact@v2.0.1
         with:
           name: CoverageReport-newui-${{ matrix.newui }}
-          path: autotest/target/coverage-report/
+          path: coverage_report.tar


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

The uploading of the coverage reports was taking a very long time and
sometimes failing. I believe this is because the artefact upload action
wasn't really designed for uploading directories with tens of thousands
of files.

Considering the upload of the primary artefacts only takes a few minutes
(and is a few hundred megabytes), I'm assuming this will save us
significant time and shorten our test runs by about 50%.


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
