### PR TITLE
chore(deps): Remove unused stax2-api dependency

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -179,7 +179,6 @@ libraryDependencies ++= Seq(
                   name = "slf4j-log4j12")
   ),
   "org.ccil.cowan.tagsoup" % "tagsoup"           % "1.2.1",
-  "org.codehaus.woodstox"  % "stax2-api"         % "3.1.4",
   "org.codehaus.woodstox"  % "woodstox-core-asl" % "4.4.1",
   "org.codehaus.xfire"     % "xfire-aegis"       % "1.2.6",
   "org.dspace"             % "cql-java"          % "1.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

It appears this was just added as part of the SBT migration.

In response to #1952 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
