### PR TITLE
Redirect to Item by React Router

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/getSearchResult.js
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/getSearchResult.js
@@ -22,6 +22,7 @@ exports.getSearchResult = {
   results: [
     {
       uuid: "9b9bf5a9-c5af-490b-88fe-7e330679fad2",
+      version: 1,
       name: "new title",
       status: "personal",
       createdDate: new Date("2014-06-11T10:28:58.190+10:00"),
@@ -53,6 +54,7 @@ exports.getSearchResult = {
     },
     {
       uuid: "266bb0ff-a730-4658-aec0-c68bbefc227c",
+      version: 1,
       status: "live",
       createdDate: new Date("2014-06-11T09:31:08.557+10:00"),
       modifiedDate: new Date("2014-06-11T09:31:08.557+10:00"),
@@ -70,6 +72,7 @@ exports.getSearchResult = {
     },
     {
       uuid: "2534e329-e37e-4851-896e-51d8b39104c4",
+      version: 1,
       status: "live",
       createdDate: new Date("2014-06-11T09:27:14.800+10:00"),
       modifiedDate: new Date("2014-06-11T09:27:14.803+10:00"),
@@ -87,6 +90,7 @@ exports.getSearchResult = {
     },
     {
       uuid: "925f5dd2-66eb-4b68-85be-93837af785d0",
+      version: 1,
       name: "new title",
       status: "personal",
       createdDate: new Date("2014-06-10T16:01:25.817+10:00"),

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/searchresult_mock_data.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/searchresult_mock_data.ts
@@ -20,6 +20,7 @@ import * as OEQ from "@openequella/rest-api-client";
 
 const basicSearchObj: OEQ.Search.SearchResultItem = {
   uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
+  version: 1,
   name: "Little Larry",
   description: "A description of a bird",
   status: "live",
@@ -46,6 +47,7 @@ const basicSearchObj: OEQ.Search.SearchResultItem = {
 
 const attachSearchObj: OEQ.Search.SearchResultItem = {
   uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
+  version: 1,
   name: "Little Larry",
   description: "A description of a bird",
   status: "live",
@@ -84,6 +86,7 @@ const attachSearchObj: OEQ.Search.SearchResultItem = {
 
 const customMetaSearchObj: OEQ.Search.SearchResultItem = {
   uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
+  version: 1,
   name: "Little Larry",
   description: "A description of a bird",
   status: "live",

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchResult.stories.tsx
@@ -28,6 +28,7 @@ export default {
 export const BasicSearchResultComponent = () => (
   <SearchResult
     name={text("name", mockData.basicSearchObj.name!)}
+    version={number("version", mockData.basicSearchObj.version)}
     uuid={text("uuid", mockData.basicSearchObj.uuid)}
     description={text("description", mockData.basicSearchObj.description!)}
     displayFields={object("display fields", [
@@ -53,6 +54,7 @@ export const BasicSearchResultComponent = () => (
 export const AttachmentSearchResultComponent = () => (
   <SearchResult
     name={text("name", mockData.attachSearchObj.name!)}
+    version={number("version", mockData.attachSearchObj.version)}
     uuid={text("uuid", mockData.attachSearchObj.uuid)}
     description={text("description", mockData.attachSearchObj.description!)}
     displayFields={object("display fields", [
@@ -84,6 +86,7 @@ export const AttachmentSearchResultComponent = () => (
 export const CustomMetadataSearchResultComponent = () => (
   <SearchResult
     name={text("name", mockData.customMetaSearchObj.name!)}
+    version={number("version", mockData.customMetaSearchObj.version)}
     uuid={text("uuid", mockData.customMetaSearchObj.uuid)}
     description={text("description", mockData.customMetaSearchObj.description!)}
     displayFields={object("display fields", [

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -40,6 +40,8 @@ import {
   Subject,
 } from "@material-ui/icons";
 import * as OEQ from "@openequella/rest-api-client";
+import { Link } from "react-router-dom";
+import { routes } from "../../mainui/routes";
 
 const useStyles = makeStyles((theme: Theme) => {
   return {
@@ -85,6 +87,7 @@ const useStyles = makeStyles((theme: Theme) => {
 
 export default function SearchResult({
   name,
+  version,
   uuid,
   description,
   displayFields,
@@ -212,11 +215,15 @@ export default function SearchResult({
     return null;
   };
 
+  const itemLink = (
+    <Link to={routes.ViewItem.to(uuid, version)}>{name ?? uuid}</Link>
+  );
+
   return (
     <ListItem alignItems="flex-start" key={uuid}>
       {thumbnail(displayOptions?.disableThumbnail ?? false)}
       <ListItemText
-        primary={<a href={links.view}> {name ?? uuid} </a>}
+        primary={itemLink}
         secondary={
           <>
             <Typography className={classes.itemDescription}>

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -179,6 +179,7 @@ object SearchHelper {
     val commentCount = LegacyGuice.itemCommentService.getComments(key, null, null, -1).size()
     SearchResultItem(
       uuid = key.getUuid,
+      version = key.getVersion,
       name = Option(bean.getName),
       description = Option(bean.getDescription),
       status = bean.getStatus,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -41,6 +41,7 @@ import com.tle.web.api.item.equella.interfaces.beans.{DisplayField, DisplayOptio
   */
 case class SearchResultItem(
     uuid: String,
+    version: Int,
     name: Option[I18NString],
     description: Option[I18NString],
     status: String,

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -145,6 +145,10 @@ export interface SearchResultItem {
    */
   uuid: string;
   /**
+   * Item's version.
+   */
+  version: number;
+  /**
    * Item's name.
    */
   name?: Common.i18nString;


### PR DESCRIPTION
#1306 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Using a hyperlink to open Item Summary page results in reloading the whole page, so we instead use `Link` provided by react-router to avoid reloading whole page. Also include an Item's version in Search result so that client can generate the correct path for viewing each item.