### PR TITLE
Ensure the default search order is included in the first search

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
@@ -550,19 +550,21 @@ public class DefaultSearch extends VeryBasicSearch {
 
   public static SortType getOrderType(String order, String q) {
     if (order != null) {
-      // allowed values are relevance, modified, name, rating
-      if (order.equals("relevance")) {
+      // Allowed values are relevance, modified, name, rating and created.
+      // However due to the inconsistent order values, rank, datemodified and datecreated are also
+      // accepted.
+      if (order.equals("relevance") || order.equals("rank")) {
         if (Check.isEmpty(q)) {
           return SortType.DATEMODIFIED;
         }
         return SortType.RANK;
-      } else if (order.equals("modified")) {
+      } else if (order.equals("modified") || order.equals("datemodified")) {
         return SortType.DATEMODIFIED;
       } else if (order.equals("name")) {
         return SortType.NAME;
       } else if (order.equals("rating")) {
         return SortType.RATING;
-      } else if (order.equals("created")) {
+      } else if (order.equals("created") || order.equals("datecreated")) {
         return SortType.DATECREATED;
       }
     }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -38,6 +38,10 @@ import { searchItems } from "./SearchModule";
 import * as OEQ from "@openequella/rest-api-client";
 import SearchResult from "./components/SearchResult";
 import { generateFromError } from "../api/errors";
+import {
+  getSearchSettingsFromServer,
+  SearchSettings,
+} from "../settings/Search/SearchSettingsModule";
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
@@ -53,9 +57,12 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       ...templateDefaults(searchStrings.title)(tp),
     }));
 
-    search({
-      status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
-    });
+    getSearchSettingsFromServer().then((settings: SearchSettings) =>
+      search({
+        status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
+        order: settings.defaultSearchSort,
+      })
+    );
   }, []);
 
   const handleError = (error: Error) => {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -59,7 +59,8 @@ object SearchHelper {
     search.setQuery(params.query)
     search.setOwner(params.owner)
 
-    val orderType = DefaultSearch.getOrderType(params.order.toLowerCase, params.query)
+    val orderType =
+      DefaultSearch.getOrderType(Option(params.order).map(_.toLowerCase).orNull, params.query)
     search.setSortFields(orderType.getSortField(params.reverseOrder))
 
     val collectionUuids = handleCollections(params.advancedSearch, params.collections)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -59,7 +59,7 @@ object SearchHelper {
     search.setQuery(params.query)
     search.setOwner(params.owner)
 
-    val orderType = DefaultSearch.getOrderType(params.order, params.query)
+    val orderType = DefaultSearch.getOrderType(params.order.toLowerCase, params.query)
     search.setSortFields(orderType.getSortField(params.reverseOrder))
 
     val collectionUuids = handleCollections(params.advancedSearch, params.collections)


### PR DESCRIPTION
#1306 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The search triggered by opening the Search page should include the default search order configured in the Search settings page. Therefore, in the Search page, retrieve Search settings first, and then add `order` to search criteria.

For some unknown reasons (maybe just unknown to me), the order values have been inconsistent  for a long time. For example, in the context of Search settings, the value of order `Last modified date` is `datemodified`. However in the context of Search, the accepted value is 'modified'. Previously in Purescript, this was handled by a Purscript Map. More details can be seen from these two links [old search setting page](https://github.com/openequella/openEQUELLA/blob/master/Source/Plugins/Core/com.equella.core/src/com/tle/web/search/settings/SearchSettingsSection.java) (line 249-254), [purs version search page](https://github.com/openequella/openEQUELLA/blob/master/Source/Plugins/Core/com.equella.core/js/src/Search/OrderControl.purs).

My approach for handling this is to slightly change the method 'getOrderType' because this requires least changes, but I am happy to discuss other approaches.