### PR TITLE
Add pagination to Search page and tweak SearchResult

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchModule.test.ts
@@ -26,7 +26,9 @@ jest.mock("@openequella/rest-api-client");
 
 describe("SearchModule", () => {
   it("should provide an list of items", async () => {
-    const searchResult = await SearchModule.searchItems();
+    const searchResult = await SearchModule.searchItems(
+      SearchModule.defaultSearchOptions
+    );
     expect(searchResult.available).toBe(4);
     expect(searchResult.results).toHaveLength(4);
   });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -17,19 +17,53 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import { API_BASE_URL } from "../config";
+import { SortOrder } from "../settings/Search/SearchSettingsModule";
 
 /**
- * A function that does a search with specified search criteria and returns a list of Items.
- * @param params Search criteria.
+ * A function that takes search options and converts search options to search params,
+ * and then does a search and returns a list of Items.
+ * @param searchOptions  Search options selected on Search page.
  */
 export const searchItems = (
-  params?: OEQ.Search.SearchParams
-): Promise<OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>> =>
-  OEQ.Search.search(API_BASE_URL, params);
+  searchOptions: SearchOptions
+): Promise<OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>> => {
+  const { rowsPerPage, currentPage, sortOrder } = searchOptions;
+  const searchParams: OEQ.Search.SearchParams = {
+    start: currentPage * rowsPerPage,
+    length: rowsPerPage,
+    status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
+    order: sortOrder,
+  };
+  return OEQ.Search.search(API_BASE_URL, searchParams);
+};
 
 export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
   start: 0,
   length: 10,
   available: 10,
   results: [],
+};
+
+/**
+ * Type of all search options on Search page
+ */
+export interface SearchOptions {
+  /**
+   * The number of items displayed in one page.
+   */
+  rowsPerPage: number;
+  /**
+   * Selected page.
+   */
+  currentPage: number;
+  /**
+   * Selected search result sorting order.
+   */
+  sortOrder: SortOrder | undefined;
+}
+
+export const defaultSearchOptions: SearchOptions = {
+  rowsPerPage: 10,
+  currentPage: 0,
+  sortOrder: undefined,
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -26,3 +26,10 @@ export const searchItems = (
   params?: OEQ.Search.SearchParams
 ): Promise<OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>> =>
   OEQ.Search.search(API_BASE_URL, params);
+
+export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
+  start: 0,
+  length: 10,
+  available: 10,
+  results: [],
+};

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -31,7 +31,10 @@ export const searchItems = (
   const searchParams: OEQ.Search.SearchParams = {
     start: currentPage * rowsPerPage,
     length: rowsPerPage,
-    status: [OEQ.Common.ItemStatus.LIVE, OEQ.Common.ItemStatus.REVIEW],
+    status: [
+      "LIVE" as OEQ.Common.ItemStatus,
+      "REVIEW" as OEQ.Common.ItemStatus,
+    ],
     order: sortOrder,
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -44,17 +44,8 @@ import {
   SearchSettings,
   SortOrder,
 } from "../settings/Search/SearchSettingsModule";
-import { makeStyles } from "@material-ui/core/styles";
-
-const useStyles = makeStyles({
-  cardAction: {
-    display: "flex",
-    justifyContent: "center",
-  },
-});
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
-  const classes = useStyles();
   const searchStrings = languageStrings.searchpage;
 
   const [rowsPerPage, setRowsPerPage] = useState<number>(10);
@@ -149,20 +140,29 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         <Card>
           <CardContent>{searchResultList}</CardContent>
 
-          <CardActions className={classes.cardAction}>
-            <TablePagination
-              component="div"
-              count={pagedSearchResult.available}
-              page={currentPage}
-              onChangePage={(_, page: number) => setCurrentPage(page)}
-              rowsPerPageOptions={[10, 25, 50]}
-              labelRowsPerPage={searchStrings.pagination.itemsPerPage}
-              rowsPerPage={rowsPerPage}
-              onChangeRowsPerPage={(event) => {
-                setRowsPerPage(parseInt(event.target.value));
-                setCurrentPage(0);
-              }}
-            />
+          <CardActions>
+            <Grid container justify="center">
+              <Grid item>
+                <TablePagination
+                  component="div"
+                  count={pagedSearchResult.available}
+                  page={searchOptions.currentPage}
+                  onChangePage={(_, page: number) =>
+                    setSearchOptions({ ...searchOptions, currentPage: page })
+                  }
+                  rowsPerPageOptions={[10, 25, 50]}
+                  labelRowsPerPage={searchStrings.pagination.itemsPerPage}
+                  rowsPerPage={searchOptions.rowsPerPage}
+                  onChangeRowsPerPage={(event) =>
+                    setSearchOptions({
+                      ...searchOptions,
+                      currentPage: 0,
+                      rowsPerPage: parseInt(event.target.value),
+                    })
+                  }
+                />
+              </Grid>
+            </Grid>
           </CardActions>
         </Card>
       </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -220,7 +220,7 @@ export default function SearchResult({
   );
 
   return (
-    <ListItem alignItems="flex-start" key={uuid}>
+    <ListItem alignItems="flex-start" divider>
       {thumbnail(displayOptions?.disableThumbnail ?? false)}
       <ListItemText
         primary={itemLink}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -342,6 +342,9 @@ export const languageStrings = {
       week: "Week",
       day: "Day",
     },
+    pagination: {
+      itemsPerPage: "items per page",
+    },
   },
   "com.equella.core.searching.search": {
     title: "Search",


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Add the feature of pagination to Search page. When change the page size or move to next/previous pages, a search is triggered.

![image](https://user-images.githubusercontent.com/47203811/86214750-e9dd5b80-bbbe-11ea-960e-3ff719809e54.png)
