### PR TITLE
Refactor Theme Editor page to use the new standard SettingsPageTemplate

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/SettingsList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/SettingsList.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List, ListSubheader } from "@material-ui/core";
+import { List, Typography } from "@material-ui/core";
 import * as React from "react";
 import { ReactNode } from "react";
 
@@ -38,10 +38,13 @@ export default function SettingsList({
   children,
 }: SettingsListProps) {
   return (
-    <List
-      subheader={<ListSubheader disableGutters>{subHeading}</ListSubheader>}
-    >
-      {children}
-    </List>
+    <>
+      {subHeading && (
+        <Typography gutterBottom variant="h5" component="h2">
+          {subHeading}
+        </Typography>
+      )}
+      <List>{children}</List>
+    </>
   );
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/SettingsListHeading.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/SettingsListHeading.tsx
@@ -15,33 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { List } from "@material-ui/core";
 import * as React from "react";
-import { ReactNode } from "react";
-import SettingsListHeading from "./SettingsListHeading";
+import { Typography } from "@material-ui/core";
 
-interface SettingsListProps {
-  /**
-   * Optional subheading. Appears above the list at the top left.
-   */
-  subHeading?: string;
-  /**
-   * The children of this component - should be zero or more SettingsListControls.
-   */
-  children: ReactNode;
+interface SettingsListHeadingProps {
+  /** The displayed heading. */
+  heading: string;
 }
+
 /**
- * This component is used to define a settings list to be used in the page/settings/* pages.
- *
+ * A Standardised header primarily consumed by SettingsList. However, for other Cards in Settings
+ * Pages where developers are not using SettingsList, they can use this to ensure header
+ * consistency.
  */
-export default function SettingsList({
-  subHeading,
-  children,
-}: SettingsListProps) {
+export default function SettingsListHeading({
+  heading,
+}: SettingsListHeadingProps) {
   return (
-    <>
-      {subHeading && <SettingsListHeading heading={subHeading} />}
-      <List>{children}</List>
-    </>
+    <Typography gutterBottom variant="h5" component="h2">
+      {heading}
+    </Typography>
   );
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetedSearchSettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetedSearchSettingsPage.tsx
@@ -32,7 +32,6 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  ListSubheader,
   makeStyles,
   Typography,
 } from "@material-ui/core";
@@ -64,6 +63,7 @@ import {
   DroppableProvided,
   DropResult,
 } from "react-beautiful-dnd";
+import SettingsListHeading from "../../../components/SettingsListHeading";
 
 const useStyles = makeStyles({
   cardAction: {
@@ -266,20 +266,7 @@ const FacetedSearchSettingsPage = ({ updateTemplate }: TemplateUpdateProps) => {
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="droppableFacetList">
         {(droppable: DroppableProvided) => (
-          <List
-            ref={droppable.innerRef}
-            subheader={
-              <>
-                <ListSubheader disableGutters>
-                  {facetedsearchsettingStrings.subHeading}
-                </ListSubheader>
-                <Typography variant={"caption"}>
-                  {facetedsearchsettingStrings.explanationText}
-                </Typography>
-              </>
-            }
-            {...droppable.droppableProps}
-          >
+          <List ref={droppable.innerRef} {...droppable.droppableProps}>
             {facetListItems}
             {droppable.placeholder}
           </List>
@@ -297,7 +284,15 @@ const FacetedSearchSettingsPage = ({ updateTemplate }: TemplateUpdateProps) => {
       preventNavigation={changesUnsaved}
     >
       <Card>
-        <CardContent>{facetList}</CardContent>
+        <CardContent>
+          <SettingsListHeading
+            heading={facetedsearchsettingStrings.subHeading}
+          />
+          <Typography variant={"caption"}>
+            {facetedsearchsettingStrings.explanationText}
+          </Typography>
+          {facetList}
+        </CardContent>
         <CardActions className={classes.cardAction}>
           <IconButton
             onClick={() => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import * as React from "react";
+import { useEffect, useState } from "react";
 import {
   templateDefaults,
   templateError,
@@ -25,14 +26,13 @@ import { routes } from "../../../mainui/routes";
 import {
   Card,
   CardActions,
+  CardContent,
+  IconButton,
+  List,
   ListItem,
   ListItemSecondaryAction,
   ListItemText,
-  ListSubheader,
-  IconButton,
-  List,
   makeStyles,
-  CardContent,
 } from "@material-ui/core";
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -41,7 +41,6 @@ import { languageStrings } from "../../../util/langstrings";
 import SettingsList from "../../../components/SettingsList";
 import SettingsListControl from "../../../components/SettingsListControl";
 import SettingsToggleSwitch from "../../../components/SettingsToggleSwitch";
-import { useEffect, useState } from "react";
 import {
   defaultSearchSettings,
   getSearchSettingsFromServer,
@@ -66,6 +65,7 @@ import {
 import MessageDialog from "../../../components/MessageDialog";
 import SettingPageTemplate from "../../../components/SettingPageTemplate";
 import { commonString } from "../../../util/commonstrings";
+import SettingsListHeading from "../../../components/SettingsListHeading";
 
 const useStyles = makeStyles({
   cardAction: {
@@ -319,13 +319,10 @@ const SearchFilterPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
       <Card>
         <CardContent>
-          <List
-            subheader={
-              <ListSubheader disableGutters>
-                {searchFilterStrings.mimetypefiltertitle}
-              </ListSubheader>
-            }
-          >
+          <SettingsListHeading
+            heading={searchFilterStrings.mimetypefiltertitle}
+          />
+          <List>
             {mimeTypeFilters.map((filter, index) => {
               return (
                 <ListItem divider={true} key={index}>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ColorPickerComponent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ColorPickerComponent.tsx
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { SketchPicker, ColorResult } from "react-color";
-import createStyles from "@material-ui/core/styles/createStyles";
-import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles";
+import { useState } from "react";
+import { ColorResult, SketchPicker } from "react-color";
+import { makeStyles } from "@material-ui/core/styles";
 
-const styles = createStyles({
+const useStyles = makeStyles({
   color: {
     width: "36px",
     height: "14px",
@@ -48,72 +48,40 @@ const styles = createStyles({
 });
 
 interface ColorProps {
-  color?: string;
-  changeColor(color: string): void;
+  currentColor?: string;
+  onColorChange(color: string): void;
 }
 
-class ColorPickerComponent extends React.Component<
-  ColorProps & WithStyles<typeof styles>
-> {
-  constructor(
-    props: ColorProps & WithStyles<"color" | "swatch" | "popover" | "cover">
-  ) {
-    super(props);
-  }
+const ColorPickerComponent = ({ currentColor, onColorChange }: ColorProps) => {
+  const [displayColorPicker, setDisplayColorPicker] = useState<boolean>(false);
+  const classes = useStyles();
 
-  state = {
-    displayColorPicker: false,
-    colorState: this.props.color,
-  };
+  const changeHandler = (color: ColorResult) => onColorChange(color.hex);
 
-  componentWillReceiveProps = (
-    nextProps: ColorProps & WithStyles<typeof styles>
-  ) => {
-    if (nextProps.color !== this.props.color) {
-      this.setState({ colorState: nextProps.color });
-    }
-  };
-
-  handleClick = () => {
-    this.setState({ displayColorPicker: true });
-  };
-
-  handleClose = () => {
-    this.setState({ displayColorPicker: false });
-  };
-
-  handleChange = (color: ColorResult) => {
-    this.setState({ colorState: color.hex });
-  };
-
-  handleComplete = (color: ColorResult) => {
-    this.props.changeColor(color.hex);
-  };
-
-  render() {
-    const { classes } = this.props;
-    return (
-      <div>
-        <div className={classes.swatch} onClick={this.handleClick}>
+  return (
+    <>
+      <div
+        className={classes.swatch}
+        onClick={() => setDisplayColorPicker(true)}
+      >
+        <div style={{ background: currentColor }} className={classes.color} />
+      </div>
+      {displayColorPicker && (
+        <div className={classes.popover}>
           <div
-            style={{ background: this.state.colorState }}
-            className={classes.color}
+            className={classes.cover}
+            onClick={() => setDisplayColorPicker(false)}
+          />
+          <SketchPicker
+            disableAlpha={true}
+            color={currentColor}
+            onChange={changeHandler}
+            onChangeComplete={changeHandler}
           />
         </div>
-        {this.state.displayColorPicker ? (
-          <div className={classes.popover}>
-            <div className={classes.cover} onClick={this.handleClose} />
-            <SketchPicker
-              disableAlpha={true}
-              color={this.state.colorState}
-              onChange={this.handleChange}
-              onChangeComplete={this.handleComplete}
-            />
-          </div>
-        ) : null}
-      </div>
-    );
-  }
-}
+      )}
+    </>
+  );
+};
 
-export default withStyles(styles)(ColorPickerComponent);
+export default ColorPickerComponent;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ColorPickerComponent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ColorPickerComponent.tsx
@@ -19,6 +19,14 @@ import * as React from "react";
 import { useState } from "react";
 import { ColorResult, SketchPicker } from "react-color";
 import { makeStyles } from "@material-ui/core/styles";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@material-ui/core";
+import { languageStrings } from "../util/langstrings";
 
 const useStyles = makeStyles({
   color: {
@@ -34,17 +42,6 @@ const useStyles = makeStyles({
     display: "inline-block",
     cursor: "pointer",
   },
-  popover: {
-    position: "absolute",
-    zIndex: 2,
-  },
-  cover: {
-    position: "fixed",
-    top: "0px",
-    right: "0px",
-    bottom: "0px",
-    left: "0px",
-  },
 });
 
 interface ColorProps {
@@ -55,6 +52,7 @@ interface ColorProps {
 const ColorPickerComponent = ({ currentColor, onColorChange }: ColorProps) => {
   const [displayColorPicker, setDisplayColorPicker] = useState<boolean>(false);
   const classes = useStyles();
+  const strings = languageStrings.newuisettings.colorPicker;
 
   const changeHandler = (color: ColorResult) => onColorChange(color.hex);
 
@@ -67,18 +65,30 @@ const ColorPickerComponent = ({ currentColor, onColorChange }: ColorProps) => {
         <div style={{ background: currentColor }} className={classes.color} />
       </div>
       {displayColorPicker && (
-        <div className={classes.popover}>
-          <div
-            className={classes.cover}
-            onClick={() => setDisplayColorPicker(false)}
-          />
-          <SketchPicker
-            disableAlpha={true}
-            color={currentColor}
-            onChange={changeHandler}
-            onChangeComplete={changeHandler}
-          />
-        </div>
+        <Dialog
+          open={displayColorPicker}
+          aria-labelledby="select-color-dialog-title"
+        >
+          <DialogTitle id="select-color-dialog-title">
+            {strings.dialogTitle}
+          </DialogTitle>
+          <DialogContent>
+            <SketchPicker
+              disableAlpha
+              color={currentColor}
+              onChange={changeHandler}
+              onChangeComplete={changeHandler}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button
+              color="primary"
+              onClick={() => setDisplayColorPicker(false)}
+            >
+              {languageStrings.common.action.done}
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
     </>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
@@ -46,6 +46,7 @@ import { IThemeSettings } from ".";
 import SettingPageTemplate from "../components/SettingPageTemplate";
 import SettingsListControl from "../components/SettingsListControl";
 import SettingsList from "../components/SettingsList";
+import { routes } from "../mainui/routes";
 
 declare const themeSettings: IThemeSettings;
 declare const logoURL: string;
@@ -112,7 +113,10 @@ class ThemePage extends React.Component<
   };
 
   componentDidMount = () => {
-    this.props.updateTemplate(templateDefaults(strings.title));
+    this.props.updateTemplate((tp) => ({
+      ...templateDefaults(strings.title)(tp),
+      backRoute: routes.Settings.to,
+    }));
   };
 
   handleDefaultButton = () => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -277,6 +277,9 @@ export const languageStrings = {
       permissiontitle: "Permission Error",
       permissiondescription: "You do not have permission to edit the settings.",
     },
+    colorPicker: {
+      dialogTitle: "Select a Color",
+    },
   },
   common: {
     action: {
@@ -299,6 +302,7 @@ export const languageStrings = {
       revertchanges: "Revert Changes",
       register: "Register",
       refresh: "Refresh",
+      done: "Done",
     },
     result: {
       success: "Saved successfully.",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -262,12 +262,12 @@ export const languageStrings = {
       secondarytextcolour: "Secondary Text Colour",
       sidebariconcolour: "Icon Colour",
     },
-    logosettings: {
+    logoSettings: {
       alt: "Logo",
       title: "Logo Settings",
-      imagespeclabel: "Use a PNG file of 230x36 pixels for best results.",
-      current: "Current Logo: ",
-      nofileselected: "No file selected.",
+      siteLogo: "Site Logo",
+      siteLogoDescription:
+        "The main logo for the site, primarily displayed in the top left of pages. (Use a PNG file of 230x36 pixels for best results.)",
     },
     errors: {
       invalidimagetitle: "Image Processing Error",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Well, this was one of those small little refactors that suddenly became a bit more... Not too much more, but.. you'll see.

The intention was to make `ThemePage` use the new `SettingsPageTemplate` and `SettingsList` so as to be consistent with our new settings work. That was achieved, however getting there got a bit tricker due to some bumps with the the `ColorPickerComponent`, so that ended up also getting refactored as well. It went from a class based component to a functional one, and rather than a pop-over is now a dialog (which is also more consistent), as well as some of it's oddities were removed and tidied up.

But also did some tweaking to `SettingsList` for a stronger heading, while also providing the heading as a stand-alone component. This was triggered by noting some of the other new settings pages had copy and pasted the `Typography` block to match what was in `SettingsList`.

In Summary:

* `ThemePage` refactored to use `SettingsPageTemplate` and `SettingsList`
* `ColorPickerComponent` refactored to functional component and dialog based
* Changed heading style of `SettingsList`
* Added new component `SettingsListHeading` (primarily for easy re-use)
* Removed display of current logo from `ThemePage` as it was redundant - current logo is always shown top left of the page
* Added back navigation to `SettingsPage` (for consistency, easy of use)

I also wanted to at least add `SettingsListHeading` to Storybook. However Storybook is currently broken on `component/new-search-page`. (I'll attempt to look at this on the side.)

Updated `ThemePage`

![image](https://user-images.githubusercontent.com/43919233/86309726-c4545e80-bc5f-11ea-8da8-9eba9aa1bf93.png)

Updated `ColorPickerComponent`

![image](https://user-images.githubusercontent.com/43919233/86309783-dcc47900-bc5f-11ea-8ab2-db1a418ac1ab.png)

Example of modified headings on other settings page

![image](https://user-images.githubusercontent.com/43919233/86309827-f6fe5700-bc5f-11ea-8c43-dc3a22f09eda.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
