### PR TITLE
Fix structured selection session course panel display overflow issues

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1069,7 +1069,7 @@ Generic layout
   flex-grow: 1;
   justify-content: space-between;
   #col2 {
-    min-width: 0px;
+    min-width: 0;
   }
 }
 

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1069,7 +1069,7 @@ Generic layout
   flex-grow: 1;
   justify-content: space-between;
   #col2 {
-    min-width: 240px;
+    min-width: 0px;
   }
 }
 
@@ -4500,16 +4500,24 @@ div#sssh_finishedButton {
 }
 
 .selection-courses-inner .folder.rootfolder {
-  @include typography-subtitle-1;
+  @include typography-subtitle-2;
+  padding-top: 4px;
 }
 
 .folders {
-  padding-top: 16px;
+  padding-top: 4px;
 }
 
 .folderlist {
   display: flex;
   flex-direction: column;
+  @include typography-subtitle-2;
+  float: left;
+  width: 100%;
+}
+
+.foldertree {
+  height: 100% !important;
 }
 
 .selection-courses-inner .folder.targetfolder.selected {
@@ -4559,7 +4567,7 @@ div#sssh_finishedButton {
 
 #selection-content-inner.wizard-layout #col2,
 #selection-content-inner.wizard-layout #affix-div {
-  width: 146px;
+  right: unset;
 }
 
 #selection-content-inner.wizard-layout .indent1 {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1540

The main issue here was that <div id=col2> contains rouge whitespace. I couldn't find exactly what code was inserting that whitespace, so the lest risky option is to just alter the minimum width. I also altered some of the text size in the course selection panel so more information be displayed.

![Screenshot from 2020-07-02 17-07-16](https://user-images.githubusercontent.com/4625498/86327644-f927dc00-bc86-11ea-94fb-cdf3d095c766.png)

Also, I noticed that the sticky save button fix for #1524  had some poritioning issues when viewed inside a selection session, which I also fixed

_A note for whoever tests this, make sure the selectOrAdd selection session also still displays correctly_

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
