### PR TITLE
Set a width and height for regular thumbnails in SearchResult compone…

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -58,9 +58,6 @@ const useStyles = makeStyles((theme: Theme) => {
       height: "auto",
     },
     placeholderThumbnail: {
-      paddingRight: theme.spacing(2),
-      width: "88px",
-      height: "auto",
       color: theme.palette.text.secondary,
     },
     itemDescription: {
@@ -129,7 +126,10 @@ export default function SearchResult({
       );
     } else {
       result = (
-        <Subject className={classes.placeholderThumbnail} fontSize="large" />
+        <Subject
+          className={`${classes.placeholderThumbnail} ${classes.thumbnail}`}
+          fontSize="large"
+        />
       );
     }
     return result;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -54,6 +54,8 @@ const useStyles = makeStyles((theme: Theme) => {
     },
     thumbnail: {
       paddingRight: theme.spacing(2),
+      width: "88px",
+      height: "auto",
     },
     placeholderThumbnail: {
       paddingRight: theme.spacing(2),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1306

Ideally i wanted to define the width and height in one place for the thumbnail and placeholderThumbnail. So if anyone has a better suggection on how to do this i'm all ears
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
