### PR TITLE
Add sorting options for Search page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -18,34 +18,7 @@
 import * as OEQ from "@openequella/rest-api-client";
 import { API_BASE_URL } from "../config";
 import { SortOrder } from "../settings/Search/SearchSettingsModule";
-
-/**
- * A function that takes search options and converts search options to search params,
- * and then does a search and returns a list of Items.
- * @param searchOptions  Search options selected on Search page.
- */
-export const searchItems = (
-  searchOptions: SearchOptions
-): Promise<OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>> => {
-  const { rowsPerPage, currentPage, sortOrder } = searchOptions;
-  const searchParams: OEQ.Search.SearchParams = {
-    start: currentPage * rowsPerPage,
-    length: rowsPerPage,
-    status: [
-      "LIVE" as OEQ.Common.ItemStatus,
-      "REVIEW" as OEQ.Common.ItemStatus,
-    ],
-    order: sortOrder,
-  };
-  return OEQ.Search.search(API_BASE_URL, searchParams);
-};
-
-export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
-  start: 0,
-  length: 10,
-  available: 10,
-  results: [],
-};
+import { languageStrings } from "../util/langstrings";
 
 /**
  * Type of all search options on Search page
@@ -69,4 +42,52 @@ export const defaultSearchOptions: SearchOptions = {
   rowsPerPage: 10,
   currentPage: 0,
   sortOrder: undefined,
+};
+
+export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
+  start: 0,
+  length: 10,
+  available: 10,
+  results: [],
+};
+
+/**
+ * A function that takes search options and converts search options to search params,
+ * and then does a search and returns a list of Items.
+ * @param searchOptions  Search options selected on Search page.
+ */
+export const searchItems = (
+  searchOptions: SearchOptions
+): Promise<OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>> => {
+  const { rowsPerPage, currentPage, sortOrder } = searchOptions;
+  const searchParams: OEQ.Search.SearchParams = {
+    start: currentPage * rowsPerPage,
+    length: rowsPerPage,
+    status: [
+      "LIVE" as OEQ.Common.ItemStatus,
+      "REVIEW" as OEQ.Common.ItemStatus,
+    ],
+    order: sortOrder,
+  };
+  return OEQ.Search.search(API_BASE_URL, searchParams);
+};
+
+/**
+ * Provide the search sorting control's data source.
+ */
+export const getSortingOptions = (): Record<string, SortOrder> => {
+  const {
+    relevance,
+    lastModified,
+    dateCreated,
+    title,
+    userRating,
+  } = languageStrings.settings.searching.searchPageSettings;
+  return {
+    [relevance]: SortOrder.RANK,
+    [lastModified]: SortOrder.DATEMODIFIED,
+    [dateCreated]: SortOrder.DATECREATED,
+    [title]: SortOrder.NAME,
+    [userRating]: SortOrder.RATING,
+  };
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -18,7 +18,6 @@
 import * as OEQ from "@openequella/rest-api-client";
 import { API_BASE_URL } from "../config";
 import { SortOrder } from "../settings/Search/SearchSettingsModule";
-import { languageStrings } from "../util/langstrings";
 
 /**
  * Type of all search options on Search page
@@ -70,24 +69,4 @@ export const searchItems = (
     order: sortOrder,
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
-};
-
-/**
- * Provide the search sorting control's data source.
- */
-export const getSortingOptions = (): Record<string, SortOrder> => {
-  const {
-    relevance,
-    lastModified,
-    dateCreated,
-    title,
-    userRating,
-  } = languageStrings.settings.searching.searchPageSettings;
-  return {
-    [relevance]: SortOrder.RANK,
-    [lastModified]: SortOrder.DATEMODIFIED,
-    [dateCreated]: SortOrder.DATECREATED,
-    [title]: SortOrder.NAME,
-    [userRating]: SortOrder.RATING,
-  };
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -27,17 +27,20 @@ import {
   Card,
   CardActions,
   CardContent,
+  CardHeader,
   Grid,
   IconButton,
   List,
-  ListSubheader,
   TablePagination,
   TextField,
+  MenuItem,
+  Select,
 } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
 import {
   defaultPagedSearchResult,
   defaultSearchOptions,
+  getSortingOptions,
   searchItems,
   SearchOptions,
 } from "./SearchModule";
@@ -47,6 +50,7 @@ import { generateFromError } from "../api/errors";
 import {
   getSearchSettingsFromServer,
   SearchSettings,
+  SortOrder,
 } from "../settings/Search/SearchSettingsModule";
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
@@ -114,11 +118,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   /**
    * A list that consists of search result items.
    */
-  const searchResultList = (
-    <List subheader={<ListSubheader>{searchStrings.subtitle}</ListSubheader>}>
-      {searchResults}
-    </List>
-  );
+  const searchResultList = <List>{searchResults}</List>;
 
   return (
     <Grid container direction="column" spacing={2}>
@@ -135,6 +135,26 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
       <Grid item xs={9}>
         <Card>
+          <CardHeader
+            title={searchStrings.subtitle}
+            action={
+              <Select
+                variant="outlined"
+                // If sortOrder is undefined, pass an empty string to select nothing.
+                value={searchOptions.sortOrder ?? ""}
+                onChange={(event) =>
+                  setSearchOptions({
+                    ...searchOptions,
+                    sortOrder: event.target.value as SortOrder,
+                  })
+                }
+              >
+                {Object.entries(getSortingOptions()).map(([text, value]) => (
+                  <MenuItem value={value}>{text}</MenuItem>
+                ))}
+              </Select>
+            }
+          />
           <CardContent>{searchResultList}</CardContent>
 
           <CardActions>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   templateDefaults,
   templateError,
@@ -33,14 +33,11 @@ import {
   List,
   TablePagination,
   TextField,
-  MenuItem,
-  Select,
 } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
 import {
   defaultPagedSearchResult,
   defaultSearchOptions,
-  getSortingOptions,
   searchItems,
   SearchOptions,
 } from "./SearchModule";
@@ -52,6 +49,7 @@ import {
   SearchSettings,
   SortOrder,
 } from "../settings/Search/SearchSettingsModule";
+import SearchOrderSelect from "./components/SearchOrderSelect";
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
@@ -72,10 +70,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     }));
 
     getSearchSettingsFromServer().then((settings: SearchSettings) => {
-      setSearchOptions({
-        ...searchOptions,
-        sortOrder: settings.defaultSearchSort,
-      });
+      handleSortOrderChanged(settings.defaultSearchSort);
     });
   }, []);
 
@@ -120,6 +115,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
    */
   const searchResultList = <List>{searchResults}</List>;
 
+  /**
+   * Provide a memorized callback for updating sort order in order to avoid re-rendering
+   * component SearchOrderSelect when other search control values are changed.
+   */
+  const handleSortOrderChanged = useCallback(
+    (order: SortOrder) =>
+      setSearchOptions({ ...searchOptions, sortOrder: order }),
+    []
+  );
+
   return (
     <Grid container direction="column" spacing={2}>
       <Grid item xs={9}>
@@ -138,21 +143,10 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           <CardHeader
             title={searchStrings.subtitle}
             action={
-              <Select
-                variant="outlined"
-                // If sortOrder is undefined, pass an empty string to select nothing.
-                value={searchOptions.sortOrder ?? ""}
-                onChange={(event) =>
-                  setSearchOptions({
-                    ...searchOptions,
-                    sortOrder: event.target.value as SortOrder,
-                  })
-                }
-              >
-                {Object.entries(getSortingOptions()).map(([text, value]) => (
-                  <MenuItem value={value}>{text}</MenuItem>
-                ))}
-              </Select>
+              <SearchOrderSelect
+                value={searchOptions.sortOrder}
+                onChange={handleSortOrderChanged}
+              />
             }
           />
           <CardContent>{searchResultList}</CardContent>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchOrderSelect.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchOrderSelect.tsx
@@ -48,7 +48,7 @@ export const SearchOrderSelect = ({
   } = languageStrings.settings.searching.searchPageSettings;
 
   /**
-   * Provide a memorised data source for search sorting control.
+   * Provide a data source for search sorting control.
    */
   const sortingOptionStrings = new Map<SortOrder, string>([
     [SortOrder.RANK, relevance],

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchOrderSelect.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchOrderSelect.tsx
@@ -1,0 +1,77 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { MenuItem, Select } from "@material-ui/core";
+import { SortOrder } from "../../settings/Search/SearchSettingsModule";
+import { languageStrings } from "../../util/langstrings";
+
+/**
+ * Type of props passed to SearchOrderSelect.
+ */
+interface SearchOrderSelectProps {
+  /**
+   * The selected order. Being undefined means no option is selected.
+   */
+  value?: SortOrder;
+  /**
+   * Fired when a different sort order is selected.
+   * @param sortOrder The new order.
+   */
+  onChange: (sortOrder: SortOrder) => void;
+}
+
+export const SearchOrderSelect = ({
+  value,
+  onChange,
+}: SearchOrderSelectProps) => {
+  const {
+    relevance,
+    lastModified,
+    dateCreated,
+    title,
+    userRating,
+  } = languageStrings.settings.searching.searchPageSettings;
+
+  /**
+   * Provide a memorised data source for search sorting control.
+   */
+  const sortingOptionStrings = new Map<SortOrder, string>([
+    [SortOrder.RANK, relevance],
+    [SortOrder.DATEMODIFIED, lastModified],
+    [SortOrder.DATECREATED, dateCreated],
+    [SortOrder.NAME, title],
+    [SortOrder.RATING, userRating],
+  ]);
+
+  return (
+    <Select
+      variant="outlined"
+      // If sortOrder is undefined, pass an empty string to select nothing.
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value as SortOrder)}
+    >
+      {Array.from(sortingOptionStrings).map(([value, text]) => (
+        <MenuItem key={value} value={value}>
+          {text}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+};
+
+export default React.memo(SearchOrderSelect);


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Added a sorting control on Search page to allow sorting search results. The initially selected sort order is consistent with the default sort order configured on the Search setting page.

![image](https://user-images.githubusercontent.com/47203811/86434092-e4f3e580-bd3f-11ea-9f5d-82049d4c3e3e.png)
