### PR TITLE
Make attachmentType optional to fix search issues

### DIFF
--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -1,6 +1,6 @@
 import * as Common from './Common';
-import { is } from 'typescript-is';
-import { GET } from './AxiosInstance';
+import {is} from 'typescript-is';
+import {GET} from './AxiosInstance';
 import * as Utils from './Utils';
 
 /**
@@ -86,7 +86,7 @@ export interface DisplayOptions {
   /**
    * The display mode for attachments when viewed from search result page.
    */
-  attachmentType: string;
+  attachmentType?: string;
   /**
    * True if thumbnail is prevented from displaying.
    */


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
The attachmentType is not always present in all items. This caused search
to fail due to type mismatch - found in the default vanilla institution.
This commit solves that issue.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
