### PR TITLE
Add helpertext for the schema selector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
@@ -17,7 +17,13 @@
  */
 import * as React from "react";
 import { ReactElement } from "react";
-import { Grid, InputLabel, MenuItem, Select } from "@material-ui/core";
+import {
+  FormHelperText,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@material-ui/core";
 import {
   schemaListSummary,
   SchemaNode,
@@ -81,21 +87,24 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
       <>
         <Grid item>
           {schemaList && (
-            <Select
-              fullWidth
-              label={
-                <InputLabel shrink id="select-label">
-                  {strings.schema}
-                </InputLabel>
-              }
-              value={selectedSchema}
-              displayEmpty
-              onChange={(event) => {
-                setSelectedSchema(event.target.value as string | undefined);
-              }}
-            >
-              {schemaList}
-            </Select>
+            <>
+              <Select
+                fullWidth
+                label={
+                  <InputLabel shrink id="select-label">
+                    {strings.schema}
+                  </InputLabel>
+                }
+                value={selectedSchema}
+                displayEmpty
+                onChange={(event) => {
+                  setSelectedSchema(event.target.value as string | undefined);
+                }}
+              >
+                {schemaList}
+              </Select>
+              <FormHelperText>{strings.permissionsHelperText}</FormHelperText>
+            </>
           )}
         </Grid>
         <Grid item>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -466,6 +466,8 @@ export const languageStrings = {
         schemaSelector: {
           schema: "Schema",
           selectASchema: "Select a schema...",
+          permissionsHelperText:
+            "The LIST_SCHEMA permission is required to select a schema",
           nodeSelector: {
             expandAll: "Expand All",
             collapseAll: "Collapse All",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
Adds the text "The LIST_SCHEMA permission is required to select a schema" underneath the schema selector.
![image](https://user-images.githubusercontent.com/24543345/86702482-5a202d00-c056-11ea-8b9b-693e341b07ec.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
