### PR TITLE
Remove subheader in searchResultList

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -31,7 +31,6 @@ import {
   Grid,
   List,
   ListItem,
-  ListSubheader,
   TablePagination,
   Typography,
 } from "@material-ui/core";
@@ -125,7 +124,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
    * A list that consists of search result items.
    */
   const searchResultList = (
-    <List subheader={<ListSubheader>{searchStrings.subtitle}</ListSubheader>}>
+    <List>
       {searchResults.length > 0 ? (
         searchResults
       ) : (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
In the screenshot, there are two places on the page reading "Search Results". Obviously this is redundant, so this PR removes the ListSubheader (the smaller grey one).
![image](https://user-images.githubusercontent.com/24543345/86729590-fd7e3b80-c070-11ea-8a84-645e9a1da017.png)
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
