### PR TITLE
Refactor the LoginNotice settings pages to use the new SettingsPageTemplate

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
@@ -17,49 +17,25 @@
  */
 import * as React from "react";
 import { AxiosError } from "axios";
-import MessageInfo from "../components/MessageInfo";
 import { generateFromError, generateNewErrorID } from "../api/errors";
 import PreLoginNoticeConfigurator from "./PreLoginNoticeConfigurator";
 import PostLoginNoticeConfigurator from "./PostLoginNoticeConfigurator";
-import {
-  Button,
-  createStyles,
-  Tabs,
-  Theme,
-  withStyles,
-  WithStyles,
-} from "@material-ui/core";
-import Tab from "@material-ui/core/Tab";
-import { NotificationType, strings } from "./LoginNoticeModule";
-import { commonString } from "../util/commonstrings";
+import { strings } from "./LoginNoticeModule";
 import {
   templateDefaults,
   templateError,
-  TemplateUpdateProps,
+  TemplateUpdate,
 } from "../mainui/Template";
 import { routes } from "../mainui/routes";
+import SettingPageTemplate from "../components/SettingPageTemplate";
 
-interface LoginNoticeConfigPageProps
-  extends TemplateUpdateProps,
-    WithStyles<typeof styles> {
-  setPreventNavigation(b: boolean): void;
+interface LoginNoticeConfigPageProps {
+  updateTemplate: (update: TemplateUpdate) => void;
 }
-
 interface LoginNoticeConfigPageState {
-  notifications: NotificationType;
   notificationOpen: boolean;
-  selectedTab: number;
   preventNav: boolean;
 }
-
-const styles = (theme: Theme) =>
-  createStyles({
-    floatingButton: {
-      right: theme.spacing(2),
-      bottom: theme.spacing(2),
-      position: "fixed",
-    },
-  });
 
 class LoginNoticeConfigPage extends React.Component<
   LoginNoticeConfigPageProps,
@@ -83,30 +59,15 @@ class LoginNoticeConfigPage extends React.Component<
   }
 
   state: LoginNoticeConfigPageState = {
-    notifications: NotificationType.Save,
     notificationOpen: false,
-    selectedTab: 0,
     preventNav: false,
   };
 
   componentDidMount() {
-    const { classes, updateTemplate } = this.props;
+    const { updateTemplate } = this.props;
     updateTemplate((tp) => ({
       ...templateDefaults(strings.title)(tp),
       backRoute: routes.Settings.to,
-      fixedViewPort: true,
-      footer: (
-        <Button
-          id="SaveButton"
-          className={classes.floatingButton}
-          onClick={this.handleSubmitButton}
-          variant="contained"
-          size="large"
-        >
-          {commonString.action.save}
-        </Button>
-      ),
-      tabs: this.tabs(),
     }));
   }
 
@@ -132,115 +93,47 @@ class LoginNoticeConfigPage extends React.Component<
     }
   };
 
-  handleChangeTab = (event: React.ChangeEvent<{}>, selectedTab: number) => {
-    this.setState({ selectedTab }, () =>
-      this.props.updateTemplate((tp) => ({ ...tp, tabs: this.tabs() }))
-    );
-  };
-
   clearNotifications = () => {
     this.setState({ notificationOpen: false });
   };
 
-  notificationString = (notificationType: NotificationType): string => {
-    switch (notificationType) {
-      case NotificationType.Revert:
-        return strings.notifications.cancelled;
-      case NotificationType.Clear:
-        return strings.notifications.cleared;
-      case NotificationType.Save:
-        return strings.notifications.saved;
-    }
-  };
-
-  Notifications = () => {
-    return (
-      <MessageInfo
-        title={this.notificationString(this.state.notifications)}
-        open={this.state.notificationOpen}
-        onClose={this.clearNotifications}
-        variant="success"
-      />
-    );
-  };
-
-  notify = (notificationType: NotificationType) => {
-    this.setState({ notificationOpen: true, notifications: notificationType });
-  };
-
-  Configurators = () => {
-    switch (this.state.selectedTab) {
-      case 0:
-        return (
-          <PreLoginNoticeConfigurator
-            handleError={this.handleError}
-            notify={this.notify}
-            ref={this.preLoginNoticeConfigurator}
-            preventNav={this.preventNav}
-          />
-        );
-      default:
-        return (
-          <PostLoginNoticeConfigurator
-            handleError={this.handleError}
-            notify={this.notify}
-            ref={this.postLoginNoticeConfigurator}
-            preventNav={this.preventNav}
-          />
-        );
-    }
-  };
-
-  handleSubmitButton = () => {
-    switch (this.state.selectedTab) {
-      case 0:
-        if (this.preLoginNoticeConfigurator.current) {
-          this.preLoginNoticeConfigurator.current.handleSubmitPreNotice();
-        }
-        break;
-      default:
-        if (this.postLoginNoticeConfigurator.current) {
-          this.postLoginNoticeConfigurator.current.handleSubmitPostNotice();
-        }
-        break;
+  save = async () => {
+    try {
+      await this.preLoginNoticeConfigurator.current?.save();
+      await this.postLoginNoticeConfigurator.current?.save();
+      this.setState({ notificationOpen: true });
+      this.preventNav(false);
+    } catch (error) {
+      this.handleError(error);
     }
   };
 
   preventNav = (preventNav: boolean) => {
-    this.setState({ preventNav }, () =>
-      this.props.setPreventNavigation(preventNav)
-    );
+    this.setState({ preventNav });
   };
 
-  tabs = () => (
-    <Tabs
-      value={this.state.selectedTab}
-      onChange={this.handleChangeTab}
-      variant="fullWidth"
-    >
-      <Tab
-        id="preTab"
-        label={strings.prelogin.label}
-        disabled={this.state.preventNav}
-      />
-      <Tab
-        id="postTab"
-        label={strings.postlogin.label}
-        disabled={this.state.preventNav}
-      />
-    </Tabs>
-  );
-
   render() {
-    const Notifications = this.Notifications;
-    const Configurators = this.Configurators;
     return (
-      <React.Fragment>
-        <Configurators />
-        <Notifications />
-      </React.Fragment>
+      <SettingPageTemplate
+        onSave={() => this.save()}
+        snackbarOpen={this.state.notificationOpen}
+        snackBarOnClose={() => this.setState({ notificationOpen: false })}
+        saveButtonDisabled={!this.state.preventNav}
+        preventNavigation={this.state.preventNav}
+      >
+        <PreLoginNoticeConfigurator
+          handleError={this.handleError}
+          ref={this.preLoginNoticeConfigurator}
+          preventNav={this.preventNav}
+        />
+        <PostLoginNoticeConfigurator
+          handleError={this.handleError}
+          ref={this.postLoginNoticeConfigurator}
+          preventNav={this.preventNav}
+        />
+      </SettingPageTemplate>
     );
   }
 }
 
-export default withStyles(styles)(LoginNoticeConfigPage);
+export default LoginNoticeConfigPage;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeModule.ts
@@ -23,11 +23,6 @@ import { BlobInfo } from "../components/RichTextEditor";
 export const PRE_LOGIN_NOTICE_API_URL = `${API_BASE_URL}/preloginnotice`;
 export const POST_LOGIN_NOTICE_API_URL = `${API_BASE_URL}/postloginnotice`;
 export const PRE_LOGIN_NOTICE_IMAGE_API_URL = `${PRE_LOGIN_NOTICE_API_URL}/image/`;
-export enum NotificationType {
-  Save,
-  Clear,
-  Revert,
-}
 
 export enum ScheduleTypeSelection {
   OFF = "OFF",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
@@ -44,13 +44,13 @@ interface PostLoginNoticeConfiguratorProps {
 }
 
 interface PostLoginNoticeConfiguratorState {
-  /** what is currently in the textfield */
+  /** What is currently in the textfield. */
   postNotice?: string;
 
-  /** what is currently in the database */
+  /** What is currently in the database. */
   dbPostNotice?: string;
 
-  /** Whether to display the dialog to confirm clearing */
+  /** Whether to display the dialog to confirm clearing. */
   clearStaged: boolean;
 }
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
@@ -29,24 +29,28 @@ import { commonString } from "../util/commonstrings";
 import {
   clearPostLoginNotice,
   getPostLoginNotice,
-  NotificationType,
-  submitPostLoginNotice,
   strings,
+  submitPostLoginNotice,
 } from "./LoginNoticeModule";
 import { AxiosError, AxiosResponse } from "axios";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogActions from "@material-ui/core/DialogActions";
+import SettingsListHeading from "../components/SettingsListHeading";
 
 interface PostLoginNoticeConfiguratorProps {
   handleError: (axiosError: AxiosError) => void;
-  notify: (notificationType: NotificationType) => void;
   preventNav: (prevNav: boolean) => void;
 }
 
 interface PostLoginNoticeConfiguratorState {
-  postNotice?: string; //what is currently in the textfield
-  dbPostNotice?: string; //what is currently in the database
+  /** what is currently in the textfield */
+  postNotice?: string;
+
+  /** what is currently in the database */
+  dbPostNotice?: string;
+
+  /** Whether to display the dialog to confirm clearing */
   clearStaged: boolean;
 }
 
@@ -63,36 +67,15 @@ class PostLoginNoticeConfigurator extends React.Component<
     };
   }
 
-  handleSubmitPostNotice = () => {
-    if (this.state.postNotice != undefined) {
-      submitPostLoginNotice(this.state.postNotice)
-        .then(() => {
-          this.props.notify(NotificationType.Save);
-          this.setState({ dbPostNotice: this.state.postNotice });
-          this.props.preventNav(false);
-        })
-        .catch((error: AxiosError) => {
-          this.props.handleError(error);
-        });
-    }
-  };
+  save = async () =>
+    (this.state.postNotice
+      ? submitPostLoginNotice(this.state.postNotice)
+      : clearPostLoginNotice()
+    ).then(() => this.setState({ dbPostNotice: this.state.postNotice }));
 
   handleClearPostNotice = () => {
-    this.setState({ postNotice: "" });
-    clearPostLoginNotice()
-      .then(() => {
-        this.setState({ dbPostNotice: "", clearStaged: false });
-        this.props.preventNav(false);
-        this.props.notify(NotificationType.Clear);
-      })
-      .catch((error: AxiosError) => {
-        this.props.handleError(error);
-      });
-  };
-
-  handleUndoPostNotice = () => {
-    this.setState({ postNotice: this.state.dbPostNotice });
-    this.props.notify(NotificationType.Revert);
+    this.setState({ postNotice: "", clearStaged: false });
+    this.props.preventNav(true);
   };
 
   handlePostTextFieldChange = (
@@ -119,9 +102,39 @@ class PostLoginNoticeConfigurator extends React.Component<
     this.setState({ clearStaged: true });
   };
 
-  Dialogs = () => {
+  render() {
+    const { postNotice, dbPostNotice } = this.state;
     return (
-      <div>
+      <>
+        <Card>
+          <CardContent>
+            <SettingsListHeading heading={strings.postLogin.title} />
+            <TextField
+              id="postNoticeField"
+              variant="outlined"
+              rows="12"
+              rowsMax="35"
+              multiline
+              fullWidth
+              inputProps={{ length: 12 }}
+              placeholder={strings.postLogin.description}
+              onChange={(e) => this.handlePostTextFieldChange(e.target)}
+              value={postNotice}
+            />
+          </CardContent>
+
+          <CardActions>
+            <Button
+              id="postClearButton"
+              disabled={dbPostNotice === ""}
+              onClick={this.stageClear}
+              variant="text"
+            >
+              {commonString.action.clear}
+            </Button>
+          </CardActions>
+        </Card>
+
         <Dialog
           open={this.state.clearStaged}
           onClose={() => this.setState({ clearStaged: false })}
@@ -142,43 +155,6 @@ class PostLoginNoticeConfigurator extends React.Component<
             </Button>
           </DialogActions>
         </Dialog>
-      </div>
-    );
-  };
-
-  render() {
-    const { postNotice, dbPostNotice } = this.state;
-    const Dialogs = this.Dialogs;
-    return (
-      <>
-        <Card>
-          <CardContent>
-            <TextField
-              id="postNoticeField"
-              variant="outlined"
-              rows="12"
-              rowsMax="35"
-              multiline
-              fullWidth
-              inputProps={{ length: 12 }}
-              placeholder={strings.postlogin.description}
-              onChange={(e) => this.handlePostTextFieldChange(e.target)}
-              value={postNotice}
-            />
-          </CardContent>
-
-          <CardActions>
-            <Button
-              id="postClearButton"
-              disabled={dbPostNotice === ""}
-              onClick={this.stageClear}
-              variant="text"
-            >
-              {commonString.action.clear}
-            </Button>
-          </CardActions>
-        </Card>
-        <Dialogs />
       </>
     );
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -30,7 +30,6 @@ import {
 import {
   clearPreLoginNotice,
   getPreLoginNotice,
-  NotificationType,
   PreLoginNotice,
   ScheduleTypeSelection,
   strings,
@@ -40,12 +39,12 @@ import {
 } from "./LoginNoticeModule";
 import { AxiosError, AxiosResponse } from "axios";
 import { DateTimePicker } from "material-ui-pickers";
+import SettingsListHeading from "../components/SettingsListHeading";
 
 const RichTextEditor = React.lazy(() => import("../components/RichTextEditor"));
 
 interface PreLoginNoticeConfiguratorProps {
   handleError: (axiosError: AxiosError) => void;
-  notify: (notificationType: NotificationType) => void;
   preventNav: (prevNav: boolean) => void;
 }
 
@@ -76,41 +75,11 @@ class PreLoginNoticeConfigurator extends React.Component<
     };
   }
 
-  handleSubmitPreNotice = () => {
-    if (this.state.current.notice == "") {
-      clearPreLoginNotice()
-        .then(() => {
-          this.props.notify(NotificationType.Clear);
-          this.setState(
-            {
-              db: this.state.current,
-            },
-            () => this.setPreventNav()
-          );
-        })
-        .catch((error: AxiosError) => {
-          this.props.handleError(error);
-        });
-    } else {
-      submitPreLoginNotice(this.state.current)
-        .then(() => {
-          this.props.notify(NotificationType.Save);
-          this.setDBToValues();
-        })
-        .catch((error: AxiosError) => {
-          this.props.handleError(error);
-        });
-    }
-  };
-
-  setDBToValues = () => {
-    this.setState(
-      {
-        db: this.state.current,
-      },
-      () => this.setPreventNav()
-    );
-  };
+  save = async () =>
+    (this.state.current.notice
+      ? submitPreLoginNotice(this.state.current)
+      : clearPreLoginNotice()
+    ).then(() => this.setState({ db: this.state.current }));
 
   componentDidMount = () => {
     getPreLoginNotice()
@@ -252,7 +221,8 @@ class PreLoginNoticeConfigurator extends React.Component<
     return (
       <Card>
         <CardContent>
-          <Grid id="preLoginConfig" container spacing={8} direction="column">
+          <SettingsListHeading heading={strings.preLogin.title} />
+          <Grid id="preLoginConfig" container spacing={2} direction="column">
             <Grid item>
               <React.Suspense fallback={<div>Loading editor...</div>}>
                 <RichTextEditor

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -201,18 +201,13 @@ export const languageStrings = {
       title: "Warning",
       confirm: "Are you sure you want to clear this login notice?",
     },
-    prelogin: {
-      label: "Before login notice",
+    preLogin: {
+      title: "Before login notice",
     },
-    postlogin: {
-      label: "After login notice",
+    postLogin: {
+      title: "After login notice",
       description:
         "Write a plaintext message to be displayed after login as an alert...",
-    },
-    notifications: {
-      saved: "Login notice saved successfully.",
-      cleared: "Login notice cleared successfully.",
-      cancelled: "Cancelled changes to login notice.",
     },
     errors: {
       permissions: "You do not have permission to edit these settings.",

--- a/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -3,13 +3,15 @@ package equellatests.pages
 import com.tle.webtests.framework.PageContext
 import com.tle.webtests.pageobject.ExpectedConditions2
 import equellatests.browserpage.NewTitledPage
+import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.{By, Keys, WebElement}
 
 case class LoginNoticePage(ctx: PageContext)
     extends NewTitledPage("Login notice editor", "page/loginconfiguration") {
+  private val SUCCESS_MSG = "Saved successfully."
 
-  private def saveButton: WebElement = findElementById("SaveButton")
+  private def saveButton: WebElement = findElementById("_saveButton")
 
   private def preNoticeField: WebElement = findElementById("tinymce")
 
@@ -32,8 +34,6 @@ case class LoginNoticePage(ctx: PageContext)
   private def postNoticeClearButton: WebElement = findElementById("postClearButton")
 
   private def postNoticeField: WebElement = findElementById("postNoticeField")
-
-  private def postTab: WebElement = findElementById("postTab")
 
   private def clearOkButton: WebElement = findElementById("okToClear")
 
@@ -60,15 +60,10 @@ case class LoginNoticePage(ctx: PageContext)
     waitFor(ExpectedConditions.textToBePresentInElementLocated(By.id("client-snackbar"), content))
   }
 
-  private def waitForPostTab(): Unit = {
-    waitFor(ExpectedConditions2.presenceOfElement(postNoticeField))
-  }
-
   def setPreLoginNotice(notice: String): Unit = {
     clearAndPopulatePreNoticeField(notice)
     switchFromTinyMCEIFrame()
-    saveButton.click()
-    waitForSnackBar("Login notice saved successfully.")
+    save()
   }
 
   def setPreLoginNoticeWithImageURL(imgURL: String): Unit = {
@@ -82,15 +77,13 @@ case class LoginNoticePage(ctx: PageContext)
     waitFor(ExpectedConditions.textToBePresentInElementValue(preNoticeAddImageField, imgURL))
     waitFor(ExpectedConditions.elementToBeClickable(preNoticeAddImageOK))
     preNoticeAddImageOK.click()
-    saveButton.click()
-    waitForSnackBar("Login notice saved successfully.")
+    save()
   }
 
   def clearPreLoginNotice(): Unit = {
     clearAndPopulatePreNoticeField("")
     switchFromTinyMCEIFrame()
-    saveButton.click()
-    waitForSnackBar("Login notice cleared successfully.")
+    save()
   }
 
   def getPreNoticeFieldContents: String = {
@@ -101,34 +94,43 @@ case class LoginNoticePage(ctx: PageContext)
   }
 
   def setPostLoginNotice(notice: String): Unit = {
-    gotoPostNoticeTab()
     populatePostNoticeField(notice)
-    saveButton.click()
-    waitForSnackBar("Login notice saved successfully.")
+    save()
   }
 
   def clearPostLoginNotice(): Unit = {
-    gotoPostNoticeTab()
     postNoticeClearButton.click()
     waitFor(ExpectedConditions2.presenceOfElement(clearOkButton))
     clearOkButton.click()
-    waitForSnackBar("Login notice cleared successfully.")
+    save()
   }
 
   def getPostNoticeFieldContents: String = {
-    gotoPostNoticeTab()
     postNoticeField.getText
   }
 
-  def gotoPostNoticeTab(): Unit = {
-    this.postTab.click()
-    waitForPostTab()
-  }
-
   def populatePostNoticeField(notice: String): Unit = {
-    gotoPostNoticeTab()
     postNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a", Keys.BACK_SPACE))
     postNoticeField.sendKeys(notice)
   }
 
+  def save(): Unit = {
+    def saveButtonActive: Boolean = saveButton.getAttribute("disabled") == null
+    def clickSaveButton(): Unit =
+      new Actions(driver)
+        .moveToElement(saveButton)
+        .click()
+        .perform()
+
+    // A retry for clicking the save button, as sometimes delays due to showing and then
+    // hiding a dialog can trip things up
+    waiter.until(_ => {
+      if (saveButtonActive) clickSaveButton()
+
+      // Once the click has been genuinely received, then the button will no longer be active
+      // and we can move on to checking for the expectant snackbar.
+      !saveButtonActive
+    })
+    waitForSnackBar(SUCCESS_MSG)
+  }
 }

--- a/autotest/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuPropertiesSerial.scala
+++ b/autotest/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuPropertiesSerial.scala
@@ -27,7 +27,6 @@ object LoginNoticeMenuPropertiesSerial extends ShotProperties("Login Notice Menu
       val notice = s"${w1.word}"
       page.setPostLoginNotice(notice)
       page.load()
-      page.gotoPostNoticeTab()
       Prop(page.getPostNoticeFieldContents == notice)
         .label("Notice: " + notice + ", NoticeField: " + page.getPostNoticeFieldContents)
     }
@@ -52,7 +51,6 @@ object LoginNoticeMenuPropertiesSerial extends ShotProperties("Login Notice Menu
       page.load()
       page.clearPostLoginNotice()
       page.load()
-      page.gotoPostNoticeTab()
       Prop(page.getPostNoticeFieldContents == "")
     }
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This is the second in a series following on from #1990 and is an attempt to standardise our settings pages with the new pattern established with the New Search UI work.

This work involved:

* Removal of tab layout for notice editors;
* Removal of custom save button and snackbar/notifications;
* Reworking save methods and handlers;
* Combining the two editors under the new SettingsPageTemplate instead; 
* Reworking the ScalaCheck tests - however this was nicely isolated in the Page class due to reasonable abstraction of processes

Attempted to fit in with what was there as much as possible and undertook minimal component level refactoring. And it seemed it had most of what was needed for triggers for the SettingsPageTemplate for prevent nav, etc.

There is a known existing issue with TinyMCE at the moment (on `develop` and all sibling branches), so please ignore that in the below screenshot. (It will be fixed soon elsewhere.)

![image](https://user-images.githubusercontent.com/43919233/86730201-9f058d00-c071-11ea-8e2b-7efb5f617486.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
