### PR TITLE
chore: Add global logoURL for Storybook

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/.storybook/preview-head.html
+++ b/Source/Plugins/Core/com.equella.core/js/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<script>let logoURL = "";</script>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
oEQ places a global variable logoURL via a script in the head of server
side rendered pages. This can then be accessed via the New UI pages
which are being tested with Storybook. So to ensure Storybook works,
this needs to be provided within Storybook.

Resolves #2013

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
