### PR TITLE
Make schema node textfield readonly. Simplify styling used inside the…

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaNodeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaNodeSelector.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme: Theme) => {
   return {
     treeView: {
       flexGrow: 1,
-      maxHeight: "30vh",
+      height: "30vh",
       overflowY: "auto",
       width: "100%",
     },

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
@@ -32,27 +32,7 @@ import {
   validateFacetFields,
 } from "./FacetedSearchSettingsModule";
 import SchemaSelector from "../../SchemaSelector";
-import { makeStyles, Theme } from "@material-ui/core/styles";
 
-const useStyles = makeStyles((theme: Theme) => {
-  return {
-    dialogPaper: {
-      width: "45%",
-      height: "90%",
-      maxHeight: "none",
-      maxWidth: "none",
-      margin: theme.spacing(2),
-      padding: theme.spacing(1),
-      overflowY: "hidden",
-    },
-    dialog: {
-      overflowY: "hidden",
-    },
-    root: {
-      flexGrow: 1,
-    },
-  };
-});
 interface FacetDialogProps {
   /**
    * If true, the dialog will be shown.
@@ -102,7 +82,6 @@ const FacetDialog = ({
   const isNameInvalid = validateFacetFields(name);
   const isSchemaNodeInvalid = validateFacetFields(schemaNode);
 
-  const classes = useStyles();
   /**
    * Initialise textfields' values, depending on 'onClose'.
    */
@@ -123,8 +102,6 @@ const FacetDialog = ({
       onClose={onClose}
       disableBackdropClick
       disableEscapeKeyDown
-      className={classes.dialog}
-      classes={{ paper: classes.dialogPaper }}
     >
       <DialogTitle>
         {facet
@@ -165,6 +142,7 @@ const FacetDialog = ({
           }}
           required
           fullWidth
+          disabled
           error={!!schemaNode && validateFacetFields(schemaNode)}
         />
         <SchemaSelector


### PR DESCRIPTION
… facetDialog component

There was some custom styling inside the FacetDialog component that we can get away with removing. Instead of specifying a custom width and height, we can instead just alter the height of the components inside the dialog (in particular the schema selector)

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1306

The main visual difference is that now the dialog height will expand out when a schema is selected, and stay that height until the dialog is closed. Not a perfect solution, but this at least seems to give the schema selector some more vertical height

![schema](https://user-images.githubusercontent.com/4625498/86861475-8dbc8f00-c10a-11ea-8b07-ed3b262bc11b.gif)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
