### PR TITLE
Add retries to PackageAndNavigationTest

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.text.MessageFormat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import retry.RetryTest;
 
 @TestInstitution("fiveo")
 public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
@@ -158,6 +159,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
+  @RetryTest
   @Test
   public void zipOnly() {
     String itemName = context.getFullName("zip");
@@ -220,6 +222,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
    * DTEC-14847 - Ensure that if a new node is created, "Multiple resources" checked but no
    * resources selected for the tabs, then everything still keeps going without error.
    */
+  @RetryTest
   @Test
   public void checkNoErrorForEmptyTabs() {
     String itemName = context.getFullName("check no error for empty tabs");

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -267,6 +267,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(attachments.attachmentExists("2 single ' quotes'"));
   }
 
+  @RetryTest
   @Test
   public void navigation() {
     String itemName = context.getFullName("navigation");

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -24,9 +24,11 @@ import java.net.URL;
 import java.text.MessageFormat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import retry.RetryTest;
 
 @TestInstitution("fiveo")
 public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
+
   private static final String QTI_ZIP = "realqti.zip";
   private static final String IMS_ZIP = "package.zip";
   private static final String SCORM_ZIP = "scorm.zip";
@@ -41,6 +43,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     return control.attachNameWaiter(name, false);
   }
 
+  @RetryTest
   @Test
   public void packageOnly() {
     String itemName = context.getFullName("package");
@@ -82,6 +85,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
         Attachments.get(filename), MessageFormat.format("{0}{1}", expectedError, filename));
   }
 
+  @RetryTest
   @Test
   public void qtiPackageOnly() {
     String itemName = context.getFullName("QTI package only");
@@ -106,6 +110,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
+  @RetryTest
   @Test
   public void scormPackageOnly() {
     String itemName = context.getFullName("SCORM package only");
@@ -130,6 +135,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
+  @RetryTest
   @Test
   public void allowedPackagesOnly() {
     String itemName = context.getFullName("QTI and SCORM package only");
@@ -158,6 +164,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
+  @RetryTest
   @Test
   public void zipOnly() {
     String itemName = context.getFullName("zip");
@@ -178,6 +185,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertFalse(attachments.attachmentExists("google2.jpg"));
   }
 
+  @RetryTest
   @Test
   public void packageTest() {
     String itemName = context.getFullName("a package");
@@ -201,6 +209,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertFalse(wizard.save().publish().hasAttachmentsSection());
   }
 
+  @RetryTest
   @Test
   public void cancelPackageTest() {
     String itemName = context.getFullName("a canceled package");
@@ -220,6 +229,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
    * DTEC-14847 - Ensure that if a new node is created, "Multiple resources" checked but no
    * resources selected for the tabs, then everything still keeps going without error.
    */
+  @RetryTest
   @Test
   public void checkNoErrorForEmptyTabs() {
     String itemName = context.getFullName("check no error for empty tabs");
@@ -244,6 +254,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
    * Redmine #5767 - Putting a double-quote in the name of a node cuts off everything after it. Try
    * doing lots of quote-y things and ensure they work as expected.
    */
+  @RetryTest
   @Test
   public void quotesInNodeNames() {
     String itemName = context.getFullName("quote check");
@@ -264,6 +275,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(attachments.attachmentExists("2 single ' quotes'"));
   }
 
+  @RetryTest
   @Test
   public void navigation() {
     String itemName = context.getFullName("navigation");
@@ -323,6 +335,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
             .isVerified());
   }
 
+  @RetryTest
   @Test
   public void packageNavigation() {
     String itemName = context.getFullName("package navigation");
@@ -340,6 +353,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(viewer.selectedAttachmentContainsText("Look at shots 1 and 2 from the Feature."));
   }
 
+  @RetryTest
   @Test
   public void modifyingNavigation() {
     String itemName = context.getFullName("navigation modification");
@@ -438,6 +452,7 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
   }
 
   /** DTEC-14857 */
+  @RetryTest
   @Test
   public void reordering() {
     String itemName = context.getFullName("reordering");

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -24,11 +24,9 @@ import java.net.URL;
 import java.text.MessageFormat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import retry.RetryTest;
 
 @TestInstitution("fiveo")
 public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
-
   private static final String QTI_ZIP = "realqti.zip";
   private static final String IMS_ZIP = "package.zip";
   private static final String SCORM_ZIP = "scorm.zip";
@@ -43,7 +41,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     return control.attachNameWaiter(name, false);
   }
 
-  @RetryTest
   @Test
   public void packageOnly() {
     String itemName = context.getFullName("package");
@@ -85,7 +82,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
         Attachments.get(filename), MessageFormat.format("{0}{1}", expectedError, filename));
   }
 
-  @RetryTest
   @Test
   public void qtiPackageOnly() {
     String itemName = context.getFullName("QTI package only");
@@ -110,7 +106,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
-  @RetryTest
   @Test
   public void scormPackageOnly() {
     String itemName = context.getFullName("SCORM package only");
@@ -135,7 +130,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
-  @RetryTest
   @Test
   public void allowedPackagesOnly() {
     String itemName = context.getFullName("QTI and SCORM package only");
@@ -164,7 +158,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     wizard.save().publish();
   }
 
-  @RetryTest
   @Test
   public void zipOnly() {
     String itemName = context.getFullName("zip");
@@ -185,7 +178,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertFalse(attachments.attachmentExists("google2.jpg"));
   }
 
-  @RetryTest
   @Test
   public void packageTest() {
     String itemName = context.getFullName("a package");
@@ -209,7 +201,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertFalse(wizard.save().publish().hasAttachmentsSection());
   }
 
-  @RetryTest
   @Test
   public void cancelPackageTest() {
     String itemName = context.getFullName("a canceled package");
@@ -229,7 +220,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
    * DTEC-14847 - Ensure that if a new node is created, "Multiple resources" checked but no
    * resources selected for the tabs, then everything still keeps going without error.
    */
-  @RetryTest
   @Test
   public void checkNoErrorForEmptyTabs() {
     String itemName = context.getFullName("check no error for empty tabs");
@@ -254,7 +244,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
    * Redmine #5767 - Putting a double-quote in the name of a node cuts off everything after it. Try
    * doing lots of quote-y things and ensure they work as expected.
    */
-  @RetryTest
   @Test
   public void quotesInNodeNames() {
     String itemName = context.getFullName("quote check");
@@ -275,7 +264,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(attachments.attachmentExists("2 single ' quotes'"));
   }
 
-  @RetryTest
   @Test
   public void navigation() {
     String itemName = context.getFullName("navigation");
@@ -335,7 +323,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
             .isVerified());
   }
 
-  @RetryTest
   @Test
   public void packageNavigation() {
     String itemName = context.getFullName("package navigation");
@@ -353,7 +340,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
     assertTrue(viewer.selectedAttachmentContainsText("Look at shots 1 and 2 from the Feature."));
   }
 
-  @RetryTest
   @Test
   public void modifyingNavigation() {
     String itemName = context.getFullName("navigation modification");
@@ -452,7 +438,6 @@ public class PackageAndNavigationTest extends AbstractCleanupAutoTest {
   }
 
   /** DTEC-14857 */
-  @RetryTest
   @Test
   public void reordering() {
     String itemName = context.getFullName("reordering");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change
Add RetryTest annotation to the tests inside PackageAndNavigationTest as they are persistently flakey.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
