### PR TITLE
Add "Raw search" mode to new search UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 import SearchBar from "../../tsrc/search/components/SearchBar";
 import { action } from "@storybook/addon-actions";
+import { boolean } from "@storybook/addon-knobs";
 
 export default {
   title: "SearchBar",
@@ -25,5 +26,8 @@ export default {
 };
 
 export const BasicSearchPage = () => (
-  <SearchBar onChange={action("OnChange called")} />
+  <SearchBar
+    onChange={action("OnChange called")}
+    rawSearchMode={boolean("raw search mode", false)}
+  />
 );

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -184,16 +184,19 @@ describe("<SearchPage/>", () => {
   it("should not debounce and send query as-is when in raw search mode", async () => {
     const input = component.find(SEARCHBAR_ID);
     const rawModeSwitch = component.find(RAW_SEARCH_TOGGLE_ID);
-    await awaitAct(() => {
-      //turn raw search mode on, add a search query and hit enter
-      rawModeSwitch.simulate("change", { target: { checked: true } });
-      jest.advanceTimersByTime(1000);
-      querySearch("raw search test");
+
+    //turn raw search mode on, add a search query and hit enter
+    await awaitAct(() =>
+      rawModeSwitch.simulate("change", { target: { checked: true } })
+    );
+    await awaitAct(() =>
+      input.simulate("change", { target: { value: "raw search test" } })
+    );
+    await awaitAct(() =>
       input.simulate("keyDown", {
         keyCode: ENTER_KEYCODE,
-      });
-      jest.advanceTimersByTime(1000);
-    });
+      })
+    );
 
     //assert that the query was passed in as-is
     expect(SearchModule.searchItems).toHaveBeenLastCalledWith({

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -56,7 +56,6 @@ describe("<SearchPage/>", () => {
   let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
 
   beforeEach(async () => {
-    jest.useFakeTimers("modern");
     component = mount(
       <BrowserRouter>
         <SearchPage updateTemplate={jest.fn()} />{" "}
@@ -88,6 +87,7 @@ describe("<SearchPage/>", () => {
    * @param searchTerm The specified search term.
    */
   const querySearch = async (searchTerm: string) => {
+    jest.useFakeTimers("modern");
     const input = component.find(SEARCHBAR_ID);
     await awaitAct(() => {
       input.simulate("change", { target: { value: searchTerm } });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -27,7 +27,7 @@ import { defaultSearchSettings } from "../../../tsrc/settings/Search/SearchSetti
 import { BrowserRouter } from "react-router-dom";
 import { CircularProgress } from "@material-ui/core";
 
-jest.useFakeTimers();
+jest.useFakeTimers("modern");
 const mockSearch = jest.spyOn(SearchModule, "searchItems");
 const mockSearchSettings = jest.spyOn(
   SearchSettingsModule,
@@ -107,5 +107,52 @@ describe("<SearchPage/>", () => {
       await searchPromise;
     });
     expect(component.find(CircularProgress)).toHaveLength(0);
+  });
+  it("should debounce append an * when not in raw search mode", async () => {
+    await act(async () => {
+      const input = component.find("input.MuiInputBase-input");
+      await input.simulate("change", { target: { value: "new query" } });
+      await jest.advanceTimersByTime(1000);
+      expect(searchPromise).toHaveBeenLastCalledWith({
+        currentPage: 0,
+        rowsPerPage: 10,
+        sortOrder: "RANK",
+        query: "new query*",
+      });
+    });
+  });
+  it("should not debounce when in raw search mode", async () => {
+    await act(async () => {
+      const input = component.find("input.MuiInputBase-input");
+      const rawModeSwitch = component.find("input[type='checkbox']");
+
+      //turn raw search mode on, add a search query and hit enter
+      await rawModeSwitch.simulate("change", { target: { checked: true } });
+      await input.simulate("change", { target: { value: "raw search test" } });
+      await input.simulate("keyDown", {
+        keyCode: 13,
+      });
+      await jest.advanceTimersByTime(1000);
+
+      //assert that the simple search wildcard was not appended
+      expect(searchPromise).not.toHaveBeenCalledWith({
+        currentPage: 0,
+        rowsPerPage: 10,
+        sortOrder: "RANK",
+        query: "raw search test*",
+      });
+      //assert that the query was passed in as-is
+      expect(searchPromise).toHaveBeenLastCalledWith({
+        currentPage: 0,
+        rowsPerPage: 10,
+        sortOrder: "RANK",
+        query: "raw search test",
+      });
+      /*assert that there were only two calls - initial search and Enter key triggered.
+      if the debounce was still on, this would be three calls -
+      the initial search, the search triggered by the debounce,
+      and the search triggered by the Enter key.*/
+      expect(searchPromise).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -95,6 +95,32 @@ describe("<SearchPage/>", () => {
     });
   };
 
+  /**
+   * Do a raw query search with fake timer. Turns on raw search mode, enters a search and hits enter.
+   * Waits for the debounce after the enter key.
+   * @param searchTerm The specified search term.
+   */
+  const rawQuerySearch = async (searchTerm: string) => {
+    jest.useFakeTimers("modern");
+    const input = component.find(SEARCHBAR_ID);
+    const rawModeSwitch = component.find(RAW_SEARCH_TOGGLE_ID);
+    //turn raw search mode on
+    await awaitAct(() =>
+      rawModeSwitch.simulate("change", { target: { checked: true } })
+    );
+    //add the searchTerm
+    await awaitAct(() => {
+      input.simulate("change", { target: { value: searchTerm } });
+    });
+    //Hit Enter and wait for debounce
+    await awaitAct(() => {
+      input.simulate("keyDown", {
+        keyCode: ENTER_KEYCODE,
+      });
+      jest.advanceTimersByTime(1000);
+    });
+  };
+
   it("should retrieve search settings and do a search when the page is opened", () => {
     expect(
       SearchSettingsModule.getSearchSettingsFromServer
@@ -182,22 +208,7 @@ describe("<SearchPage/>", () => {
   });
 
   it("should not debounce and send query as-is when in raw search mode", async () => {
-    const input = component.find(SEARCHBAR_ID);
-    const rawModeSwitch = component.find(RAW_SEARCH_TOGGLE_ID);
-
-    //turn raw search mode on, add a search query and hit enter
-    await awaitAct(() =>
-      rawModeSwitch.simulate("change", { target: { checked: true } })
-    );
-    await awaitAct(() =>
-      input.simulate("change", { target: { value: "raw search test" } })
-    );
-    await awaitAct(() =>
-      input.simulate("keyDown", {
-        keyCode: ENTER_KEYCODE,
-      })
-    );
-
+    await rawQuerySearch("raw search test");
     //assert that the query was passed in as-is
     expect(SearchModule.searchItems).toHaveBeenLastCalledWith({
       ...defaultSearchOptions,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -32,6 +32,9 @@ import {
 import { BrowserRouter } from "react-router-dom";
 import { CircularProgress } from "@material-ui/core";
 
+const ENTER_KEYCODE = 13;
+const SEARCHBAR_ID = "input[id='searchBar']";
+const RAW_SEARCH_TOGGLE_ID = "input[id='rawSearch']";
 const mockSearch = jest.spyOn(SearchModule, "searchItems");
 const mockSearchSettings = jest.spyOn(
   SearchSettingsModule,
@@ -85,7 +88,7 @@ describe("<SearchPage/>", () => {
    */
   const querySearch = async (searchTerm: string) => {
     jest.useFakeTimers("modern");
-    const input = component.find("input.MuiInputBase-input");
+    const input = component.find(SEARCHBAR_ID);
     await awaitAct(() => {
       input.simulate("change", { target: { value: searchTerm } });
       jest.advanceTimersByTime(1000);
@@ -178,33 +181,20 @@ describe("<SearchPage/>", () => {
     expect(component.find(CircularProgress)).toHaveLength(0);
   });
 
-  it("should debounce and append an * when not in raw search mode", async () => {
-    await querySearch("new query");
-    expect(searchPromise).toHaveBeenLastCalledWith({
-      ...defaultSearchOptions,
-      query: "new query*",
-    });
-  });
-
   it("should not debounce and send query as-is when in raw search mode", async () => {
-    const input = component.find("input.MuiInputBase-input");
-    const rawModeSwitch = component.find("input[type='checkbox']");
+    const input = component.find(SEARCHBAR_ID);
+    const rawModeSwitch = component.find(RAW_SEARCH_TOGGLE_ID);
     await awaitAct(() => {
       //turn raw search mode on, add a search query and hit enter
       rawModeSwitch.simulate("change", { target: { checked: true } });
       jest.advanceTimersByTime(1000);
       querySearch("raw search test");
       input.simulate("keyDown", {
-        keyCode: 13,
+        keyCode: ENTER_KEYCODE,
       });
       jest.advanceTimersByTime(1000);
     });
 
-    //assert that the simple search wildcard was not appended
-    expect(searchPromise).not.toHaveBeenLastCalledWith({
-      ...defaultSearchOptions,
-      query: "raw search test*",
-    });
     //assert that the query was passed in as-is
     expect(searchPromise).toHaveBeenLastCalledWith({
       ...defaultSearchOptions,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -56,6 +56,7 @@ describe("<SearchPage/>", () => {
   let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
 
   beforeEach(async () => {
+    jest.useFakeTimers("modern");
     component = mount(
       <BrowserRouter>
         <SearchPage updateTemplate={jest.fn()} />{" "}
@@ -87,7 +88,6 @@ describe("<SearchPage/>", () => {
    * @param searchTerm The specified search term.
    */
   const querySearch = async (searchTerm: string) => {
-    jest.useFakeTimers("modern");
     const input = component.find(SEARCHBAR_ID);
     await awaitAct(() => {
       input.simulate("change", { target: { value: searchTerm } });
@@ -196,7 +196,7 @@ describe("<SearchPage/>", () => {
     });
 
     //assert that the query was passed in as-is
-    expect(searchPromise).toHaveBeenLastCalledWith({
+    expect(SearchModule.searchItems).toHaveBeenLastCalledWith({
       ...defaultSearchOptions,
       query: "raw search test",
     });
@@ -204,6 +204,6 @@ describe("<SearchPage/>", () => {
     if the debounce was still on, this would be three calls -
     the initial search, the search triggered by the debounce,
     and the search triggered by the Enter key.*/
-    expect(searchPromise).toHaveBeenCalledTimes(2);
+    expect(SearchModule.searchItems).toHaveBeenCalledTimes(2);
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -161,15 +161,15 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
               rawSearchMode={useRawSearch}
               onChange={handleQueryChanged}
             />
-            <Grid container justify={"flex-end"}>
+            <Grid container justify="flex-end">
               <Grid item>
                 <Tooltip title={searchStrings.rawSearchTooltip}>
                   <FormControlLabel
-                    labelPlacement={"start"}
+                    labelPlacement="start"
                     label={searchStrings.rawSearch}
                     control={
                       <Switch
-                        size={"small"}
+                        size="small"
                         onChange={(_, checked) => setUseRawSearch(checked)}
                         value={useRawSearch}
                         name={searchStrings.rawSearch}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -28,13 +28,16 @@ import {
   CardActions,
   CardContent,
   CardHeader,
+  CircularProgress,
+  FormControlLabel,
   Grid,
   List,
   ListItem,
-  TablePagination,
-  Typography,
-  CircularProgress,
   makeStyles,
+  Switch,
+  TablePagination,
+  Tooltip,
+  Typography,
 } from "@material-ui/core";
 import {
   defaultPagedSearchResult,
@@ -66,7 +69,7 @@ const useStyles = makeStyles({
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
   const classes = useStyles();
-
+  const [useRawSearch, setUseRawSearch] = useState<boolean>(false);
   const [searchOptions, setSearchOptions] = useState<SearchOptions>(
     defaultSearchOptions
   );
@@ -154,7 +157,28 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       <Grid item xs={9}>
         <Card>
           <CardContent>
-            <SearchBar onChange={handleQueryChanged} />
+            <SearchBar
+              rawSearchMode={useRawSearch}
+              onChange={handleQueryChanged}
+            />
+            <Grid container justify={"flex-end"}>
+              <Grid item>
+                <Tooltip title={searchStrings.rawSearchTooltip}>
+                  <FormControlLabel
+                    labelPlacement={"start"}
+                    label={searchStrings.rawSearch}
+                    control={
+                      <Switch
+                        size={"small"}
+                        onChange={(_, checked) => setUseRawSearch(checked)}
+                        value={useRawSearch}
+                        name={searchStrings.rawSearch}
+                      />
+                    }
+                  />
+                </Tooltip>
+              </Grid>
+            </Grid>
           </CardContent>
         </Card>
       </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -169,6 +169,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
                     label={searchStrings.rawSearch}
                     control={
                       <Switch
+                        id="rawSearch"
                         size="small"
                         onChange={(_, checked) => setUseRawSearch(checked)}
                         value={useRawSearch}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -54,7 +54,7 @@ export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
   /**
    * uses lodash to debounce the search query by half a second
    */
-  const delayedQuery = useCallback(debounce(callOnChange, 500), [onChange]);
+  const debouncedQuery = useCallback(debounce(callOnChange, 500), [onChange]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     switch (event.keyCode) {
@@ -64,14 +64,14 @@ export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
         break;
       case ENTER_KEY_CODE:
         event.preventDefault();
-        callOnChange(query);
+        debouncedQuery(query);
         break;
     }
   };
   const handleQueryChange = (query: string) => {
     setQuery(query);
     if (!rawSearchMode) {
-      delayedQuery(query);
+      debouncedQuery(query);
     }
   };
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -21,14 +21,23 @@ import { useCallback } from "react";
 import SearchIcon from "@material-ui/icons/Search";
 import { Close } from "@material-ui/icons";
 import { debounce } from "lodash";
+import { languageStrings } from "../../util/langstrings";
 
+const ENTER_KEY_CODE = 13;
 const ESCAPE_KEY_CODE = 27;
+
 interface SearchBarProps {
   /**
    * Callback fired when the user stops typing (debounced for 500 milliseconds).
    * @param query The string to search.
    */
   onChange: (query: string) => void;
+  /**
+   * Flag for raw search mode.
+   * If false, search is a debounced type-ahead style simple search with a * wildcard added automatically.
+   * If true, search occurs only on Enter press and is an explicit search which supports Lucene syntax.
+   */
+  rawSearchMode: boolean;
 }
 
 /**
@@ -37,30 +46,44 @@ interface SearchBarProps {
  * This component does not handle the API query itself,
  * that should be done in the parent component with the onChange callback.
  */
-export default function SearchBar({ onChange }: SearchBarProps) {
+export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
   const [query, setQuery] = React.useState<string>("");
-
+  const strings = languageStrings.searchpage;
   /**
    * uses lodash to debounce the search query by half a second
    */
   const delayedQuery = useCallback(
-    debounce((query: string) => onChange(query), 500),
+    debounce((query: string) => onChange(query + "*"), 500),
     [onChange]
   );
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (event.keyCode) {
+      case ESCAPE_KEY_CODE:
+        event.preventDefault();
+        handleQueryChange("");
+        break;
+      case ENTER_KEY_CODE:
+        event.preventDefault();
+        if (rawSearchMode) {
+          onChange(query);
+        } else {
+          onChange(query + "*");
+        }
+        break;
+    }
+  };
   const handleQueryChange = (query: string) => {
     setQuery(query);
-    delayedQuery(query);
+    if (!rawSearchMode) {
+      delayedQuery(query);
+    }
   };
 
   return (
     <TextField
-      onKeyDown={(event) => {
-        if (event.keyCode == ESCAPE_KEY_CODE) {
-          event.preventDefault();
-          handleQueryChange("");
-        }
-      }}
+      helperText={rawSearchMode ? strings.pressEnterToSearch : " "}
+      onKeyDown={handleKeyDown}
       InputProps={{
         startAdornment: (
           <InputAdornment position="start">

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -49,13 +49,12 @@ interface SearchBarProps {
 export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
   const [query, setQuery] = React.useState<string>("");
   const strings = languageStrings.searchpage;
+  const callOnChange = (query: string) =>
+    onChange(query + (rawSearchMode ? "" : "*"));
   /**
    * uses lodash to debounce the search query by half a second
    */
-  const delayedQuery = useCallback(
-    debounce((query: string) => onChange(query + "*"), 500),
-    [onChange]
-  );
+  const delayedQuery = useCallback(debounce(callOnChange, 500), [onChange]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     switch (event.keyCode) {
@@ -65,11 +64,7 @@ export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
         break;
       case ENTER_KEY_CODE:
         event.preventDefault();
-        if (rawSearchMode) {
-          onChange(query);
-        } else {
-          onChange(query + "*");
-        }
+        callOnChange(query);
         break;
     }
   };
@@ -82,6 +77,7 @@ export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
 
   return (
     <TextField
+      id="searchBar"
       helperText={rawSearchMode ? strings.pressEnterToSearch : " "}
       onKeyDown={handleKeyDown}
       InputProps={{

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -315,6 +315,9 @@ export const languageStrings = {
     noResultsFound: "No results found.",
     refineTitle: "Refine search",
     modifiedDate: "Modified",
+    rawSearch: "Raw Search",
+    pressEnterToSearch: "Press enter to search",
+    rawSearchTooltip: "Supports use of Apache Lucene search syntax",
     searchresult: {
       attachments: "Attachments",
       dateModified: "Modified",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change
- Adds a toggle to the search page for "raw search" mode. 
- When raw search is off, search queries are de-bounced type-ahead, sent to the server side with an appended '*' wildcard
- When raw search is on, search queries are sent as-is, and only when you hit enter
- Helper-text to remind the user to hit Enter appears when in raw search mode
- Tool-tip appears when hovering on the toggle to explain the purpose of raw search mode
- Jest tests to assert that type-ahead and wildcard append happen in simple search mode
- Jest test to assert that type-ahead and wildcard append do not happen in raw search mode
![image](https://user-images.githubusercontent.com/24543345/87269018-5fc2ba80-c50f-11ea-97b1-e58bb70a7c3e.png)
![image](https://user-images.githubusercontent.com/24543345/87269123-97316700-c50f-11ea-9b47-40dac883d32f.png)
![image](https://user-images.githubusercontent.com/24543345/87269273-05762980-c510-11ea-9360-2caf0fefaae8.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
