### PR TITLE
Add support for GET /api/collection to API module

### DIFF
--- a/oeq-ts-rest-api/src/Collection.ts
+++ b/oeq-ts-rest-api/src/Collection.ts
@@ -43,6 +43,6 @@ export const listCollections = (
   return GET<Common.PagedResult<Common.BaseEntity>>(
     apiBasePath + COLLECTION_ROOT_PATH,
     validator,
-    params ?? undefined
+    params
   );
 };

--- a/oeq-ts-rest-api/src/Collection.ts
+++ b/oeq-ts-rest-api/src/Collection.ts
@@ -1,0 +1,48 @@
+import * as Common from './Common';
+import { GET } from './AxiosInstance';
+import * as Security from './Security';
+import { is } from 'typescript-is';
+
+export interface CollectionSecurity extends Security.BaseEntitySecurity {
+  dynamicRules: Security.DynamicRule[];
+  metadata: Record<string, Security.ItemMetadataSecurity>;
+  statuses: Record<string, Security.TargetListEntry[]>;
+}
+
+export interface Collection extends Common.BaseEntity {
+  schema: Common.BaseEntityReference;
+  workflow?: Common.BaseEntityReference;
+  reviewPeriod?: number;
+  security: CollectionSecurity;
+  filestoreId: string;
+}
+
+const isPagedCollection = (
+  instance: unknown
+): instance is Common.PagedResult<Collection> =>
+  is<Common.PagedResult<Collection>>(instance);
+
+const COLLECTION_ROOT_PATH = '/collection';
+
+/**
+ * List all available collections which the currently authenticated user has access to. Results can
+ * be customised based on params, and if the `full` param is specified then the return value is
+ * actually `Collection` with all details.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param params Query parameters to customize (and/or page) result
+ */
+export const listCollections = (
+  apiBasePath: string,
+  params?: Common.ListCommonParams
+): Promise<Common.PagedResult<Common.BaseEntity>> => {
+  // Only if the `full` param is specified do you get a whole Collection definition, otherwise
+  // it's the bare minimum of BaseEntity.
+  const validator = params?.full ? isPagedCollection : Common.isPagedBaseEntity;
+
+  return GET<Common.PagedResult<Common.BaseEntity>>(
+    apiBasePath + COLLECTION_ROOT_PATH,
+    validator,
+    params ?? undefined
+  );
+};

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -1,5 +1,5 @@
 import * as Security from './Security';
-import { is } from 'typescript-is';
+import {is} from 'typescript-is';
 
 export type i18nString = string;
 
@@ -45,6 +45,14 @@ export interface BaseEntity {
   links: Record<string, string>;
 }
 
+export interface BaseEntityReference {
+  uuid: string;
+  name?: i18nString;
+
+  // BEWARE: The server model (com.tle.common.interfaces.BaseEntityReference) has 'extras'
+  // which means there's potential for additional fields added dynamically at runtime.
+}
+
 export enum ItemStatus {
   DRAFT = 'DRAFT',
   LIVE = 'LIVE',
@@ -74,3 +82,29 @@ export interface PagedResult<T> {
 export const isPagedBaseEntity = (
   instance: unknown
 ): instance is PagedResult<BaseEntity> => is<PagedResult<BaseEntity>>(instance);
+
+/**
+ * Query params for common to listing endpoints. All are optional!
+ */
+export interface ListCommonParams {
+    /**
+     * Search name and description
+     */
+    q?: string;
+    /**
+     * Privilege(s) to filter by
+     */
+    privilege?: string[];
+    /**
+     * Resumption token for paging
+     */
+    resumptionToken?: string;
+    /**
+     * Number of results
+     */
+    length?: number;
+    /**
+     * Return full entity (needs VIEW or EDIT privilege)
+     */
+    full?: boolean;
+}

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -1,5 +1,5 @@
 import * as Security from './Security';
-import {is} from 'typescript-is';
+import { is } from 'typescript-is';
 
 export type i18nString = string;
 
@@ -87,24 +87,24 @@ export const isPagedBaseEntity = (
  * Query params for common to listing endpoints. All are optional!
  */
 export interface ListCommonParams {
-    /**
-     * Search name and description
-     */
-    q?: string;
-    /**
-     * Privilege(s) to filter by
-     */
-    privilege?: string[];
-    /**
-     * Resumption token for paging
-     */
-    resumptionToken?: string;
-    /**
-     * Number of results
-     */
-    length?: number;
-    /**
-     * Return full entity (needs VIEW or EDIT privilege)
-     */
-    full?: boolean;
+  /**
+   * Search name and description
+   */
+  q?: string;
+  /**
+   * Privilege(s) to filter by
+   */
+  privilege?: string[];
+  /**
+   * Resumption token for paging
+   */
+  resumptionToken?: string;
+  /**
+   * Number of results
+   */
+  length?: number;
+  /**
+   * Return full entity (needs VIEW or EDIT privilege)
+   */
+  full?: boolean;
 }

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -1,6 +1,6 @@
 import * as Common from './Common';
-import {GET} from './AxiosInstance';
-import {is} from 'typescript-is';
+import { GET } from './AxiosInstance';
+import { is } from 'typescript-is';
 
 export interface Citation {
   name: string;

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -1,6 +1,6 @@
 import * as Common from './Common';
-import { GET } from './AxiosInstance';
-import { is } from 'typescript-is';
+import {GET} from './AxiosInstance';
+import {is} from 'typescript-is';
 
 export interface Citation {
   name: string;
@@ -22,32 +22,6 @@ export interface EquellaSchema extends Schema {
   importTransformsMap: Record<string, string>;
   ownerUuid: string;
   serializedDefinition: string;
-}
-
-/**
- * Query params for listing of schemas. All are optional!
- */
-export interface ListSchemaParams {
-  /**
-   * Search name and description
-   */
-  q?: string;
-  /**
-   * Privilege(s) to filter by
-   */
-  privilege?: string[];
-  /**
-   * Resumption token for paging
-   */
-  resumptionToken?: string;
-  /**
-   * Number of results
-   */
-  length?: number;
-  /**
-   * Return full entity (needs VIEW or EDIT privilege)
-   */
-  full?: boolean;
 }
 
 /**
@@ -81,7 +55,7 @@ const SCHEMA_ROOT_PATH = '/schema';
  */
 export const listSchemas = (
   apiBasePath: string,
-  params?: ListSchemaParams
+  params?: Common.ListCommonParams
 ): Promise<Common.PagedResult<Common.BaseEntity>> => {
   // Only if the `full` param is specified do you get a whole Schema definition, otherwise
   // it's the bare minimum of BaseEntity.

--- a/oeq-ts-rest-api/src/Schema.ts
+++ b/oeq-ts-rest-api/src/Schema.ts
@@ -66,7 +66,7 @@ export const listSchemas = (
   return GET<Common.PagedResult<Common.BaseEntity>>(
     apiBasePath + SCHEMA_ROOT_PATH,
     validator,
-    params ?? undefined
+    params
   );
 };
 

--- a/oeq-ts-rest-api/src/Security.ts
+++ b/oeq-ts-rest-api/src/Security.ts
@@ -8,3 +8,16 @@ export interface TargetListEntry {
 export interface BaseEntitySecurity {
   rules: TargetListEntry[];
 }
+
+export interface ItemMetadataSecurity {
+  name: string;
+  script: string
+  entries: TargetListEntry[];
+}
+
+export interface DynamicRule {
+  name: string;
+  path: string;
+  type: string;
+  targetList:  TargetListEntry[];
+}

--- a/oeq-ts-rest-api/src/Security.ts
+++ b/oeq-ts-rest-api/src/Security.ts
@@ -11,7 +11,7 @@ export interface BaseEntitySecurity {
 
 export interface ItemMetadataSecurity {
   name: string;
-  script: string
+  script: string;
   entries: TargetListEntry[];
 }
 
@@ -19,5 +19,5 @@ export interface DynamicRule {
   name: string;
   path: string;
   type: string;
-  targetList:  TargetListEntry[];
+  targetList: TargetListEntry[];
 }

--- a/oeq-ts-rest-api/src/index.ts
+++ b/oeq-ts-rest-api/src/index.ts
@@ -1,4 +1,5 @@
 export * as Auth from './Auth';
+export * as Collection from './Collection';
 export * as Common from './Common';
 export * as LegacyContent from './LegacyContent';
 export * as Errors from './Errors';

--- a/oeq-ts-rest-api/test/collection.test.ts
+++ b/oeq-ts-rest-api/test/collection.test.ts
@@ -1,0 +1,28 @@
+import * as OEQ from '../src';
+import * as TC from './TestConfig';
+
+beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
+
+afterAll(() => OEQ.Auth.logout(TC.API_PATH, true));
+
+describe('Listing collections', () => {
+  it('should be possible list collections with no params', async () => {
+    const result = await OEQ.Collection.listCollections(TC.API_PATH);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.results).toHaveLength(result.length);
+  });
+
+  it('should be possible to retrieve a custom list of collections via params', async () => {
+    const howMany = 8;
+    const result = await OEQ.Collection.listCollections(TC.API_PATH, {
+      length: howMany,
+      full: true,
+    });
+    expect(result).toHaveLength(howMany);
+    // confirm that `full` returned additional information
+    expect(result.results[0].createdDate).toBeTruthy();
+    expect(
+      (result.results[0] as OEQ.Collection.Collection).filestoreId
+    ).toEqual('default');
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds support for the main GET endpoint to list oEQ Collections. This is initially needed so that we can provide a list of collections to filter search results by, however full support is provided here (including the use of the `full` flag).

This is _very_ similar to the Schema endpoint, and so we have a pattern now emerging. I think any BaseEntity related Resources will more or less follow this. But we'll want to see more - especially as we start to also edit them (so far we've only done retrievals).

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
