### PR TITLE
Feature/search2 API attachment enhancements

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -207,13 +207,13 @@ object SearchHelper {
       .map(
         att =>
           SearchResultAttachment(
-            att.getRawAttachmentType,
-            att.getUuid,
-            Option(att.getDescription),
-            att.isPreview,
-            getMimetypeForAttachment(att),
-            !thumbExists(itemKey, att.getUuid),
-            getLinksFromBean(att)
+            attachmentType = att.getRawAttachmentType,
+            id = att.getUuid,
+            description = Option(att.getDescription),
+            preview = att.isPreview,
+            mimeType = getMimetypeForAttachment(att),
+            isPlaceholderThumb = !thumbExists(itemKey, att.getUuid),
+            links = getLinksFromBean(att)
         ))
       .toList
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -211,7 +211,7 @@ object SearchHelper {
             att.getUuid,
             Option(att.getDescription),
             att.isPreview,
-            getFilenameFromBean(att),
+            getMimetypeForAttachment(att),
             !thumbExists(itemKey, att.getUuid),
             getLinksFromBean(att)
         ))
@@ -228,9 +228,9 @@ object SearchHelper {
   }
 
   /**
-    * Extract the filename for AbstractExtendableBean.
+    * Extract the mimetype for AbstractExtendableBean.
     */
-  def getFilenameFromBean[T <: AbstractExtendableBean](bean: T): Option[String] = {
+  def getMimetypeForAttachment[T <: AbstractExtendableBean](bean: T): Option[String] = {
     bean match {
       case file: AbstractFileAttachmentBean =>
         Option(LegacyGuice.mimeTypeService.getMimeTypeForFilename(file.getFilename))

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -63,6 +63,7 @@ case class SearchResultItem(
   * @param description The description of an attachment.
   * @param preview If an attachment can be previewed or not.
   * @param mimeType Mime Type of file based attachments
+  * @param isPlaceholderThumb Indicates if an attachment does not yet have a generated thumbnail
   * @param links Attachment's links.
   */
 case class SearchResultAttachment(

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -62,6 +62,7 @@ case class SearchResultItem(
   * @param id The unique ID of an attachment.
   * @param description The description of an attachment.
   * @param preview If an attachment can be previewed or not.
+  * @param mimeType Mime Type of file based attachments
   * @param links Attachment's links.
   */
 case class SearchResultAttachment(
@@ -69,5 +70,7 @@ case class SearchResultAttachment(
     id: String,
     description: Option[String],
     preview: Boolean,
+    mimeType: Option[String],
+    isPlaceholderThumb: Boolean,
     links: java.util.Map[String, String]
 )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1306

Two new attachment properties have been added to the SearchHelper object, used by the search2 api endpoint:
- Mimetype (for file based attachments)
- isPlaceholderThumb: Indicates if an attachment does not yet have a generated thumbnail

The plan is to eventually use these two properties to display more pleasing thumbnails in the SearchResult frontend component


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
