### PR TITLE
Refactor raw search into searchbar

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
@@ -18,7 +18,6 @@
 import * as React from "react";
 import SearchBar from "../../tsrc/search/components/SearchBar";
 import { action } from "@storybook/addon-actions";
-import { boolean } from "@storybook/addon-knobs";
 
 export default {
   title: "SearchBar",
@@ -26,8 +25,5 @@ export default {
 };
 
 export const BasicSearchPage = () => (
-  <SearchBar
-    onChange={action("OnChange called")}
-    rawSearchMode={boolean("raw search mode", false)}
-  />
+  <SearchBar onChange={action("OnChange called")} />
 );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -29,14 +29,11 @@ import {
   CardContent,
   CardHeader,
   CircularProgress,
-  FormControlLabel,
   Grid,
   List,
   ListItem,
   makeStyles,
-  Switch,
   TablePagination,
-  Tooltip,
   Typography,
 } from "@material-ui/core";
 import {
@@ -69,7 +66,6 @@ const useStyles = makeStyles({
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
   const classes = useStyles();
-  const [useRawSearch, setUseRawSearch] = useState<boolean>(false);
   const [searchOptions, setSearchOptions] = useState<SearchOptions>(
     defaultSearchOptions
   );
@@ -157,29 +153,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       <Grid item xs={9}>
         <Card>
           <CardContent>
-            <SearchBar
-              rawSearchMode={useRawSearch}
-              onChange={handleQueryChanged}
-            />
-            <Grid container justify="flex-end">
-              <Grid item>
-                <Tooltip title={searchStrings.rawSearchTooltip}>
-                  <FormControlLabel
-                    labelPlacement="start"
-                    label={searchStrings.rawSearch}
-                    control={
-                      <Switch
-                        id="rawSearch"
-                        size="small"
-                        onChange={(_, checked) => setUseRawSearch(checked)}
-                        value={useRawSearch}
-                        name={searchStrings.rawSearch}
-                      />
-                    }
-                  />
-                </Tooltip>
-              </Grid>
-            </Grid>
+            <SearchBar onChange={handleQueryChanged} />
           </CardContent>
         </Card>
       </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -15,9 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IconButton, InputAdornment, TextField } from "@material-ui/core";
+import {
+  FormControlLabel,
+  Grid,
+  IconButton,
+  InputAdornment,
+  Switch,
+  TextField,
+  Tooltip,
+} from "@material-ui/core";
 import * as React from "react";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import SearchIcon from "@material-ui/icons/Search";
 import { Close } from "@material-ui/icons";
 import { debounce } from "lodash";
@@ -32,12 +40,6 @@ interface SearchBarProps {
    * @param query The string to search.
    */
   onChange: (query: string) => void;
-  /**
-   * Flag for raw search mode.
-   * If false, search is a debounced type-ahead style simple search with a * wildcard added automatically.
-   * If true, search occurs only on Enter press and is an explicit search which supports Lucene syntax.
-   */
-  rawSearchMode: boolean;
 }
 
 /**
@@ -46,7 +48,9 @@ interface SearchBarProps {
  * This component does not handle the API query itself,
  * that should be done in the parent component with the onChange callback.
  */
-export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
+export default function SearchBar({ onChange }: SearchBarProps) {
+  const searchStrings = languageStrings.searchpage;
+  const [rawSearchMode, setRawSearchMode] = useState<boolean>(false);
   const [query, setQuery] = React.useState<string>("");
   const strings = languageStrings.searchpage;
   const callOnChange = (query: string) =>
@@ -76,28 +80,54 @@ export default function SearchBar({ onChange, rawSearchMode }: SearchBarProps) {
   };
 
   return (
-    <TextField
-      id="searchBar"
-      helperText={rawSearchMode ? strings.pressEnterToSearch : " "}
-      onKeyDown={handleKeyDown}
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <SearchIcon fontSize="small" />
-          </InputAdornment>
-        ),
-        endAdornment: query.length > 0 && (
-          <IconButton onClick={() => handleQueryChange("")} size="small">
-            <Close />
-          </IconButton>
-        ),
-      }}
-      fullWidth
-      onChange={(event) => {
-        handleQueryChange(event.target.value);
-      }}
-      variant="standard"
-      value={query}
-    />
+    <Grid container direction="row">
+      <Grid item xs={10}>
+        <TextField
+          id="searchBar"
+          helperText={rawSearchMode ? strings.pressEnterToSearch : " "}
+          onKeyDown={handleKeyDown}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+            endAdornment: query.length > 0 && (
+              <IconButton onClick={() => handleQueryChange("")} size="small">
+                <Close />
+              </IconButton>
+            ),
+          }}
+          fullWidth
+          onChange={(event) => {
+            handleQueryChange(event.target.value);
+          }}
+          variant="standard"
+          value={query}
+        />
+      </Grid>
+      {/* inline style ensures the raw search controls align vertically to the searchbar*/}
+      <Grid xs={2} item style={{ alignSelf: "center" }}>
+        {/* inline style ensures that the raw search control justifies to the right of it's grid item*/}
+        <Tooltip
+          title={searchStrings.rawSearchTooltip}
+          style={{ float: "right" }}
+        >
+          <FormControlLabel
+            labelPlacement="start"
+            label={searchStrings.rawSearch}
+            control={
+              <Switch
+                id="rawSearch"
+                size="small"
+                onChange={(_, checked) => setRawSearchMode(checked)}
+                value={rawSearchMode}
+                name={searchStrings.rawSearch}
+              />
+            }
+          />
+        </Tooltip>
+      </Grid>
+    </Grid>
   );
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -51,14 +51,17 @@ interface SearchBarProps {
 export default function SearchBar({ onChange }: SearchBarProps) {
   const searchStrings = languageStrings.searchpage;
   const [rawSearchMode, setRawSearchMode] = useState<boolean>(false);
-  const [query, setQuery] = React.useState<string>("");
+  const [queryString, setQuery] = React.useState<string>("");
   const strings = languageStrings.searchpage;
   const callOnChange = (query: string) =>
     onChange(query + (rawSearchMode ? "" : "*"));
   /**
    * uses lodash to debounce the search query by half a second
    */
-  const debouncedQuery = useCallback(debounce(callOnChange, 500), [onChange]);
+  const debouncedQuery = useCallback(debounce(callOnChange, 500), [
+    onChange,
+    rawSearchMode,
+  ]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     switch (event.keyCode) {
@@ -68,7 +71,7 @@ export default function SearchBar({ onChange }: SearchBarProps) {
         break;
       case ENTER_KEY_CODE:
         event.preventDefault();
-        debouncedQuery(query);
+        debouncedQuery(queryString);
         break;
     }
   };
@@ -92,7 +95,7 @@ export default function SearchBar({ onChange }: SearchBarProps) {
                 <SearchIcon fontSize="small" />
               </InputAdornment>
             ),
-            endAdornment: query.length > 0 && (
+            endAdornment: queryString.length > 0 && (
               <IconButton onClick={() => handleQueryChange("")} size="small">
                 <Close />
               </IconButton>
@@ -103,7 +106,7 @@ export default function SearchBar({ onChange }: SearchBarProps) {
             handleQueryChange(event.target.value);
           }}
           variant="standard"
-          value={query}
+          value={queryString}
         />
       </Grid>
       {/* inline style ensures the raw search controls align vertically to the searchbar*/}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included (existing tests cover this area)
- [x] screenshots are included showing significant UI changes

##### Description of change
- Move raw search controls into SearchBar.tsx from SearchPage.tsx
- Use grid and styles to place the raw search control to the right hand side of the search bar rather than underneath, with some extra room for language string changes
![image](https://user-images.githubusercontent.com/24543345/87492313-9c1c2500-c68d-11ea-9176-cc828d497b80.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
