### PR TITLE
Trim the search query and only append wildcard to non-empty queries

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -141,6 +141,14 @@ describe("<SearchPage/>", () => {
     expect(component.html()).toContain("266bb0ff-a730-4658-aec0-c68bbefc227c");
   });
 
+  it("should not append a wildcard for a search which is empty when trimmed", async () => {
+    await querySearch("      ");
+    expect(SearchModule.searchItems).toHaveBeenCalledWith({
+      ...defaultSearchOptions,
+      query: "",
+    });
+  });
+
   it("should display 'No results found.' when there are no search results", async () => {
     mockSearch.mockImplementationOnce(() =>
       Promise.resolve(getEmptySearchResult)

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -53,8 +53,10 @@ export default function SearchBar({ onChange }: SearchBarProps) {
   const [rawSearchMode, setRawSearchMode] = useState<boolean>(false);
   const [queryString, setQuery] = React.useState<string>("");
   const strings = languageStrings.searchpage;
-  const callOnChange = (query: string) =>
-    onChange(query + (rawSearchMode ? "" : "*"));
+  const callOnChange = (query: string) => {
+    const trimmedQuery = query.trim();
+    onChange(trimmedQuery + (rawSearchMode || !trimmedQuery ? "" : "*"));
+  };
   /**
    * uses lodash to debounce the search query by half a second
    */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -53,10 +53,15 @@ export default function SearchBar({ onChange }: SearchBarProps) {
   const [rawSearchMode, setRawSearchMode] = useState<boolean>(false);
   const [queryString, setQuery] = React.useState<string>("");
   const strings = languageStrings.searchpage;
+
   const callOnChange = (query: string) => {
+    //only append the wildcard if raw search is off, and the query isn't blank
     const trimmedQuery = query.trim();
-    onChange(trimmedQuery + (rawSearchMode || !trimmedQuery ? "" : "*"));
+    const appendWildcard = !rawSearchMode && trimmedQuery.length > 0;
+    const formattedQuery = trimmedQuery + (appendWildcard ? "*" : "");
+    onChange(formattedQuery);
   };
+
   /**
    * uses lodash to debounce the search query by half a second
    */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
WIldcard for simple search was getting incorrectly appended to empty search queries. This fix trims the query before sending it and only appends the wildcard for non-empty searches.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
