### PR TITLE
Restyle new search bar

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
   },
   divider: {
     height: 28,
-    margin: "4px 12px 4px",
+    margin: "4px 12px",
   },
 });
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -16,25 +16,37 @@
  * limitations under the License.
  */
 import {
-  Card,
-  CardContent,
+  Divider,
   FormControlLabel,
-  Grid,
   IconButton,
-  InputAdornment,
+  InputBase,
+  Paper,
   Switch,
-  TextField,
   Tooltip,
 } from "@material-ui/core";
 import * as React from "react";
 import { useCallback, useState } from "react";
 import SearchIcon from "@material-ui/icons/Search";
-import { Close } from "@material-ui/icons";
 import { debounce } from "lodash";
 import { languageStrings } from "../../util/langstrings";
+import { makeStyles } from "@material-ui/core/styles";
 
 const ENTER_KEY_CODE = 13;
 const ESCAPE_KEY_CODE = 27;
+
+const useStyles = makeStyles({
+  root: {
+    display: "flex",
+    alignItems: "center",
+  },
+  input: {
+    flex: "auto",
+  },
+  divider: {
+    height: 28,
+    margin: "4px 12px 4px",
+  },
+});
 
 interface SearchBarProps {
   /**
@@ -51,6 +63,8 @@ interface SearchBarProps {
  * that should be done in the parent component with the onChange callback.
  */
 export default function SearchBar({ onChange }: SearchBarProps) {
+  const classes = useStyles();
+
   const searchStrings = languageStrings.searchpage;
   const [rawSearchMode, setRawSearchMode] = useState<boolean>(false);
   const [queryString, setQuery] = React.useState<string>("");
@@ -72,7 +86,7 @@ export default function SearchBar({ onChange }: SearchBarProps) {
     rawSearchMode,
   ]);
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     switch (event.keyCode) {
       case ESCAPE_KEY_CODE:
         event.preventDefault();
@@ -84,6 +98,7 @@ export default function SearchBar({ onChange }: SearchBarProps) {
         break;
     }
   };
+
   const handleQueryChange = (query: string) => {
     setQuery(query);
     if (!rawSearchMode) {
@@ -92,61 +107,37 @@ export default function SearchBar({ onChange }: SearchBarProps) {
   };
 
   return (
-    <Card>
-      <CardContent>
-        <Grid container direction="row">
-          <Grid item xs={10}>
-            <TextField
-              id="searchBar"
-              helperText={rawSearchMode ? strings.pressEnterToSearch : " "}
-              onKeyDown={handleKeyDown}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon fontSize="small" />
-                  </InputAdornment>
-                ),
-                endAdornment: queryString.length > 0 && (
-                  <IconButton
-                    onClick={() => handleQueryChange("")}
-                    size="small"
-                  >
-                    <Close />
-                  </IconButton>
-                ),
-              }}
-              fullWidth
-              onChange={(event) => {
-                handleQueryChange(event.target.value);
-              }}
-              variant="standard"
-              value={queryString}
+    <Paper className={classes.root}>
+      <IconButton
+        onClick={() => debouncedQuery(queryString)}
+        aria-label={strings.title}
+      >
+        <SearchIcon />
+      </IconButton>
+      <InputBase
+        id="searchBar"
+        className={classes.input}
+        onKeyDown={handleKeyDown}
+        onChange={(event) => {
+          handleQueryChange(event.target.value);
+        }}
+        value={queryString}
+        placeholder={rawSearchMode ? strings.pressEnterToSearch : strings.title}
+      />
+      <Divider className={classes.divider} orientation="vertical" />
+      <Tooltip title={searchStrings.rawSearchTooltip}>
+        <FormControlLabel
+          label={searchStrings.rawSearch}
+          control={
+            <Switch
+              id="rawSearch"
+              onChange={(_, checked) => setRawSearchMode(checked)}
+              value={rawSearchMode}
+              name={searchStrings.rawSearch}
             />
-          </Grid>
-          {/* inline style ensures the raw search controls align vertically to the searchbar*/}
-          <Grid xs={2} item style={{ alignSelf: "center" }}>
-            {/* inline style ensures that the raw search control justifies to the right of it's grid item*/}
-            <Tooltip
-              title={searchStrings.rawSearchTooltip}
-              style={{ float: "right" }}
-            >
-              <FormControlLabel
-                labelPlacement="start"
-                label={searchStrings.rawSearch}
-                control={
-                  <Switch
-                    id="rawSearch"
-                    size="small"
-                    onChange={(_, checked) => setRawSearchMode(checked)}
-                    value={rawSearchMode}
-                    name={searchStrings.rawSearch}
-                  />
-                }
-              />
-            </Tooltip>
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
+          }
+        />
+      </Tooltip>
+    </Paper>
   );
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -316,7 +316,7 @@ export const languageStrings = {
     refineTitle: "Refine search",
     modifiedDate: "Modified",
     rawSearch: "Raw Search",
-    pressEnterToSearch: "Press enter to search",
+    pressEnterToSearch: "Raw Search enabled, press enter to search",
     rawSearchTooltip: "Supports use of Apache Lucene search syntax",
     searchresult: {
       attachments: "Attachments",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -315,8 +315,8 @@ export const languageStrings = {
     noResultsFound: "No results found.",
     refineTitle: "Refine search",
     modifiedDate: "Modified",
-    rawSearch: "Raw Search",
-    pressEnterToSearch: "Raw Search enabled, press enter to search",
+    rawSearch: "Raw search",
+    pressEnterToSearch: "Raw search enabled, press enter to search",
     rawSearchTooltip: "Supports use of Apache Lucene search syntax",
     searchresult: {
       attachments: "Attachments",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

So as to be a bit cleaner, and similar to a number of Material Design
search bars you see about the place - so as to hopefully feel
contemporary to users.

Required custom styling, but I think that's acceptable in this case as
we wanted something a little different and it is a key/special component
as one of the main ones users interact with.

Note two changes:

1. I've made the search button on the left hand side clickable; and
2. I haven't included the button to clear a search - I really wanted to try and keep it as minimal and clean as needed. I figured between ESC and backspace users should have enough.... :thinking: 

![image](https://user-images.githubusercontent.com/43919233/87518291-6bef7900-c6c3-11ea-8376-c74ae7ef83f4.png)

#1306 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
