### PR TITLE
Add one task for 'npm run check' to core sbt

### DIFF
--- a/Source/Plugins/Core/com.equella.core/build.sbt
+++ b/Source/Plugins/Core/com.equella.core/build.sbt
@@ -133,7 +133,13 @@ buildJS := {
     .toSeq
 }
 
+buildCheck := {
+  println("Starting npm run check")
+  val rootDirectory = (baseDirectory in LocalProject("equella")).value
+  Common.nodeScript("check", rootDirectory)
+}
 resourceGenerators in Compile += buildJS.taskValue
+resourceGenerators in Compile += buildCheck.taskValue
 
 clean := {
   clean.value

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -28,6 +28,7 @@ object CommonSettings extends AutoPlugin {
     lazy val writeScriptingJavadoc = taskKey[File]("Write the scripting javadoc")
     lazy val mergeJPF              = inputKey[Unit]("Merge all")
     lazy val buildJS               = taskKey[Seq[File]]("Build JS resources")
+    lazy val buildCheck            = taskKey[Unit]("Execute npm run check")
     lazy val checkJavaCodeStyle    = taskKey[Unit]("Run checkstyle")
 
     lazy val platformCommon  = LocalProject("com_tle_platform_common")


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Currently, those npm checks are only running on GHA. So add new sbt task in core sbt in order to have those checks also running on Codebuild.
And perhaps we can take `npm run check` out from GHA’s job `Run checks`. :thinking: 