### PR TITLE
Remember search options when going 'back' to the search page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
@@ -24,6 +24,17 @@ export default {
   component: SearchBar,
 };
 
-export const BasicSearchPage = () => (
-  <SearchBar onChange={action("OnChange called")} />
-);
+const actions = {
+  onQueryChange: action("onQueryChange called"),
+  onRawModeChange: action("onRawModeChange called"),
+  doSearch: action("doSearch called"),
+};
+
+const values = {
+  query: "",
+  rawMode: false,
+};
+
+export const NonRawMode = () => <SearchBar {...actions} {...values} />;
+
+export const RawMode = () => <SearchBar {...actions} {...values} rawMode />;

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -53,8 +53,7 @@ const searchPromise = mockSearch.mockImplementation(() =>
 );
 mockCollections.mockImplementation(() => Promise.resolve(getCollectionMap));
 const defaultSearchOptions: SearchOptions = {
-  rowsPerPage: 10,
-  currentPage: 0,
+  ...SearchModule.defaultSearchOptions,
   sortOrder: SortOrder.RANK,
 };
 const defaultCollectionPrivileges = ["SEARCH_COLLECTION"];
@@ -63,6 +62,7 @@ describe("<SearchPage/>", () => {
   let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;
 
   beforeEach(async () => {
+    window.history.replaceState({}, "Clean history state");
     component = mount(
       <BrowserRouter>
         <SearchPage updateTemplate={jest.fn()} />{" "}
@@ -142,22 +142,14 @@ describe("<SearchPage/>", () => {
 
   it("should support debounce query search and display search results", async () => {
     await querySearch("new query");
-    // After 1s the second search should be triggered
+    // After 1s the second search should be triggered. (The first being the initial component mount.)
     expect(SearchModule.searchItems).toHaveBeenCalledTimes(2);
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
       ...defaultSearchOptions,
-      query: "new query*",
+      query: "new query",
     });
     expect(component.html()).not.toContain("No results found.");
     expect(component.html()).toContain("266bb0ff-a730-4658-aec0-c68bbefc227c");
-  });
-
-  it("should not append a wildcard for a search which is empty when trimmed", async () => {
-    await querySearch("      ");
-    expect(SearchModule.searchItems).toHaveBeenCalledWith({
-      ...defaultSearchOptions,
-      query: "",
-    });
   });
 
   it("should display 'No results found.' when there are no search results", async () => {
@@ -228,16 +220,17 @@ describe("<SearchPage/>", () => {
 
   it("should not debounce and send query as-is when in raw search mode", async () => {
     await rawQuerySearch("raw search test");
-    //assert that the query was passed in as-is
+    // assert that the query was passed in as-is
     expect(SearchModule.searchItems).toHaveBeenLastCalledWith({
       ...defaultSearchOptions,
+      rawMode: true,
       query: "raw search test",
     });
-    /*assert that there were only two calls - initial search and Enter key triggered.
-    if the debounce was still on, this would be three calls -
-    the initial search, the search triggered by the debounce,
-    and the search triggered by the Enter key.*/
-    expect(SearchModule.searchItems).toHaveBeenCalledTimes(2);
+    // There should be three calls:
+    // 1. The initial call on component mount
+    // 2. Switching to raw mode
+    // 3. Typing a query, and hitting enter
+    expect(SearchModule.searchItems).toHaveBeenCalledTimes(3);
   });
 
   it("should filter search results by collections", async () => {

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -36,7 +36,6 @@ import { CircularProgress } from "@material-ui/core";
 import { CollectionSelector } from "../../../tsrc/search/components/CollectionSelector";
 import { SearchOptions } from "../../../tsrc/search/SearchModule";
 
-const ENTER_KEYCODE = 13;
 const SEARCHBAR_ID = "input[id='searchBar']";
 const RAW_SEARCH_TOGGLE_ID = "input[id='rawSearch']";
 const mockSearch = jest.spyOn(SearchModule, "searchItems");
@@ -118,12 +117,6 @@ describe("<SearchPage/>", () => {
     //add the searchTerm
     await awaitAct(() => {
       input.simulate("change", { target: { value: searchTerm } });
-    });
-    //Hit Enter and wait for debounce
-    await awaitAct(() => {
-      input.simulate("keyDown", {
-        keyCode: ENTER_KEYCODE,
-      });
       jest.advanceTimersByTime(1000);
     });
   };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -35,8 +35,8 @@ export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchR
 };
 
 /**
- * Helper function, to support raw mode where. When _not_ raw mode we append a wildcard
- * to support the idea of a simple (typeahead) search.
+ * Helper function, to support formatting of query in raw mode. When _not_ raw mode
+ * we append a wildcard to support the idea of a simple (typeahead) search.
  *
  * @param query the intended search query to be sent to the API
  * @param addWildcard whether a wildcard should be appended
@@ -103,7 +103,8 @@ export interface SearchOptions {
    */
   collections?: Collection[];
   /**
-   * Whether the search page is currently accepting 'raw' searches.
+   * Whether to send the `query` as is (true) or to apply some processing (such as appending
+   * a wildcard operator).
    */
   rawMode: boolean;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchModule.ts
@@ -24,6 +24,7 @@ export const defaultSearchOptions: SearchOptions = {
   rowsPerPage: 10,
   currentPage: 0,
   sortOrder: undefined,
+  rawMode: false,
 };
 
 export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
@@ -31,6 +32,19 @@ export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchR
   length: 10,
   available: 10,
   results: [],
+};
+
+/**
+ * Helper function, to support raw mode where. When _not_ raw mode we append a wildcard
+ * to support the idea of a simple (typeahead) search.
+ *
+ * @param query the intended search query to be sent to the API
+ * @param addWildcard whether a wildcard should be appended
+ */
+const formatQuery = (query: string, addWildcard: boolean): string => {
+  const trimmedQuery = query ? query.trim() : "";
+  const appendWildcard = addWildcard && trimmedQuery.length > 0;
+  return trimmedQuery + (appendWildcard ? "*" : "");
 };
 
 /**
@@ -44,11 +58,14 @@ export const searchItems = ({
   currentPage,
   sortOrder,
   collections,
+  rawMode,
 }: SearchOptions): Promise<
   OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
 > => {
+  // If query is undefined, then we want to keep 'undefined'; but otherwise let's pre-process it.
+  const processedQuery = query ? formatQuery(query, !rawMode) : undefined;
   const searchParams: OEQ.Search.SearchParams = {
-    query: query,
+    query: processedQuery,
     start: currentPage * rowsPerPage,
     length: rowsPerPage,
     status: [
@@ -85,4 +102,8 @@ export interface SearchOptions {
    * A list of collections.
    */
   collections?: Collection[];
+  /**
+   * Whether the search page is currently accepting 'raw' searches.
+   */
+  rawMode: boolean;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -128,12 +128,21 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       rowsPerPage: rowsPerPage,
     });
 
+  const handleRawModeChanged = (rawMode: boolean) =>
+    setSearchOptions({ ...searchOptions, rawMode: rawMode });
+
   return (
     <Grid container spacing={2}>
       <Grid item xs={9}>
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            <SearchBar onChange={handleQueryChanged} />
+            <SearchBar
+              query={searchOptions.query ?? ""}
+              rawMode={searchOptions.rawMode}
+              onQueryChange={handleQueryChanged}
+              onRawModeChange={handleRawModeChanged}
+              doSearch={search}
+            />
           </Grid>
           <Grid item xs={12}>
             <SearchResultList

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -42,12 +42,17 @@ import { RefineSearchPanel } from "./components/RefineSearchPanel";
 import { SearchResultList } from "./components/SearchResultList";
 import { CollectionSelector } from "./components/CollectionSelector";
 import { Collection } from "../modules/CollectionsModule";
+import { useHistory } from "react-router";
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
 
+  const history = useHistory();
+
   const [searchOptions, setSearchOptions] = useState<SearchOptions>(
-    defaultSearchOptions
+    // If the user has gone 'back' to this page, then use their previous options. Otherwise
+    // we start fresh - i.e. if a new navigation to Search Page.
+    (history.location.state as SearchOptions) ?? defaultSearchOptions
   );
   const [pagedSearchResult, setPagedSearchResult] = useState<
     OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
@@ -91,9 +96,10 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const search = (): void => {
     setShowSpinner(true);
     searchItems(searchOptions)
-      .then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) =>
-        setPagedSearchResult(items)
-      )
+      .then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) => {
+        setPagedSearchResult(items);
+        history.replace({ ...history.location, state: searchOptions });
+      })
       .catch(handleError)
       .finally(() => setShowSpinner(false));
   };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -70,7 +70,9 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     // Show spinner before calling API to retrieve Search settings.
     setShowSpinner(true);
     getSearchSettingsFromServer().then((settings: SearchSettings) => {
-      handleSortOrderChanged(settings.defaultSearchSort);
+      handleSortOrderChanged(
+        searchOptions.sortOrder ?? settings.defaultSearchSort
+      );
     });
   }, []);
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -134,6 +134,7 @@ export default function SearchBar({
       <Divider className={classes.divider} orientation="vertical" />
       <Tooltip title={searchStrings.rawSearchTooltip}>
         <FormControlLabel
+          style={{ opacity: 0.6 }}
           label={searchStrings.rawSearch}
           control={
             <Switch
@@ -142,6 +143,7 @@ export default function SearchBar({
               value={rawMode}
               checked={rawMode}
               name={searchStrings.rawSearch}
+              size="small"
             />
           }
         />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -31,7 +31,6 @@ import SearchIcon from "@material-ui/icons/Search";
 import { languageStrings } from "../../util/langstrings";
 import { makeStyles } from "@material-ui/core/styles";
 
-const ENTER_KEY_CODE = 13;
 const ESCAPE_KEY_CODE = 27;
 
 const useStyles = makeStyles({
@@ -94,26 +93,17 @@ export default function SearchBar({
   ]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    switch (event.keyCode) {
-      case ESCAPE_KEY_CODE:
-        if (currentQuery) {
-          // iff there is a current query, clear it out and trigger a search
-          setCurrentQuery("");
-          onQueryChange("");
-        }
-        break;
-      case ENTER_KEY_CODE:
-        debouncedOnQueryChange(currentQuery);
-        break;
+    if (event.keyCode === ESCAPE_KEY_CODE && currentQuery) {
+      // iff there is a current query, clear it out and trigger a search
+      setCurrentQuery("");
+      onQueryChange("");
     }
   };
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const updatedQuery = event.target.value;
     setCurrentQuery(updatedQuery);
-    if (!rawMode) {
-      debouncedOnQueryChange(updatedQuery);
-    }
+    debouncedOnQueryChange(updatedQuery);
   };
 
   return (
@@ -128,7 +118,9 @@ export default function SearchBar({
         onChange={handleOnChange}
         value={currentQuery}
         placeholder={
-          rawMode ? searchStrings.pressEnterToSearch : searchStrings.title
+          rawMode
+            ? searchStrings.rawSearchEnabledPlaceholder
+            : searchStrings.rawSearchDisabledPlaceholder
         }
       />
       <Divider className={classes.divider} orientation="vertical" />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -89,7 +89,9 @@ export default function SearchBar({
 
   const [currentQuery, setCurrentQuery] = useState<string>(query);
 
-  const debouncedOnQueryChange = useCallback(debounce(onQueryChange, 500), []);
+  const debouncedOnQueryChange = useCallback(debounce(onQueryChange, 500), [
+    doSearch,
+  ]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     switch (event.keyCode) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -316,7 +316,8 @@ export const languageStrings = {
     refineTitle: "Refine search",
     modifiedDate: "Modified",
     rawSearch: "Raw search",
-    pressEnterToSearch: "Raw search enabled, press enter to search",
+    rawSearchEnabledPlaceholder: "Search (raw mode)",
+    rawSearchDisabledPlaceholder: "Search",
     rawSearchTooltip: "Supports use of Apache Lucene search syntax",
     searchresult: {
       attachments: "Attachments",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

The main feature which was being implemented here was to remember what options a user has selected on a search page when they use the back button to return to a search. But also snuck in a quick couple of others (reduced prominence of raw mode toggle; and remove need to press enter when in raw search mode) following team review.

This became a bit more involved, as it was realised `SearchBar` was handling the state around raw mode itself - rather than pushing state up. As a result, `SearchBar` was refactored to use two way binding to support pushing this state up allowing it to be stored in history. However `SearchBar` does still maintain it's own internal state of the current query value to support debouncing of sending the new query value up.

In addition to state, it was also noted that `SearchBar` had taken on the business logic around what raw mode meant. This then was also pushed out back to the Module layer, which in turn then also meant the test should be moved - and others added.

(A also swapped the debounce used by the `SearchBar` to the one included in Material-UI to reduce dependency on lodash.)

Of note, is that with the two way binding being used for the new Collections control, it automatically had those options stored in history. Therefore, if this pattern is observed going forward, the additional settings will also readily be persisted for 'on back'.

A couple of screenshots to show the change in the raw toggle:

![image](https://user-images.githubusercontent.com/43919233/87888157-5b962000-ca6e-11ea-8b99-7d02e6e3d764.png)

![image](https://user-images.githubusercontent.com/43919233/87888164-694ba580-ca6e-11ea-8efc-773a253c0710.png)


#1306 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
