### PR TITLE
Add a new npm build task to run checks in core npm build

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -18,7 +18,7 @@
     "dev": "pulp build && cross-env-shell parcel watch --no-autoinstall --public-url=. --out-dir=${npm_package_config_devjs} entrydev/*.html entrydev/scripts/*.js",
     "dev:build": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_devjs} entrybuild/*.html entrybuild/scripts/*.js",
     "build": "npm-run-all build:*",
-    "build:check": "cd ../../../../../ && npm run check",
+    "build:check": "cd ../../../../../ && npm run check:license && npm run check:ts && npm run check:ts-types-source",
     "build:bundles": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_dist} entrybuild/*.html entrybuild/scripts/*.js",
     "build:langbundle": "cross-env-shell parcel build target/genlang.js --no-minify --no-source-maps --target node --out-dir=target/tools && cross-env-shell \"node target/tools/genlang.js > ${npm_package_config_buildlang}/jsbundle.json\"",
     "compileps": "pulp build",

--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -18,7 +18,7 @@
     "dev": "pulp build && cross-env-shell parcel watch --no-autoinstall --public-url=. --out-dir=${npm_package_config_devjs} entrydev/*.html entrydev/scripts/*.js",
     "dev:build": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_devjs} entrybuild/*.html entrybuild/scripts/*.js",
     "build": "npm-run-all build:*",
-    "build:check": "cd ../../../../../ && npm run check:license && npm run check:ts && npm run check:ts-types-source",
+    "build:check": "cd ../../../../../ && npm install && npm run check:license && npm run check:ts && npm run check:ts-types-source",
     "build:bundles": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_dist} entrybuild/*.html entrybuild/scripts/*.js",
     "build:langbundle": "cross-env-shell parcel build target/genlang.js --no-minify --no-source-maps --target node --out-dir=target/tools && cross-env-shell \"node target/tools/genlang.js > ${npm_package_config_buildlang}/jsbundle.json\"",
     "compileps": "pulp build",

--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -18,6 +18,7 @@
     "dev": "pulp build && cross-env-shell parcel watch --no-autoinstall --public-url=. --out-dir=${npm_package_config_devjs} entrydev/*.html entrydev/scripts/*.js",
     "dev:build": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_devjs} entrybuild/*.html entrybuild/scripts/*.js",
     "build": "npm-run-all build:*",
+    "build:check": "cd ../../../../../ && npm run check",
     "build:bundles": "run-s bundleps && cross-env-shell parcel build --public-url=. --out-dir=${npm_package_config_dist} entrybuild/*.html entrybuild/scripts/*.js",
     "build:langbundle": "cross-env-shell parcel build target/genlang.js --no-minify --no-source-maps --target node --out-dir=target/tools && cross-env-shell \"node target/tools/genlang.js > ${npm_package_config_buildlang}/jsbundle.json\"",
     "compileps": "pulp build",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Our npm check tasks are defined in the root folder `package.json`. As a result,  we are required to create a CI job on both GHA and Codebuild to get these tasking running . This PR attempts to integrate these tasks into the `core npm build` so each CI will run them without  an extra job.