### PR TITLE
Fix broken Storybook stories

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/.storybook/preview-head.html
+++ b/Source/Plugins/Core/com.equella.core/js/.storybook/preview-head.html
@@ -1,1 +1,8 @@
-<script>let logoURL = "";</script>
+<script>
+  const logoURL = "";
+  const renderData = {
+    baseResources: "p/r/2020.2.0/com.equella.core/",
+    newUI: true,
+    autotestMode: false,
+  };
+</script>

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/MimeTypeFilterEditingDialog.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/MimeTypeFilterEditingDialog.stories.tsx
@@ -25,7 +25,8 @@ export default {
   title: "MimeTypeFilterDialog",
   component: MimeTypeFilterEditingDialog,
 };
-export const mimeTypeFilter: MimeTypeFilter = {
+
+const mimeTypeFilter: MimeTypeFilter = {
   id: "f8eab6cf-98bc-4c5f-a9a2-8ecdd07533d0",
   name: "Image filter",
   mimeTypes: ["image/png", "image/jpeg"],

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/RichEditor.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/RichEditor.stories.tsx
@@ -33,13 +33,15 @@ export default {
   component: RichTextEditor,
 };
 
+const defaultProps = {
+  skinUrl: "http://localhost:6006/tinymce/skins/ui/oxide",
+  onStateChange: action("stateChange"),
+};
 export const WithHTMLInput = () => (
   <RichTextEditor
+    {...defaultProps}
     htmlInput={text("htmlInput", "<p>example</p>")}
-    onStateChange={action("stateChange")}
   />
 );
 
-export const WithoutHTMLInput = () => (
-  <RichTextEditor onStateChange={action("stateChange")} />
-);
+export const WithoutHTMLInput = () => <RichTextEditor {...defaultProps} />;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
@@ -81,6 +81,10 @@ export interface BlobInfo {
 
 interface RichTextEditorProps {
   htmlInput?: string;
+  /** Optionally provide the name of the skin to use. */
+  skinName?: string;
+  /** Optionally provide the URL for the location of the skin. */
+  skinUrl?: string;
   onStateChange(html: string): void;
   imageUploadCallBack?(file: BlobInfo): AxiosPromise<ImageReturnType>;
 }
@@ -143,8 +147,8 @@ class RichTextEditor extends React.Component<
             images_upload_handler: this.uploadImages,
             paste_data_images: true,
             relative_urls: false,
-            skin: "oxide",
-            skin_url: skinUrl,
+            skin: this.props.skinName ?? "oxide",
+            skin_url: this.props.skinUrl ?? skinUrl,
             media_dimensions: false,
           }}
           toolbar="formatselect | bold italic strikethrough underline forecolor backcolor | link image media file | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent hr | removeformat | undo redo | preview | ltr rtl"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included - kind of (via storybook)

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

I'd started to notice a few broken bits in storybook (for example #2024). So I went through and clicked on all the stories to make sure they worked, and those which didn't I've addressed in this PR.

Of note, fixing `RichEditor.stories.tsx` at first seemed like it'd just be adding `renderData` to preview-head.html (to mimic how the oEQ server places that in the header). However once that problem was fixed, another more significant problem resulted which was TinyMCE unable to load its CSS.

This issue was due to the component attempting to use the dynamic configuration (from `renderData` and `Config`) to set a URL for where to download the CSS from. But this was tripping over using the default `href` on the `<base>` element which Storybook adds. So instead, I modified the component to have an optional prop to allow specifying this. I've then used this prop to specify the URL specific to when being delivered via Storybook.

As a result, I've a feeling the `RichEditor.stories.tsx` has never worked. :thinking: 

Resolves #2024 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
