### PR TITLE
Make window scroll to top when search is performed

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -101,7 +101,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       .then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) => {
         setPagedSearchResult(items);
         history.replace({ ...history.location, state: searchOptions });
-        //scroll back up to the top of the page
+        // scroll back up to the top of the page
         window.scrollTo(0, 0);
       })
       .catch(handleError)

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -101,6 +101,8 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       .then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) => {
         setPagedSearchResult(items);
         history.replace({ ...history.location, state: searchOptions });
+        //scroll back up to the top of the page
+        window.scrollTo(0, 0);
       })
       .catch(handleError)
       .finally(() => setShowSpinner(false));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1306
![search scroll](https://user-images.githubusercontent.com/4625498/88141713-7bc50b00-cc37-11ea-8f66-0b5843a761e1.gif)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
