### PR TITLE
Refactor the Jest test of Faceted search settings page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
@@ -53,8 +53,8 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
       const defaultListItem = [[undefined, strings.selectASchema]];
       const schemaArray = defaultListItem.concat(Array.from(schemas));
       setSchemaList(
-        schemaArray.map(([uuid, name]) => (
-          <MenuItem id={uuid} value={uuid}>
+        schemaArray.map(([uuid, name], index) => (
+          <MenuItem id={uuid} value={uuid} key={uuid ?? index}>
             {name}
           </MenuItem>
         ))
@@ -88,7 +88,7 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
                   {strings.schema}
                 </InputLabel>
               }
-              value={selectedSchema}
+              value={selectedSchema ?? ""}
               displayEmpty
               onChange={(event) => {
                 setSelectedSchema(event.target.value as string | undefined);


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR attempts to remove lots of 'react-beautiful-dnd' warnings by using the approach discussed in 'react-beautiful-dnd' github.
This PR also addresses other warnings (e.g. MUI warning about uncontrolled component && Jest warning about using `act`) in this test.

![image](https://user-images.githubusercontent.com/47203811/88253881-be99e800-ccf6-11ea-8ae7-62256e2bf9f5.png)
