### PR TITLE
chore(ci): Revert GHA checkout action to v1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,9 @@ jobs:
   build_and_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      # Using v1 (rather than v2) through-out this workflow due to issue:
+      # https://github.com/actions/checkout/issues/237
+      - uses: actions/checkout@v1
 
       - name: NPM Cache
         uses: actions/cache@v2
@@ -121,7 +123,7 @@ jobs:
   build_import_export_tool:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -189,7 +191,7 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
       - name: Download installer
         uses: actions/download-artifact@v1


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

There is currently an issue we're having with GHA where the wrong commit
is built. This appears to be related to issue
https://github.com/actions/checkout/issues/237

There is a comment there from 4 days ago
(https://github.com/actions/checkout/issues/237#issuecomment-662662682)
where the issue is now acknowledged but it's noted as a complex issue
with no definite date for resolution.

Others have reverted to v1, so it seems worth trying - especially if the
availability of the fix seems to be an unknown (possibly long) time
away.

P.S. It seems mainly related to forks - so I think the Renovate PRs are okay.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
