### PR TITLE
Integrate date range selector to search page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -21,7 +21,7 @@ import {
 } from "../../../__mocks__/getSearchResult";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
 import * as React from "react";
-import SearchPage from "../../../tsrc/search/SearchPage";
+import SearchPage, { SearchPageOptions } from "../../../tsrc/search/SearchPage";
 import { mount, ReactWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
@@ -47,9 +47,10 @@ const searchPromise = mockSearch.mockImplementation(() =>
   Promise.resolve(getSearchResult)
 );
 mockCollections.mockImplementation(() => Promise.resolve(getCollectionMap));
-const defaultSearchOptions: SearchModule.SearchOptions = {
+const defaultSearchPageOptions: SearchPageOptions = {
   ...SearchModule.defaultSearchOptions,
   sortOrder: SearchSettingsModule.SortOrder.RANK,
+  dateRangeQuickModeEnabled: true,
 };
 const defaultCollectionPrivileges = ["SEARCH_COLLECTION"];
 
@@ -122,7 +123,9 @@ describe("<SearchPage/>", () => {
       SearchSettingsModule.getSearchSettingsFromServer
     ).toHaveBeenCalledTimes(1);
     expect(SearchModule.searchItems).toHaveBeenCalledTimes(1);
-    expect(SearchModule.searchItems).toHaveBeenCalledWith(defaultSearchOptions);
+    expect(SearchModule.searchItems).toHaveBeenCalledWith(
+      defaultSearchPageOptions
+    );
     expect(CollectionsModule.collectionListSummary).toHaveBeenCalledTimes(1);
     expect(CollectionsModule.collectionListSummary).toHaveBeenCalledWith(
       defaultCollectionPrivileges
@@ -134,7 +137,7 @@ describe("<SearchPage/>", () => {
     // After 1s the second search should be triggered. (The first being the initial component mount.)
     expect(SearchModule.searchItems).toHaveBeenCalledTimes(2);
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
-      ...defaultSearchOptions,
+      ...defaultSearchPageOptions,
       query: "new query",
     });
     expect(component.html()).not.toContain("No results found.");
@@ -159,7 +162,7 @@ describe("<SearchPage/>", () => {
       itemsPerPageSelect.simulate("change", { target: { value: 25 } })
     );
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
-      ...defaultSearchOptions,
+      ...defaultSearchPageOptions,
       rowsPerPage: 25,
     });
     expect(component.html()).toContain("1-12 of 12");
@@ -188,7 +191,7 @@ describe("<SearchPage/>", () => {
     // Because sorting is done on the server-side and we are using mock data, we can only check if the selected
     // sort order is included in the search params
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
-      ...defaultSearchOptions,
+      ...defaultSearchPageOptions,
       sortOrder: SearchSettingsModule.SortOrder.DATEMODIFIED,
     });
   });
@@ -211,7 +214,7 @@ describe("<SearchPage/>", () => {
     await rawQuerySearch("raw search test");
     // assert that the query was passed in as-is
     expect(SearchModule.searchItems).toHaveBeenLastCalledWith({
-      ...defaultSearchOptions,
+      ...defaultSearchPageOptions,
       rawMode: true,
       query: "raw search test",
     });
@@ -241,7 +244,7 @@ describe("<SearchPage/>", () => {
     await awaitAct(() => handleCollectionChange(selectedCollections));
     expect(SearchModule.searchItems).toHaveBeenCalledTimes(2);
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
-      ...defaultSearchOptions,
+      ...defaultSearchPageOptions,
       collections: selectedCollections,
     });
   });
@@ -254,8 +257,7 @@ describe("<SearchPage/>", () => {
     component.update();
     const dateRangeSelector = component.find(DateRangeSelector);
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
-      ...defaultSearchOptions,
-      dateRangeQuickModeEnabled: true,
+      ...defaultSearchPageOptions,
       lastModifiedDateRange: {
         start: dateRangeSelector.prop("dateRange")!.start,
         end: undefined,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -255,6 +255,7 @@ describe("<SearchPage/>", () => {
     const dateRangeSelector = component.find(DateRangeSelector);
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
       ...defaultSearchOptions,
+      dateRangeQuickModeEnabled: true,
       lastModifiedDateRange: {
         start: dateRangeSelector.prop("dateRange")!.start,
         end: undefined,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -30,6 +30,7 @@ import * as SearchSettingsModule from "../../../tsrc/modules/SearchSettingsModul
 import { BrowserRouter } from "react-router-dom";
 import { CircularProgress } from "@material-ui/core";
 import { CollectionSelector } from "../../../tsrc/search/components/CollectionSelector";
+import { DateRangeSelector } from "../../../tsrc/components/DateRangeSelector";
 
 const SEARCHBAR_ID = "input[id='searchBar']";
 const RAW_SEARCH_TOGGLE_ID = "input[id='rawSearch']";
@@ -242,6 +243,22 @@ describe("<SearchPage/>", () => {
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
       ...defaultSearchOptions,
       collections: selectedCollections,
+    });
+  });
+
+  it("should support selecting a date range through Quick options", async () => {
+    const quickOptions = component.find("#date_range_selector input");
+    await awaitAct(() =>
+      quickOptions.simulate("change", { target: { value: "Today" } })
+    );
+    component.update();
+    const dateRangeSelector = component.find(DateRangeSelector);
+    expect(SearchModule.searchItems).toHaveBeenCalledWith({
+      ...defaultSearchOptions,
+      lastModifiedDateRange: {
+        start: dateRangeSelector.prop("dateRange")!.start,
+        end: undefined,
+      },
     });
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -45,9 +45,6 @@ export interface DateRange {
   end?: Date;
 }
 
-/**
- * Props of date pickers.
- */
 interface DatePickerProps {
   /**
    * The field which a date picker controls.
@@ -212,7 +209,7 @@ export const DateRangeSelector = ({
   );
 
   /**
-   * Generate two Date pickers and each of them is wrapped inside a Grid item.
+   * Generate two date pickers and wrap them with Grid items.
    */
   const getDatePickers = (): ReactNode => {
     const dateRangePickers: DatePickerProps[] = [

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -45,6 +45,24 @@ export interface DateRange {
   end?: Date;
 }
 
+/**
+ * Props of date pickers.
+ */
+interface DatePickerProps {
+  /**
+   * The field which a date picker controls.
+   */
+  field: "start" | "end";
+  /**
+   * The label of a date picker.
+   */
+  label: string;
+  /**
+   * The value of a date picker.
+   */
+  value?: Date;
+}
+
 export interface DateRangeSelectorProps {
   /**
    * Fired when date range is changed.
@@ -193,33 +211,50 @@ export const DateRangeSelector = ({
     </FormControl>
   );
 
+  /**
+   * Generate two Date pickers and each of them is wrapped inside a Grid item.
+   */
+  const getDatePickers = (): ReactNode => {
+    const dateRangePickers: DatePickerProps[] = [
+      {
+        field: "start",
+        label: startLabel,
+        value: dateRange?.start,
+      },
+      {
+        field: "end",
+        label: endLabel,
+        value: dateRange?.end,
+      },
+    ];
+
+    return dateRangePickers.map(({ field, label, value }) => (
+      <Grid item key={field}>
+        <DatePicker
+          disableFuture
+          variant="inline"
+          inputVariant="outlined"
+          autoOk
+          labelFunc={(value, invalidLabel) =>
+            value?.toLocaleString() ?? invalidLabel
+          }
+          label={label}
+          value={value}
+          onChange={(newDate: MaterialUiPickersDate) =>
+            onDateRangeChange({
+              ...dateRange,
+              [field]: newDate?.toJSDate(),
+            })
+          }
+        />
+      </Grid>
+    ));
+  };
+
   const customDatePicker: ReactNode = (
     <MuiPickersUtilsProvider utils={LuxonUtils}>
       <Grid container spacing={2}>
-        {[
-          [startLabel, dateRange?.start],
-          [endLabel, dateRange?.end],
-        ].map(([label, value]) => (
-          <Grid item>
-            <DatePicker
-              disableFuture
-              variant="inline"
-              inputVariant="outlined"
-              autoOk
-              labelFunc={(value, invalidLabel) =>
-                value?.toLocaleString() ?? invalidLabel
-              }
-              label={label}
-              value={value}
-              onChange={(newDate: MaterialUiPickersDate) =>
-                onDateRangeChange({
-                  ...dateRange,
-                  end: newDate?.toJSDate(),
-                })
-              }
-            />
-          </Grid>
-        ))}
+        {getDatePickers()}
       </Grid>
     </MuiPickersUtilsProvider>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -69,6 +69,7 @@ export interface DateRangeSelectorProps {
   /**
    * Fired when the status of Quick mode is changed.
    * @param enabled The new status of Quick mode
+   * @param dateRange Date range updated due to the mode change.
    */
   onQuickModeChange: (enabled: boolean, dateRange?: DateRange) => void;
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -26,7 +26,6 @@ export const defaultSearchOptions: SearchOptions = {
   currentPage: 0,
   sortOrder: undefined,
   rawMode: false,
-  dateRangeQuickModeEnabled: true,
 };
 
 export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
@@ -113,11 +112,7 @@ export interface SearchOptions {
    */
   rawMode: boolean;
   /**
-   * A date range for Items' last modified dates.
+   * A date range for searching items by last modified date.
    */
   lastModifiedDateRange?: DateRange;
-  /**
-   * Whether to enable Quick mode (true) or to use custom date pickers (false)
-   */
-  dateRangeQuickModeEnabled: boolean;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -19,12 +19,14 @@ import * as OEQ from "@openequella/rest-api-client";
 import { API_BASE_URL } from "../config";
 import { SortOrder } from "./SearchSettingsModule";
 import { Collection } from "./CollectionsModule";
+import { DateRange } from "../components/DateRangeSelector";
 
 export const defaultSearchOptions: SearchOptions = {
   rowsPerPage: 10,
   currentPage: 0,
   sortOrder: undefined,
   rawMode: false,
+  dateRangeQuickModeEnabled: true,
 };
 
 export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
@@ -59,6 +61,7 @@ export const searchItems = ({
   sortOrder,
   collections,
   rawMode,
+  lastModifiedDateRange,
 }: SearchOptions): Promise<
   OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
 > => {
@@ -74,6 +77,8 @@ export const searchItems = ({
     ],
     order: sortOrder,
     collections: collections?.map((collection) => collection.uuid),
+    modifiedAfter: lastModifiedDateRange?.start?.toISOString(),
+    modifiedBefore: lastModifiedDateRange?.end?.toISOString(),
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
 };
@@ -107,4 +112,12 @@ export interface SearchOptions {
    * a wildcard operator).
    */
   rawMode: boolean;
+  /**
+   * A date range for Items' last modified dates.
+   */
+  lastModifiedDateRange?: DateRange;
+  /**
+   * Whether to enable Quick mode (true) or to use custom date pickers (false)
+   */
+  dateRangeQuickModeEnabled: boolean;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -161,10 +161,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const handleRawModeChanged = (rawMode: boolean) =>
     setSearchPageOptions({ ...searchPageOptions, rawMode: rawMode });
 
-  const handleQuickDateRangeModeChange = (quickDateRangeMode: boolean) =>
+  const handleQuickDateRangeModeChange = (
+    quickDateRangeMode: boolean,
+    dateRange?: DateRange
+  ) =>
     setSearchPageOptions({
       ...searchPageOptions,
       dateRangeQuickModeEnabled: quickDateRangeMode,
+      // When the mode is changed, the date range may also need to be updated.
+      // For example, if a custom date range is converted to Quick option 'All', then both start and end should be undefined.
+      lastModifiedDateRange: dateRange,
     });
 
   const handleLastModifiedDateRangeChange = (dateRange?: DateRange) =>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -48,7 +48,7 @@ import { DateRange, DateRangeSelector } from "../components/DateRangeSelector";
 /**
  * Type of search options that are specific to Search page presentation layer.
  */
-interface SearchPageOptions extends SearchOptions {
+export interface SearchPageOptions extends SearchOptions {
   /**
    * Whether to enable Quick mode (true) or to use custom date pickers (false).
    */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -23,7 +23,7 @@ import {
   TemplateUpdateProps,
 } from "../mainui/Template";
 import { languageStrings } from "../util/langstrings";
-import { Grid } from "@material-ui/core";
+import { Grid, Typography } from "@material-ui/core";
 import {
   defaultPagedSearchResult,
   defaultSearchOptions,
@@ -43,9 +43,15 @@ import { SearchResultList } from "./components/SearchResultList";
 import { CollectionSelector } from "./components/CollectionSelector";
 import { Collection } from "../modules/CollectionsModule";
 import { useHistory } from "react-router";
+import { DateRange, DateRangeSelector } from "../components/DateRangeSelector";
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
+  const {
+    startDatePicker,
+    endDatePicker,
+    quickOptionDropdown,
+  } = searchStrings.lastModifiedDateSelector;
 
   const history = useHistory();
 
@@ -135,6 +141,15 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const handleRawModeChanged = (rawMode: boolean) =>
     setSearchOptions({ ...searchOptions, rawMode: rawMode });
 
+  const handleQuickDateRangeModeChange = (quickDateRangeMode: boolean) =>
+    setSearchOptions({
+      ...searchOptions,
+      dateRangeQuickModeEnabled: quickDateRangeMode,
+    });
+
+  const handleLastModifiedDateRangeChange = (dateRange?: DateRange) =>
+    setSearchOptions({ ...searchOptions, lastModifiedDateRange: dateRange });
+
   return (
     <Grid container spacing={2}>
       <Grid item xs={9}>
@@ -170,9 +185,21 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
       <Grid item xs={3}>
         <RefineSearchPanel>
+          <Typography variant="h6">Collections</Typography>
           <CollectionSelector
             onSelectionChange={handleCollectionSelectionChanged}
             value={searchOptions.collections}
+          />
+
+          <Typography variant="h6">Date modified</Typography>
+          <DateRangeSelector
+            onDateRangeChange={handleLastModifiedDateRangeChange}
+            onQuickModeChange={handleQuickDateRangeModeChange}
+            startDatePickerLabel={startDatePicker}
+            endDatePickerLabel={endDatePicker}
+            quickOptionDropdownLabel={quickOptionDropdown}
+            dateRange={searchOptions.lastModifiedDateRange}
+            quickModeEnabled={searchOptions.dateRangeQuickModeEnabled}
           />
         </RefineSearchPanel>
       </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -86,8 +86,8 @@ export const CollectionSelector = ({
         <TextField
           {...params}
           variant="outlined"
-          label={collectionSelectorStrings.label}
-          placeholder={collectionSelectorStrings.label}
+          label={collectionSelectorStrings.title}
+          placeholder={collectionSelectorStrings.title}
         />
       )}
     />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
@@ -20,9 +20,9 @@ import { ReactNode } from "react";
 import {
   Card,
   CardContent,
-  CardHeader,
   List,
   ListItem,
+  Typography,
 } from "@material-ui/core";
 import { languageStrings } from "../../util/langstrings";
 
@@ -37,13 +37,11 @@ export const RefineSearchPanel = ({ children }: RefinePanelProps) => {
   const { title } = languageStrings.searchpage.refineSearchPanel;
   return (
     <Card>
-      <CardHeader title={title} />
       <CardContent>
+        <Typography variant="h5">{title}</Typography>
         <List>
           {React.Children.map(children, (child, index) => (
-            <ListItem divider={index != React.Children.count(children) - 1}>
-              {child}
-            </ListItem>
+            <ListItem>{child}</ListItem>
           ))}
         </List>
       </CardContent>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -355,6 +355,11 @@ export const languageStrings = {
     collectionSelector: {
       label: "Collections",
     },
+    lastModifiedDateSelector: {
+      startDatePicker: "Modified after",
+      endDatePicker: "Modified before",
+      quickOptionDropdown: "Last modified date",
+    },
   },
   "com.equella.core.searching.search": {
     title: "Search",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -353,9 +353,10 @@ export const languageStrings = {
       title: "Refine search",
     },
     collectionSelector: {
-      label: "Collections",
+      title: "Collections",
     },
     lastModifiedDateSelector: {
+      title: "Date modified",
       startDatePicker: "Modified after",
       endDatePicker: "Modified before",
       quickOptionDropdown: "Last modified date",


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Integrated the Date range selector with Search page. Also slightly changed to header of Refine panel.

![image](https://user-images.githubusercontent.com/47203811/88495104-3b310d00-cffc-11ea-903e-de2498d83812.png)

![image](https://user-images.githubusercontent.com/47203811/88495108-46843880-cffc-11ea-84a5-e133ada1127e.png)

