### PR TITLE
oeq-ts-rest-api: Add support for /userquery/search

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/package-lock.json
+++ b/Source/Plugins/Core/com.equella.core/js/package-lock.json
@@ -24617,7 +24617,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "react-popper": {
       "version": "1.3.7",

--- a/oeq-ts-rest-api/.eslintrc.js
+++ b/oeq-ts-rest-api/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   root: true,
   env: {
+    node: true,
     browser: true,
     es6: true,
   },
@@ -10,6 +11,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:jest/recommended',
     'plugin:jest/style',
+    'plugin:prettier/recommended',
   ],
   globals: {
     Atomics: 'readonly',

--- a/oeq-ts-rest-api/package-lock.json
+++ b/oeq-ts-rest-api/package-lock.json
@@ -2449,6 +2449,15 @@
         "@typescript-eslint/experimental-utils": "^2.5.0"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -2811,6 +2820,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -5257,6 +5272,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "25.5.0",

--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -43,6 +43,7 @@
     "@typescript-eslint/parser": "3.6.0",
     "eslint": "7.4.0",
     "eslint-plugin-jest": "23.18.0",
+    "eslint-plugin-prettier": "3.1.4",
     "jest": "26.1.0",
     "rollup": "2.21.0",
     "rollup-plugin-typescript2": "0.27.1",

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -5,6 +5,8 @@ export type i18nString = string;
 
 export type I18nStrings = Record<string, string>;
 
+export type UuidString = string;
+
 export interface User {
   id: string;
   username?: string;

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -1,6 +1,6 @@
 import { GET } from './AxiosInstance';
 import { is } from 'typescript-is';
-import {UuidString} from "./Common";
+import { UuidString } from './Common';
 
 export interface UserDetails {
   id: UuidString;
@@ -59,4 +59,8 @@ export const search = (
   apiBasePath: string,
   params: SearchParams
 ): Promise<SearchResult> =>
-  GET<SearchResult>( apiBasePath + USERQUERY_ROOT_PATH + '/search', isSearchResult, params);
+  GET<SearchResult>(
+    apiBasePath + USERQUERY_ROOT_PATH + '/search',
+    isSearchResult,
+    params
+  );

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -1,0 +1,62 @@
+import { GET } from './AxiosInstance';
+import { is } from 'typescript-is';
+import {UuidString} from "./Common";
+
+export interface UserDetails {
+  id: UuidString;
+  username: string;
+  firstName: string;
+  lastName: string;
+  email?: string;
+}
+
+export interface GroupDetails {
+  id: UuidString;
+  name: string;
+}
+
+export interface RoleDetails {
+  id: UuidString;
+  name: string;
+}
+
+/**
+ * Results for the Search operation, where lists will be populated based on Search criteria. If
+ * the Search criteria results in no results for one of the lists, then they will be returned as
+ * an empty list.
+ *
+ * Based on com.tle.web.api.users.LookupQueryResult
+ */
+export interface SearchResult {
+  users: UserDetails[];
+  groups: GroupDetails[];
+  roles: RoleDetails[];
+}
+
+export interface SearchParams {
+  /** Wildcard supporting text string to filter results by. */
+  q?: string;
+  /** Include groups in the results. */
+  groups: boolean;
+  /** Include roles in the results. */
+  roles: boolean;
+  /** Include users in the results. */
+  users: boolean;
+}
+
+const isSearchResult = (instance: unknown): instance is SearchResult =>
+  is<SearchResult>(instance);
+
+const USERQUERY_ROOT_PATH = '/userquery';
+
+/**
+ * Search for users and related entities (i.e. groups and roles).
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param params Query parameters to customize result
+ */
+export const search = (
+  apiBasePath: string,
+  params: SearchParams
+): Promise<SearchResult> =>
+  GET<SearchResult>( apiBasePath + USERQUERY_ROOT_PATH + '/search', isSearchResult, params);

--- a/oeq-ts-rest-api/src/Utils.ts
+++ b/oeq-ts-rest-api/src/Utils.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import { cloneDeep } from 'lodash';
 /**
  * Performs inplace conversion of specified fields with supplied converter.
  *
@@ -7,19 +7,25 @@ import { cloneDeep } from 'lodash'
  * @param recursive True if processing nested objects is required.
  * @param converter A function converting fields' type.
  */
-const convertFields = <T, R>(input: unknown, targetFields: string[], recursive: boolean, converter: (value: T) => R): void => {
+const convertFields = <T, R>(
+  input: unknown,
+  targetFields: string[],
+  recursive: boolean,
+  converter: (value: T) => R
+): void => {
   const entries: [string, any][] = Object.entries(input as any);
 
   entries.forEach(([field, value]) => {
-    if(typeof value === "object" && recursive) {
+    if (typeof value === 'object' && recursive) {
       convertFields(value, targetFields, recursive, converter);
-    }
-    else {
+    } else {
       targetFields
-        .filter(targetField => targetField === field)
-        .forEach(targetField => (input as any)[targetField] = converter(value))
+        .filter((targetField) => targetField === field)
+        .forEach(
+          (targetField) => ((input as any)[targetField] = converter(value))
+        );
     }
-  })
+  });
 };
 
 /**
@@ -31,9 +37,8 @@ const convertFields = <T, R>(input: unknown, targetFields: string[], recursive: 
  */
 export const convertDateFields = <T>(input: unknown, fields: string[]): T => {
   const inputClone: any = cloneDeep(input);
-  convertFields(inputClone,
-    fields,
-    true,
-    (value: string) => isNaN(Date.parse(value))? undefined: new Date( value));
+  convertFields(inputClone, fields, true, (value: string) =>
+    isNaN(Date.parse(value)) ? undefined : new Date(value)
+  );
   return inputClone;
 };

--- a/oeq-ts-rest-api/src/index.ts
+++ b/oeq-ts-rest-api/src/index.ts
@@ -7,4 +7,5 @@ export * as Schema from './Schema';
 export * as Security from './Security';
 export * as Settings from './Settings';
 export * as Search from './Search';
+export * as UserQuery from './UserQuery';
 export * as Utils from './Utils';

--- a/oeq-ts-rest-api/test/TestConfig.ts
+++ b/oeq-ts-rest-api/test/TestConfig.ts
@@ -1,4 +1,4 @@
-export const TARGET_HOST = 'http://localhost:8080/'
+export const TARGET_HOST = 'http://localhost:8080/';
 export const API_PATH = `${TARGET_HOST}rest/api`;
 export const API_PATH_VANILLA = `${TARGET_HOST}vanilla/api`;
 export const USERNAME = 'TLE_ADMINISTRATOR';

--- a/oeq-ts-rest-api/test/TestConfig.ts
+++ b/oeq-ts-rest-api/test/TestConfig.ts
@@ -1,3 +1,5 @@
-export const API_PATH = 'http://localhost:8080/rest/api';
+export const TARGET_HOST = 'http://localhost:8080/'
+export const API_PATH = `${TARGET_HOST}rest/api`;
+export const API_PATH_VANILLA = `${TARGET_HOST}vanilla/api`;
 export const USERNAME = 'TLE_ADMINISTRATOR';
 export const PASSWORD = 'abc';

--- a/oeq-ts-rest-api/test/UserQuery.test.ts
+++ b/oeq-ts-rest-api/test/UserQuery.test.ts
@@ -1,0 +1,72 @@
+import * as OEQ from '../src';
+import * as TC from './TestConfig';
+import { SearchResult } from '../src/UserQuery';
+
+// We use Vanilla for this one so that we also have 'roles' to test with.
+const API_PATH = TC.API_PATH_VANILLA;
+
+beforeAll(() => OEQ.Auth.login(API_PATH, TC.USERNAME, TC.PASSWORD));
+
+afterAll(() => OEQ.Auth.logout(API_PATH, true));
+
+describe('/userquery/search', () => {
+  test.each<keyof SearchResult>(['users', 'roles', 'groups'])(
+    'should be possible to list %s',
+    async (property: keyof SearchResult) => {
+      const result = await OEQ.UserQuery.search(API_PATH, {
+        // Disable all ...
+        users: false,
+        roles: false,
+        groups: false,
+        // ... and enable the one under test
+        [property]: true,
+      });
+      const entities = result[property];
+      expect(entities).toBeTruthy();
+      expect(entities.length).toBeGreaterThan(0);
+    }
+  );
+
+  it('should be possible to list a combination', async () => {
+    const result = await OEQ.UserQuery.search(API_PATH, {
+      users: true,
+      roles: true,
+      groups: false,
+    });
+    expect(result).toBeTruthy();
+    expect(result.users.length).toBeGreaterThan(0);
+    expect(result.roles.length).toBeGreaterThan(0);
+    expect(result.groups).toHaveLength(0);
+  });
+
+  it('should be possible to list all types', async () => {
+    const result = await OEQ.UserQuery.search(API_PATH, {
+      users: true,
+      roles: true,
+      groups: true,
+    });
+    expect(result).toBeTruthy();
+    expect(result.users.length).toBeGreaterThan(0);
+    expect(result.roles.length).toBeGreaterThan(0);
+    expect(result.groups.length).toBeGreaterThan(0);
+  });
+
+  it('should be possible to filter with a query string', async () => {
+    const query = 'user';
+    const result = await OEQ.UserQuery.search(API_PATH, {
+      q: query,
+      users: true,
+      roles: true,
+      groups: true,
+    });
+    const names = result.users
+      .map((u) => u.username)
+      .concat(result.groups.map((g) => g.name))
+      .concat(result.roles.map((r) => r.name))
+      .map((n) => n.toLowerCase());
+    const doesNotContainQuery = (testValue: string) =>
+      testValue.search(query) === -1;
+    // There should be no names in the list which don't contain the query
+    expect(names.find(doesNotContainQuery)).toBeFalsy();
+  });
+});

--- a/oeq-ts-rest-api/test/search.test.ts
+++ b/oeq-ts-rest-api/test/search.test.ts
@@ -4,25 +4,25 @@ import * as OEQ from '../src';
 beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
 afterAll(() => OEQ.Auth.logout(TC.API_PATH, true));
 
-describe("Search for items", () => {
-  it("should be able to search without params", async () => {
+describe('Search for items', () => {
+  it('should be able to search without params', async () => {
     const searchResult = await OEQ.Search.search(TC.API_PATH);
     // The default start is 0 and length of search results is 10.
     expect(searchResult.start).toBe(0);
     expect(searchResult).toHaveLength(10);
     expect(searchResult.available).toBeGreaterThan(0);
-    expect(searchResult.results).toHaveLength(10)
+    expect(searchResult.results).toHaveLength(10);
   });
 
-  it("should be able to search with params", async () => {
-    const collection = "a77112e6-3370-fd02-6ac6-6bc5aec22001";
+  it('should be able to search with params', async () => {
+    const collection = 'a77112e6-3370-fd02-6ac6-6bc5aec22001';
     const searchParams: OEQ.Search.SearchParams = {
-      query: "API",
+      query: 'API',
       status: [OEQ.Common.ItemStatus.LIVE],
-      collections: [collection]
+      collections: [collection],
     };
     const searchResult = await OEQ.Search.search(TC.API_PATH, searchParams);
-    const {uuid, status, collectionId} = searchResult.results[0];
+    const { uuid, status, collectionId } = searchResult.results[0];
 
     expect(searchResult).toHaveLength(searchResult.results.length);
     expect(uuid).toBeTruthy();
@@ -31,8 +31,9 @@ describe("Search for items", () => {
     expect(collectionId).toBe(collection);
   });
 
-  it("should get 404 response if search for a non-existing collection", async () => {
-    await expect(OEQ.Search.search(TC.API_PATH, {collections: ["testing collection"]}))
-      .rejects.toHaveProperty('status', 404);
-  })
+  it('should get 404 response if search for a non-existing collection', async () => {
+    await expect(
+      OEQ.Search.search(TC.API_PATH, { collections: ['testing collection'] })
+    ).rejects.toHaveProperty('status', 404);
+  });
 });

--- a/oeq-ts-rest-api/test/utils.test.ts
+++ b/oeq-ts-rest-api/test/utils.test.ts
@@ -1,7 +1,7 @@
 import * as OEQ from '../src';
-import {is} from "typescript-is";
+import { is } from 'typescript-is';
 
-describe("Convert date fields", () => {
+describe('Convert date fields', () => {
   interface StringDate {
     dates: {
       yesterday: string;
@@ -21,26 +21,32 @@ describe("Convert date fields", () => {
     };
   }
 
-  it("should convert valid date strings to objects of Date", () => {
+  it('should convert valid date strings to objects of Date', () => {
     const validDates: StringDate = {
       dates: {
-        yesterday: "2020-06-11T11:45:24.296+10:00",
-        today: "2020-06-12T11:45:24.296+10:00",
-      }
+        yesterday: '2020-06-11T11:45:24.296+10:00',
+        today: '2020-06-12T11:45:24.296+10:00',
+      },
     };
 
-    const dates = OEQ.Utils.convertDateFields<StandardDate>(validDates, ["yesterday", "today"] );
+    const dates = OEQ.Utils.convertDateFields<StandardDate>(validDates, [
+      'yesterday',
+      'today',
+    ]);
     expect(is<StandardDate>(dates)).toBe(true);
   });
 
-  it("should return undefined for fields that have invalid date strings", () => {
+  it('should return undefined for fields that have invalid date strings', () => {
     const invalidDates: StringDate = {
       dates: {
-        yesterday: "hello",
-        today: "world",
-      }
+        yesterday: 'hello',
+        today: 'world',
+      },
     };
-    const dates = OEQ.Utils.convertDateFields<StandardDate>(invalidDates, ["yesterday", "today"] );
+    const dates = OEQ.Utils.convertDateFields<StandardDate>(invalidDates, [
+      'yesterday',
+      'today',
+    ]);
     expect(is<InvalidDate>(dates)).toBe(true);
-  })
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Primarily the change here was to add support for the `/userquery/search` endpoint in the form of `UserQuery.ts`. But then when I noticed the formatting on my commits was not correct I added that support to the `oeq-ts-rest-api` module by applying the final tweaks to`oeq-ts-rest-api/package.json` and `oeq-ts-rest-api/.eslintrc.js`. On running that, suddenly I found many other files were also a bit out of wack.

So unfortunately this PR now contains a lot more noise than I'd like. Here is a run down to the help:

Feature (ccf789a):

* `UserQuery.ts`
* `UserQuery.test.ts`
* Auxillary: `Common.ts`, `index.ts`, `TestConfig.ts`

**Ran the tests:**

```
Test Suites: 7 passed, 7 total
Tests:       23 passed, 23 total
Snapshots:   0 total
Time:        4.905 s
Ran all test suites.
```

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
