### PR TITLE
Improve Date range selector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -131,8 +131,20 @@ export const DateRangeSelector = ({
   useEffect(() => {
     const start = stateDateRange?.start;
     const end = stateDateRange?.end;
-    // Call onDateRangeChange when the range is open-ended or when start <= end
-    if (!start || !end || start <= end) {
+    const isStartValid = start && DateTime.fromJSDate(start).isValid;
+    const isEndValid = end && DateTime.fromJSDate(end).isValid;
+
+    // start is undefined and end is a valid date
+    const openStart = !start && isEndValid;
+    // End is undefined and start is a valid date
+    const openEnd = !end && isStartValid;
+    // Both are undefined
+    const openRange = !start && !end;
+    // Both are valid dates and start is equal or less than end
+    const closedRange = isStartValid && isEndValid && start! <= end!;
+
+    // Call onDateRangeChange for above four cases
+    if (openStart || openEnd || openRange || closedRange) {
       onDateRangeChange(stateDateRange);
     }
   }, [stateDateRange]);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -28,7 +28,7 @@ import {
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
 import SettingsToggleSwitch from "./SettingsToggleSwitch";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { languageStrings } from "../util/langstrings";
 import LuxonUtils from "@date-io/luxon";
 import { DateTime } from "luxon";
@@ -128,7 +128,12 @@ export const DateRangeSelector = ({
     dateRange
   );
 
+  const isInitialRender = useRef(true);
   useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
     const start = stateDateRange?.start;
     const end = stateDateRange?.end;
     const isStartValid = start && DateTime.fromJSDate(start).isValid;
@@ -142,7 +147,6 @@ export const DateRangeSelector = ({
     const openRange = !start && !end;
     // Both are valid dates and start is equal or less than end
     const closedRange = isStartValid && isEndValid && start! <= end!;
-
     // Call onDateRangeChange for above four cases
     if (openStart || openEnd || openRange || closedRange) {
       onDateRangeChange(stateDateRange);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -197,18 +197,18 @@ export const DateRangeSelector = ({
    *
    * @param dateRange A date range to be converted to a Quick date option label.
    */
-  const dateRangeToDateOptionConverter = (): string => {
+  const dateRangeToDateOptionConverter = (dateRange?: DateRange): string => {
     let option = quickOptionLabels.all;
     if (
-      !stateDateRange ||
-      !stateDateRange.start ||
-      (stateDateRange.end &&
-        stateDateRange.end.toDateString() !== new Date().toDateString())
+      !dateRange ||
+      !dateRange.start ||
+      (dateRange.end &&
+        dateRange.end.toDateString() !== new Date().toDateString())
     ) {
       return option;
     }
 
-    const start = DateTime.fromJSDate(stateDateRange.start);
+    const start = DateTime.fromJSDate(dateRange.start);
     getDateRangeOptions().forEach(
       (dateTime: DateTime | undefined, label: string) => {
         if (dateTime && dateTime.toISODate() === start.toISODate()) {
@@ -233,7 +233,7 @@ export const DateRangeSelector = ({
     <FormControl variant="outlined" fullWidth>
       <InputLabel id="date_range_selector_label">{quickOptionLabel}</InputLabel>
       <Select
-        value={dateRangeToDateOptionConverter()}
+        value={dateRangeToDateOptionConverter(stateDateRange)}
         id="date_range_selector"
         labelId="date_range_selector_label"
         onChange={(event) =>
@@ -277,12 +277,12 @@ export const DateRangeSelector = ({
             clearable
             inputVariant="outlined"
             autoOk
-            // Show date in locale string, or nothing if date is null.
+            // Show date in ISO format string, or nothing if date is null.
             labelFunc={(date, _) => {
-              return date?.toLocaleString() ?? "";
+              return date?.toISODate() ?? "";
             }}
             // TextField inputs are parsed to this format.
-            format="dd/MM/yyyy"
+            format="yyyy-MM-dd"
             // The maximum start date is the range's end whereas minimum end date is the range's start.
             minDate={!isStart ? stateDateRange?.start : undefined}
             maxDate={isStart ? stateDateRange?.end : undefined}
@@ -302,7 +302,10 @@ export const DateRangeSelector = ({
   };
 
   const customDatePicker: ReactNode = (
-    <MuiPickersUtilsProvider utils={LuxonUtils}>
+    <MuiPickersUtilsProvider
+      utils={LuxonUtils}
+      locale={DateTime.local().locale}
+    >
       <Grid container spacing={2}>
         {getDatePickers()}
       </Grid>
@@ -322,7 +325,8 @@ export const DateRangeSelector = ({
           setValue={(value) => {
             // If selected custom date range matches the option `All` then clear both start and end.
             const isAllSelected =
-              dateRangeToDateOptionConverter() === quickOptionLabels.all;
+              dateRangeToDateOptionConverter(stateDateRange) ===
+              quickOptionLabels.all;
             const updatedRange = isAllSelected
               ? undefined
               : { ...dateRange, end: undefined };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -20,6 +20,7 @@ import { API_BASE_URL } from "../config";
 import { SortOrder } from "./SearchSettingsModule";
 import { Collection } from "./CollectionsModule";
 import { DateRange } from "../components/DateRangeSelector";
+import { getISODateString } from "../util/Date";
 
 export const defaultSearchOptions: SearchOptions = {
   rowsPerPage: 10,
@@ -76,8 +77,8 @@ export const searchItems = ({
     ],
     order: sortOrder,
     collections: collections?.map((collection) => collection.uuid),
-    modifiedAfter: lastModifiedDateRange?.start?.toISOString(),
-    modifiedBefore: lastModifiedDateRange?.end?.toISOString(),
+    modifiedAfter: getISODateString(lastModifiedDateRange?.start),
+    modifiedBefore: getISODateString(lastModifiedDateRange?.end),
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -59,8 +59,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
   const {
     title: dateModifiedSelectorTitle,
-    startDatePicker,
-    endDatePicker,
     quickOptionDropdown,
   } = searchStrings.lastModifiedDateSelector;
   const { title: collectionSelectorTitle } = searchStrings.collectionSelector;
@@ -224,8 +222,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           <DateRangeSelector
             onDateRangeChange={handleLastModifiedDateRangeChange}
             onQuickModeChange={handleQuickDateRangeModeChange}
-            startDatePickerLabel={startDatePicker}
-            endDatePickerLabel={endDatePicker}
             quickOptionDropdownLabel={quickOptionDropdown}
             dateRange={searchPageOptions.lastModifiedDateRange}
             quickModeEnabled={searchPageOptions.dateRangeQuickModeEnabled}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/Date.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/Date.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DateTime } from "luxon";
+
+/**
+ * Convert a date to string in ISO format but keep time unchanged.
+ * One should call 'toISOString()' to get the UTC date in ISO format.
+ * @param date The date to be converted to a string in ISO format.
+ */
+export const getISODateString = (date?: Date) =>
+  date ? DateTime.fromJSDate(date).toISODate() : undefined;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -549,8 +549,8 @@ export const languageStrings = {
       "You have unsaved changes. Are you sure you want to leave this page without saving?",
   },
   dateRangeSelector: {
-    defaultStartDatePickerLabel: "Start",
-    defaultEndDatePickerLabel: "End",
+    defaultStartDatePickerLabel: "From",
+    defaultEndDatePickerLabel: "To",
     defaultDropdownLabel: "Quick date ranges",
     quickOptionSwitchLabel: "Enable quick options",
     quickOptionLabels: {


### PR DESCRIPTION
#1306

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Here are some improvements made for the Date range selector. However, the component becomes a lot more complicated accordingly. So I am still thinking if these improvements are worth to have. 
 
1. Used `KeyboardDatePicker` to allow type and clear a date. But in order to properly use it, `state` is required, which increases complexity.
2. Changed to default picker labels to `from` and `to`.
3. Added a util function to help convert a date object to a string in ISO format. The reason is Javascript native function `toISOString` changes the time to UTC time,  which may result in incorrect search results.