### PR TITLE
Do not redirect if href is undefined

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -170,7 +170,7 @@ export const LegacyContent = React.memo(function LegacyContent({
             userUpdated();
           }
           redirected({ href: content.route, external: false });
-        } else {
+        } else if (content.href) {
           redirected({ href: content.href, external: true });
         }
       })


### PR DESCRIPTION
#1394 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

When a attachment reordering is performed, a Legacy content request is sent and its response is an empty object. `LegacyContent.tsx` did not handle this case properly, which results in opening a `undefined` page. So this PR attempts to fix this issue and #1523 .