### PR TITLE
Do not assign null to undefined in Typescript.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/Date.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/Date.tsx
@@ -39,14 +39,14 @@ export default function Date({ displayRelative, date }: DateProps) {
   const classes = useStyles();
   const luxDate = DateTime.fromJSDate(date);
   let primaryDate = luxDate.toLocaleString(DateTime.DATETIME_MED);
-  let hoverDate = luxDate.toRelative() || "undefined";
+  let hoverDate = luxDate.toRelative();
   if (displayRelative) {
     //swap 'em around
     [primaryDate, hoverDate] = [hoverDate, primaryDate];
   }
 
   return (
-    <Tooltip title={hoverDate}>
+    <Tooltip title={hoverDate ?? "undefined"}>
       <Typography className={classes.dateModified} component="span">
         {primaryDate}
       </Typography>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/Date.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/Date.ts
@@ -22,5 +22,10 @@ import { DateTime } from "luxon";
  * One should call 'toISOString()' to get the UTC date in ISO format.
  * @param date The date to be converted to a string in ISO format.
  */
-export const getISODateString = (date?: Date) =>
-  date ? DateTime.fromJSDate(date).toISODate() : undefined;
+export const getISODateString = (date?: Date) => {
+  if (date) {
+    // If the result of toISODate is null then return undefined.
+    return DateTime.fromJSDate(date).toISODate() ?? undefined;
+  }
+  return undefined;
+};


### PR DESCRIPTION
- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
We have recently updated  `@types/luxon` from 1.24.1 to 1.24.3 and the newer version has changed some functions' return types. (e.g. `string` -> `string | null`). So  this PR removed a couple incorrect null assignment.