### PR TITLE
Fix resumption token used in REST APIs

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/PagedResults.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/PagedResults.scala
@@ -102,16 +102,15 @@ object PagedResults {
 
     val (_, results) = collectMore(_length, firstOffset, 0, Vector.empty)
     val pb           = new PagingBean[BEB]
-    val actualLen    = results.length
     val available = res.getEntityService
       .countAll(new EnumerateOptions(q, 0, -1, system, if (includeDisabled) null else false))
       .toInt
     pb.setStart(firstOffset)
-    pb.setLength(actualLen)
+    pb.setLength(results.length)
     pb.setAvailable(available)
     // Include resumption token if there are items which can be retrieved in next request.
-    if (actualLen + firstOffset < available)
-      pb.setResumptionToken(s"${firstOffset + actualLen}:${_length}")
+    if (results.length + firstOffset < available)
+      pb.setResumptionToken(s"${firstOffset + results.length}:${_length}")
     pb.setResults(results.map {
       case (be, canFull, privs) => addPrivs(privs, res.serialize(be, null, canFull))
     }.asJava)


### PR DESCRIPTION
#1735 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Fixed the resumption token used in some REST APIs. 

The testing environment for below screenshots has 5 items totally.

First request with initial resumption token being `0:2`. The length specified in params is ignored.
![Screenshot from 2020-08-04 14-31-02](https://user-images.githubusercontent.com/47203811/89253404-ecb8e980-d65f-11ea-888a-ec5fdf3c6d68.png)

Second request with the token returned from last request
![Screenshot from 2020-08-04 14-31-15](https://user-images.githubusercontent.com/47203811/89253773-e2e3b600-d660-11ea-8a13-954127850734.png)



Third request with the token returned from last request. No more token is returned.
![Screenshot from 2020-08-04 14-31-24](https://user-images.githubusercontent.com/47203811/89253815-00188480-d661-11ea-9332-ed7a0d74c6cb.png)



Another request with an initial token which can retrieve all items so no token returned.
![Screenshot from 2020-08-04 14-31-43](https://user-images.githubusercontent.com/47203811/89253585-605af680-d660-11ea-84e7-6c7cf724b385.png)


Another request with an invalid token. So use the length from query params instead.
![Screenshot from 2020-08-04 14-32-35](https://user-images.githubusercontent.com/47203811/89253637-7d8fc500-d660-11ea-91dd-a325276758c6.png)


