### PR TITLE
Update Schema module and Collection module

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/getCollectionsResp.js
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/getCollectionsResp.js
@@ -161,7 +161,6 @@ exports.getCollectionsResp = {
       },
     },
   ],
-  resumptionToken: "17:10",
 };
 
 exports.getCollectionMap = [

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/CollectionsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/CollectionsModule.ts
@@ -17,6 +17,7 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import { API_BASE_URL } from "../config";
+import { listEntities } from "./OEQHelpers";
 
 /**
  * Provides a simple Map<string,string> summary of available collections, where K is the UUID
@@ -26,15 +27,16 @@ import { API_BASE_URL } from "../config";
  */
 export const collectionListSummary = (
   requiredPrivileges?: string[]
-): Promise<Collection[]> =>
-  OEQ.Collection.listCollections(API_BASE_URL, {
-    // We believe very few people have more than 20 collections, so this will do for now.
-    // As there are some oddities currently in the oEQ paging as seen in
-    // https://github.com/openequella/openEQUELLA/issues/1735
-    length: 100,
-    privilege: requiredPrivileges,
-  }).then((pagedResult) => pagedResult.results);
-
+): Promise<Collection[]> => {
+  const getCollections = (resumptionToken: string) =>
+    OEQ.Collection.listCollections(API_BASE_URL, {
+      privilege: requiredPrivileges,
+      resumption: resumptionToken,
+    });
+  return listEntities<OEQ.Common.BaseEntity>(getCollections).then(
+    (results) => results
+  );
+};
 /**
  * A simplified type of Collection used when only collection uuid and name are required.
  */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/OEQHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/OEQHelpers.ts
@@ -45,12 +45,11 @@ export const listEntities = async <T extends OEQ.Common.BaseEntity>(
   getData: (resumptionToken: string) => Promise<OEQ.Common.PagedResult<T>>
 ): Promise<T[]> => {
   const entities: T[] = [];
-  let token: string = DEFAULT_RESUMPTION_TOKEN;
+  let token: string | undefined = DEFAULT_RESUMPTION_TOKEN;
   while (token) {
-    await getData(token).then((pagedResult) => {
-      entities.push(...pagedResult.results);
-      token = pagedResult.resumptionToken ?? "";
-    });
+    const pagedResult: OEQ.Common.PagedResult<T> = await getData(token);
+    entities.push(...pagedResult.results);
+    token = pagedResult.resumptionToken;
   }
   return entities;
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/OEQHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/OEQHelpers.ts
@@ -46,7 +46,6 @@ export const listEntities = <T extends OEQ.Common.BaseEntity>(
 ): Promise<T[]> => {
   const entities: T[] = [];
   return getData(DEFAULT_RESUMPTION_TOKEN).then(async (pagedResult) => {
-    console.log(pagedResult);
     entities.push(...pagedResult.results);
     // If a resumption token is returned, recursively call listEntities to retrieve more entities.
     if (pagedResult.resumptionToken) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/OEQHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/OEQHelpers.ts
@@ -41,20 +41,16 @@ const DEFAULT_RESUMPTION_TOKEN = "0:10";
  * @param getData A function which takes a resumption token to retrieve specific entities
  *        such as schemas and collections.
  */
-export const listEntities = <T extends OEQ.Common.BaseEntity>(
+export const listEntities = async <T extends OEQ.Common.BaseEntity>(
   getData: (resumptionToken: string) => Promise<OEQ.Common.PagedResult<T>>
 ): Promise<T[]> => {
   const entities: T[] = [];
-  return getData(DEFAULT_RESUMPTION_TOKEN).then(async (pagedResult) => {
-    entities.push(...pagedResult.results);
-    // If a resumption token is returned, recursively call listEntities to retrieve more entities.
-    if (pagedResult.resumptionToken) {
-      const nextResumptionToken = pagedResult.resumptionToken;
-      const moreEntities = await listEntities(() =>
-        getData(nextResumptionToken)
-      );
-      entities.push(...moreEntities);
-    }
-    return entities;
-  });
+  let token: string = DEFAULT_RESUMPTION_TOKEN;
+  while (token) {
+    await getData(token).then((pagedResult) => {
+      entities.push(...pagedResult.results);
+      token = pagedResult.resumptionToken ?? "";
+    });
+  }
+  return entities;
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SchemaModule.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SchemaModule.tsx
@@ -17,7 +17,7 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import { API_BASE_URL } from "../config";
-import { summarisePagedBaseEntities } from "./OEQHelpers";
+import { summarisePagedBaseEntities, listEntities } from "./OEQHelpers";
 
 /**
  * A minimal representation of a node within an oEQ schema.
@@ -41,13 +41,15 @@ export interface SchemaNode {
  *
  * On failure, an OEQ.Errors.ApiError will be thrown.
  */
-export const schemaListSummary = (): Promise<Map<string, string>> =>
-  OEQ.Schema.listSchemas(API_BASE_URL, {
-    // We believe very few people have more than 5 schemas, so this will do for now.
-    // As there are some oddities currently in the oEQ paging as seen in
-    // https://github.com/openequella/openEQUELLA/issues/1735
-    length: 100,
-  }).then(summarisePagedBaseEntities);
+export const schemaListSummary = async (): Promise<Map<string, string>> => {
+  const getSchemas = (resumptionToken: string) =>
+    OEQ.Schema.listSchemas(API_BASE_URL, {
+      resumption: resumptionToken,
+    });
+  return listEntities<OEQ.Common.BaseEntity>(getSchemas).then((entities) =>
+    summarisePagedBaseEntities(entities)
+  );
+};
 
 /**
  * Recursive helper function to build a simple outline of the structure of an oEQ schema.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/PagedResults.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/PagedResults.scala
@@ -51,7 +51,7 @@ object PagedResults {
       includeDisabled: Boolean): PagingBean[BEB] = {
     val (firstOffset, lengthFromToken) = decodeOffsetStart(resumption)
     // If resumption token provides a length then use it, or otherwise use the one from params.
-    val _length = if (lengthFromToken.isDefined) lengthFromToken.get else length
+    val _length = lengthFromToken.getOrElse(length)
     val privilege =
       if (_privilege.isEmpty) Set("LIST_" + res.getPrivilegeType) else _privilege.asScala.toSet
     val forFull = Set("VIEW_" + res.getPrivilegeType, "EDIT_" + res.getPrivilegeType)

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -100,7 +100,7 @@ export interface ListCommonParams {
   /**
    * Resumption token for paging
    */
-  resumptionToken?: string;
+  resumption?: string;
   /**
    * Number of results
    */


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

As the resumption token has been fixed, this PR attempts to update Schema module and Collection module to use resumption tokens to retrieve data.

Created a new function to list entities that extend `BaseEntity`, and then updated the two modules to use this function. Also updated mock data and renamed a field of `CommonParams`.

![Screenshot from 2020-08-05 15-55-32](https://user-images.githubusercontent.com/47203811/89377434-1f80e180-d735-11ea-9923-71687046a6ce.png)

![Screenshot from 2020-08-05 15-56-20](https://user-images.githubusercontent.com/47203811/89377439-23acff00-d735-11ea-824b-964bc849c151.png)

