### PR TITLE
Changed OEQThumb PlaceholderIcon to TextFields icon, based on communi…

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/OEQThumb.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/OEQThumb.tsx
@@ -25,7 +25,7 @@ import {
   Panorama as ImageIcon,
   InsertDriveFile as DefaultFileIcon,
   Language as WebIcon,
-  Subject as PlaceholderIcon,
+  TextFields as PlaceholderIcon,
 } from "@material-ui/icons";
 
 const useStyles = makeStyles((theme: Theme) => {


### PR DESCRIPTION
…ty feedback

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
https://github.com/openequella/openEQUELLA/issues/1306

Previously we were using the 'Subject' Material UI icon as a placeholder thumbnails, for search results that don't contain any attachments.

During an Edalex client forum it was decided that the icon should be changed. It was decided that the Subject Icon should be changed to a TextFields icon.

![Screenshot from 2020-08-06 11-39-16](https://user-images.githubusercontent.com/4625498/89480776-88219a00-d7d9-11ea-85a7-1acfc58dbf44.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
