### PR TITLE
Feature/refine by user

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/.storybook/preview-head.html
+++ b/Source/Plugins/Core/com.equella.core/js/.storybook/preview-head.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"/>
 <script>
   const logoURL = "";
   const renderData = {

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
@@ -58,9 +58,12 @@ export const users: OEQ.UserQuery.UserDetails[] = [
  *
  * @param query A simple string to filter by (no wildcard support)
  */
-export const userDetailsProvider = (
+export const userDetailsProvider = async (
   query?: string
-): Promise<OEQ.UserQuery.UserDetails[]> =>
-  new Promise((resolve) =>
+): Promise<OEQ.UserQuery.UserDetails[]> => {
+  // A sleep to emulate latency
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return new Promise((resolve) =>
     resolve(query ? users.filter((u) => u.username.search(query) === 0) : users)
   );
+};

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
@@ -63,7 +63,7 @@ export const userDetailsProvider = async (
 ): Promise<OEQ.UserQuery.UserDetails[]> => {
   // A sleep to emulate latency
   await new Promise((resolve) => setTimeout(resolve, 500));
-  return new Promise((resolve) =>
-    resolve(query ? users.filter((u) => u.username.search(query) === 0) : users)
+  return Promise.resolve(
+    query ? users.filter((u) => u.username.search(query) === 0) : users
   );
 };

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/OwnerSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/OwnerSelector.stories.tsx
@@ -34,10 +34,5 @@ const commonParams = {
 export const NoSelectedUser = () => <OwnerSelector {...commonParams} />;
 
 export const SelectedUser = () => (
-  <OwnerSelector
-    onClearSelect={action("onClearSelect")}
-    onSelect={action("onSelect")}
-    userListProvider={UserSearchMock.userDetailsProvider}
-    value={UserSearchMock.users[0]}
-  />
+  <OwnerSelector {...commonParams} value={UserSearchMock.users[0]} />
 );

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/OwnerSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/OwnerSelector.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import OwnerSelector from "../../tsrc/search/components/OwnerSelector";
+import { action } from "@storybook/addon-actions";
+import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
+
+export default {
+  title: "Search/OwnerSelector",
+  component: OwnerSelector,
+};
+
+const commonParams = {
+  onClearSelect: action("onClearSelect"),
+  onSelect: action("onSelect"),
+  userListProvider: UserSearchMock.userDetailsProvider,
+};
+
+export const NoSelectedUser = () => <OwnerSelector {...commonParams} />;
+
+export const SelectedUser = () => (
+  <OwnerSelector
+    onClearSelect={action("onClearSelect")}
+    onSelect={action("onSelect")}
+    userListProvider={UserSearchMock.userDetailsProvider}
+    value={UserSearchMock.users[0]}
+  />
+);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/MuiQueries.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/MuiQueries.ts
@@ -27,5 +27,5 @@ export const queryMuiButtonByText = (container: HTMLElement, text: string) =>
   queryByText(
     container,
     (content: string, element: HTMLElement) =>
-      content === text && (element.parentElement?.matches("button") as boolean)
+      content === text && (element.parentElement?.matches("button") ?? false)
   );

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/MuiQueries.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/MuiQueries.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { queryByText } from "@testing-library/react";
+
+/**
+ * Helper function to find MUI buttons with React Testing Library.
+ *
+ * @param container A root element to start the search from
+ * @param text The text to identify the button by.
+ */
+export const queryMuiButtonByText = (container: HTMLElement, text: string) =>
+  queryByText(
+    container,
+    (content: string, element: HTMLElement) =>
+      content === text && (element.parentElement?.matches("button") as boolean)
+  );

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/UserSearch.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/UserSearch.test.tsx
@@ -23,13 +23,9 @@ import UserSearch from "../../../tsrc/components/UserSearch";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import { sprintf } from "sprintf-js";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
+import { doSearch, getUserList } from "./UserSearchTestHelpers";
 
 describe("<UserSearch/>", () => {
-  const {
-    failedToFindUsersMessage,
-    queryFieldLabel,
-  } = languageStrings.userSearchComponent;
-
   // Helper to render and wait for component under test
   const renderUserSearch = async (
     onSelect: (username: OEQ.UserQuery.UserDetails) => void = jest.fn()
@@ -42,29 +38,18 @@ describe("<UserSearch/>", () => {
     );
 
     // Wait for it to be rendered
-    await waitFor(() => screen.getByText(queryFieldLabel));
+    await waitFor(() =>
+      screen.getByText(languageStrings.userSearchComponent.queryFieldLabel)
+    );
 
     return container;
-  };
-
-  // Helper function to execute a search (assuming rendered component)
-  const doSearch = (queryValue: string) => {
-    const queryField = screen
-      .getByText(queryFieldLabel)
-      .parentElement?.querySelector("input");
-    if (!queryField) {
-      throw new Error("Unable to find query field!");
-    }
-
-    fireEvent.change(queryField, { target: { value: queryValue } });
-    fireEvent.keyDown(queryField, { key: "Enter", code: "Enter" });
   };
 
   it("displays the search bar and no users on initial render", async () => {
     const container = await renderUserSearch();
 
     // Ensure the user list section is not present
-    expect(container.querySelector("#UserSearch-UserList")).toBeFalsy();
+    expect(getUserList(container)).toBeFalsy();
   });
 
   it("displays an error when it can't find requested user", async () => {
@@ -76,7 +61,12 @@ describe("<UserSearch/>", () => {
 
     // Ensure an error was displayed
     await waitFor(() =>
-      screen.getByText(sprintf(failedToFindUsersMessage, noSuchUser))
+      screen.getByText(
+        sprintf(
+          languageStrings.userSearchComponent.failedToFindUsersMessage,
+          noSuchUser
+        )
+      )
     );
   });
 

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/UserSearchTestHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/UserSearchTestHelpers.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Helper function to execute a search (assuming rendered component)
+import { fireEvent, screen } from "@testing-library/react";
+import { languageStrings } from "../../../tsrc/util/langstrings";
+
+/**
+ * Helper function to do the steps of entering a submitting a search in the <UserSearch/>
+ * component.
+ *
+ * @param queryValue the value to put in the query field before pressing enter
+ */
+export const doSearch = (queryValue: string) => {
+  const queryField = screen
+    .getByText(languageStrings.userSearchComponent.queryFieldLabel)
+    .parentElement?.querySelector("input");
+  if (!queryField) {
+    throw new Error("Unable to find query field!");
+  }
+
+  fireEvent.change(queryField, { target: { value: queryValue } });
+  fireEvent.keyDown(queryField, { key: "Enter", code: "Enter" });
+};
+
+/**
+ * Helper function to assist in finding the list of users after a search.
+ *
+ * @param container a root container within which <UserSearch/> exists
+ */
+export const getUserList = (container: HTMLElement): Element | null =>
+  container.querySelector("#UserSearch-UserList");

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/UserSearchTestHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/UserSearchTestHelpers.ts
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Helper function to execute a search (assuming rendered component)
 import { fireEvent, screen } from "@testing-library/react";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -28,33 +28,117 @@ import { act } from "react-dom/test-utils";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import * as SearchSettingsModule from "../../../tsrc/modules/SearchSettingsModule";
+import * as UserModule from "../../../tsrc/modules/UserModule";
 import { BrowserRouter } from "react-router-dom";
 import { CircularProgress } from "@material-ui/core";
 import { CollectionSelector } from "../../../tsrc/search/components/CollectionSelector";
 import { paginatorControls } from "../components/SearchPaginationTestHelper";
 import { DateRangeSelector } from "../../../tsrc/components/DateRangeSelector";
+import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
+import { render, RenderResult, screen, waitFor } from "@testing-library/react";
+import {
+  clearSelection,
+  selectUser,
+} from "./components/OwnerSelectTestHelpers";
 
 const SEARCHBAR_ID = "input[id='searchBar']";
 const RAW_SEARCH_TOGGLE_ID = "input[id='rawSearch']";
+
+const mockCollections = jest.spyOn(CollectionsModule, "collectionListSummary");
+const mockListUsers = jest.spyOn(UserModule, "listUsers");
 const mockSearch = jest.spyOn(SearchModule, "searchItems");
 const mockSearchSettings = jest.spyOn(
   SearchSettingsModule,
   "getSearchSettingsFromServer"
 );
-const mockCollections = jest.spyOn(CollectionsModule, "collectionListSummary");
-const searchSettingPromise = mockSearchSettings.mockImplementation(() =>
-  Promise.resolve(SearchSettingsModule.defaultSearchSettings)
+
+const searchSettingPromise = mockSearchSettings.mockResolvedValue(
+  SearchSettingsModule.defaultSearchSettings
 );
-const searchPromise = mockSearch.mockImplementation(() =>
-  Promise.resolve(getSearchResult)
-);
-mockCollections.mockImplementation(() => Promise.resolve(getCollectionMap));
+const searchPromise = mockSearch.mockResolvedValue(getSearchResult);
+
+mockCollections.mockResolvedValue(getCollectionMap);
+mockListUsers.mockResolvedValue(UserSearchMock.users);
+
 const defaultSearchPageOptions: SearchPageOptions = {
   ...SearchModule.defaultSearchOptions,
   sortOrder: SearchSettingsModule.SortOrder.RANK,
   dateRangeQuickModeEnabled: true,
 };
 const defaultCollectionPrivileges = ["SEARCH_COLLECTION"];
+
+describe("Refine search by Owner", () => {
+  const testUser = UserSearchMock.users[0];
+  let page: RenderResult;
+
+  beforeEach(async () => {
+    window.history.replaceState({}, "Clean history state");
+    page = render(
+      <BrowserRouter>
+        <SearchPage updateTemplate={jest.fn()} />{" "}
+      </BrowserRouter>
+    );
+    // Wait for the first completion of initial search
+    await act(async () => {
+      await searchPromise;
+    });
+  });
+
+  afterEach(() => {
+    // Needed to keep Enzyme tests below happy
+    jest.clearAllMocks();
+  });
+
+  const getOwnerFilter = (container: Element): HTMLElement => {
+    const e = container.querySelector("#RefineSearchPanel-OwnerSelector");
+    if (!e) {
+      throw new Error("Failed to find OwnerSelector");
+    }
+
+    return e as HTMLElement;
+  };
+
+  const confirmSelectedUser = (username: string) => screen.getByText(username);
+
+  const confirmSelectedUserCleared = (username: string) => {
+    let stillPresent = true;
+    try {
+      confirmSelectedUser(username);
+    } catch {
+      stillPresent = false;
+    }
+    if (stillPresent) {
+      throw new Error("Can still see the username: " + username);
+    }
+  };
+
+  const _selectUser = async (container: HTMLElement, username: string) => {
+    await selectUser(getOwnerFilter(container), username);
+    // The selected user will now be displayed
+    await waitFor(() => confirmSelectedUser(username));
+  };
+
+  it("should be possible to set the owner", async () => {
+    await _selectUser(page.container, testUser.username);
+
+    expect(SearchModule.searchItems).toHaveBeenCalledWith({
+      ...defaultSearchPageOptions,
+      owner: testUser,
+    });
+  });
+
+  it("should be possible to clear the owner filter", async () => {
+    await _selectUser(page.container, testUser.username);
+
+    // Now clear the selection
+    clearSelection();
+    await waitFor(() => confirmSelectedUserCleared(testUser.username));
+
+    expect(SearchModule.searchItems).toHaveBeenCalledWith(
+      defaultSearchPageOptions
+    );
+  });
+});
 
 describe("<SearchPage/>", () => {
   let component: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>;

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/OwnerSelectTestHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/OwnerSelectTestHelpers.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { queryMuiButtonByText } from "../../MuiQueries";
+import { languageStrings } from "../../../../tsrc/util/langstrings";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { doSearch } from "../../components/UserSearchTestHelpers";
+
+export const getSelectButton = (container: HTMLElement) =>
+  queryMuiButtonByText(container, languageStrings.common.action.select);
+
+// Helper user action abstraction function
+export const clickSelect = (container: HTMLElement) => {
+  const selectButton = getSelectButton(container);
+  if (!selectButton) {
+    throw new Error(
+      "Was expecting the 'select' button to be available, but no. :/"
+    );
+  }
+  fireEvent.click(selectButton);
+};
+
+export const selectUser = async (container: HTMLElement, username: string) => {
+  clickSelect(container);
+  doSearch(username);
+  // Wait for mock latency
+  const findUsername = () => screen.getByText(username);
+  await waitFor(findUsername);
+  // Click on a user
+  fireEvent.click(findUsername());
+  // And click select
+  const dialogSelectButton = getSelectButton(screen.getByRole("dialog"));
+  if (!dialogSelectButton) {
+    throw new Error(
+      "Unable to find the 'select' button in the user select dialog."
+    );
+  }
+  fireEvent.click(dialogSelectButton);
+};
+
+export const clearSelection = () =>
+  fireEvent.click(
+    screen.getByLabelText(languageStrings.searchpage.filterOwner.clear)
+  );

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/OwnerSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/OwnerSelector.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import {
+  fireEvent,
+  queryByText,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import { languageStrings } from "../../../../tsrc/util/langstrings";
+import OwnerSelector from "../../../../tsrc/search/components/OwnerSelector";
+import * as UserSearchMock from "../../../../__mocks__/UserSearch.mock";
+import { doSearch } from "../../components/UserSearchTestHelpers";
+
+import "@testing-library/jest-dom/extend-expect";
+
+const queryMuiButtonByText = (container: HTMLElement, text: string) =>
+  queryByText(
+    container,
+    (content: string, element: HTMLElement) =>
+      content === text && (element.parentElement?.matches("button") as boolean)
+  );
+
+describe("<OwnerSelector/>", () => {
+  const testUser = UserSearchMock.users[0];
+  const getSelectButton = (container: HTMLElement) =>
+    queryMuiButtonByText(container, languageStrings.common.action.select);
+
+  // Helper user action abstraction function
+  const clickSelect = (container: HTMLElement) => {
+    const selectButton = getSelectButton(container);
+    if (!selectButton) {
+      throw new Error(
+        "Was expecting the 'select' button to be available, but no. :/"
+      );
+    }
+    fireEvent.click(selectButton);
+  };
+
+  it("should show the select button when no user selected", () => {
+    const { container } = render(
+      <OwnerSelector onClearSelect={jest.fn()} onSelect={jest.fn()} />
+    );
+    expect(getSelectButton(container)).toBeInTheDocument();
+  });
+
+  it("should not show the select button when a user has been selected, but instead show the user details", () => {
+    const { container, queryByText } = render(
+      <OwnerSelector
+        onClearSelect={jest.fn()}
+        onSelect={jest.fn()}
+        value={testUser}
+      />
+    );
+    expect(getSelectButton(container)).not.toBeInTheDocument();
+    expect(queryByText(testUser.username)).toBeInTheDocument();
+  });
+
+  it("should trigger the clear callback when the clear user button is clicked", () => {
+    const clearCallback = jest.fn();
+    const { getByLabelText } = render(
+      <OwnerSelector
+        onClearSelect={clearCallback}
+        onSelect={jest.fn()}
+        value={testUser}
+      />
+    );
+
+    fireEvent.click(
+      getByLabelText(languageStrings.searchpage.filterOwner.clear)
+    );
+
+    expect(clearCallback).toHaveBeenCalled();
+  });
+
+  it("should display the select user dialog when select is clicked", () => {
+    const { container, queryByText } = render(
+      <OwnerSelector onClearSelect={jest.fn()} onSelect={jest.fn()} />
+    );
+
+    clickSelect(container);
+
+    expect(
+      queryByText(languageStrings.searchpage.filterOwner.selectTitle)
+    ).toBeInTheDocument();
+  });
+
+  it("should trigger the callback with the correct details of the selected user", async () => {
+    const onSelectCallback = jest.fn();
+    const { container, getByText, getByRole } = render(
+      <OwnerSelector
+        onClearSelect={jest.fn()}
+        onSelect={onSelectCallback}
+        userListProvider={UserSearchMock.userDetailsProvider}
+      />
+    );
+
+    clickSelect(container);
+    doSearch(testUser.username);
+    // Wait for mock latency
+    const findUsername = () => getByText(testUser.username);
+    await waitFor(findUsername);
+    // Click on a user
+    fireEvent.click(findUsername());
+    // And click select
+    const dialogSelectButton = getSelectButton(getByRole("dialog"));
+    if (!dialogSelectButton) {
+      throw new Error(
+        "Unable to find the 'select' button in the user select dialog."
+      );
+    }
+    fireEvent.click(dialogSelectButton);
+
+    // Finally, was the callback called with the correct user details
+    expect(onSelectCallback).toHaveBeenCalledWith(testUser);
+  });
+
+  it("should not call the onSelect callback if cancel is clicked", () => {
+    const onSelectCallback = jest.fn();
+    const { container, getByRole } = render(
+      <OwnerSelector onClearSelect={jest.fn()} onSelect={onSelectCallback} />
+    );
+
+    clickSelect(container);
+    const dialogCancelButton = queryMuiButtonByText(
+      getByRole("dialog"),
+      languageStrings.common.action.cancel
+    );
+    if (!dialogCancelButton) {
+      throw new Error(
+        "Unable to find 'cancel' button in the user select dialog"
+      );
+    }
+    fireEvent.click(dialogCancelButton);
+
+    expect(onSelectCallback).not.toHaveBeenCalled();
+  });
+});

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/UserSearch.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/UserSearch.tsx
@@ -102,7 +102,7 @@ const UserSearch = ({
           <SearchIcon />
         </IconButton>
       </Grid>
-      <Grid item>
+      <Grid item style={{ flexGrow: 1 }}>
         <TextField
           label={queryFieldLabel}
           value={query}
@@ -111,6 +111,7 @@ const UserSearch = ({
             setQuery(event.target.value);
           }}
           onKeyDown={handleQueryFieldKeypress}
+          fullWidth
         />
       </Grid>
     </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/UserSearch.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/UserSearch.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { KeyboardEvent, useState } from "react";
 import * as OEQ from "@openequella/rest-api-client";
 import {
+  CircularProgress,
   Grid,
   IconButton,
   List,
@@ -66,20 +67,25 @@ const UserSearch = ({
     OEQ.Common.UuidString | undefined
   >(undefined);
   const [hasSearched, setHasSearched] = useState<boolean>(false);
+  const [showSpinner, setShowSpinner] = useState<boolean>(false);
 
   // Simple helper function to assist with providing useful id's for testing and theming.
   const genId = (suffix?: string) =>
     (id ? `${id}-` : "") + "UserSearch" + (suffix ? `-${suffix}` : "");
 
-  const handleOnSearch = () =>
-    userListProvider(query).then((userDetails: OEQ.UserQuery.UserDetails[]) => {
-      setHasSearched(true);
-      setUsers(
-        userDetails.sort((a, b) =>
-          a.username.toLowerCase().localeCompare(b.username.toLowerCase())
-        )
-      );
-    });
+  const handleOnSearch = () => {
+    setShowSpinner(true);
+    userListProvider(query)
+      .then((userDetails: OEQ.UserQuery.UserDetails[]) => {
+        setHasSearched(true);
+        setUsers(
+          userDetails.sort((a, b) =>
+            a.username.toLowerCase().localeCompare(b.username.toLowerCase())
+          )
+        );
+      })
+      .finally(() => setShowSpinner(false));
+  };
 
   const handleQueryFieldKeypress = (event: KeyboardEvent<HTMLDivElement>) => {
     switch (event.key) {
@@ -88,6 +94,7 @@ const UserSearch = ({
         setUsers([]);
         setSelectedUser(undefined);
         setHasSearched(false);
+        event.stopPropagation();
         break;
       case "Enter":
         handleOnSearch();
@@ -163,13 +170,21 @@ const UserSearch = ({
     );
   };
 
+  const spinner = (
+    <Grid container justify="center">
+      <Grid item>
+        <CircularProgress />
+      </Grid>
+    </Grid>
+  );
+
   return (
     <Grid id={genId()} container direction="column" spacing={1}>
       <Grid item xs={12}>
         {queryBar}
       </Grid>
       <Grid item xs={12}>
-        {userList()}
+        {showSpinner ? spinner : userList()}
       </Grid>
     </Grid>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -62,6 +62,7 @@ export const searchItems = ({
   collections,
   rawMode,
   lastModifiedDateRange,
+  owner,
 }: SearchOptions): Promise<
   OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
 > => {
@@ -79,6 +80,7 @@ export const searchItems = ({
     collections: collections?.map((collection) => collection.uuid),
     modifiedAfter: getISODateString(lastModifiedDateRange?.start),
     modifiedBefore: getISODateString(lastModifiedDateRange?.end),
+    owner: owner?.id,
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
 };
@@ -116,4 +118,8 @@ export interface SearchOptions {
    * A date range for searching items by last modified date.
    */
   lastModifiedDateRange?: DateRange;
+  /**
+   * A user for which to filter the search by based on ownership of items.
+   */
+  owner?: OEQ.UserQuery.UserDetails;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -195,6 +195,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
   const refinePanelControls: RefinePanelControl[] = [
     {
+      idSuffix: "CollectionSelector",
       title: collectionSelectorTitle,
       component: (
         <CollectionSelector
@@ -204,6 +205,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       ),
     },
     {
+      idSuffix: "DateRangeSelector",
       title: dateModifiedSelectorTitle,
       component: (
         <DateRangeSelector
@@ -216,6 +218,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       ),
     },
     {
+      idSuffix: "OwnerSelector",
       title: searchStrings.filterOwner.title,
       component: (
         <OwnerSelector

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -47,6 +47,7 @@ import { CollectionSelector } from "./components/CollectionSelector";
 import { Collection } from "../modules/CollectionsModule";
 import { useHistory } from "react-router";
 import { DateRange, DateRangeSelector } from "../components/DateRangeSelector";
+import OwnerSelector from "./components/OwnerSelector";
 
 /**
  * Type of search options that are specific to Search page presentation layer.
@@ -180,6 +181,18 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       lastModifiedDateRange: dateRange,
     });
 
+  const handleOwnerChange = (owner: OEQ.UserQuery.UserDetails) =>
+    setSearchPageOptions({
+      ...searchPageOptions,
+      owner: { ...owner },
+    });
+
+  const handleOwnerClear = () =>
+    setSearchPageOptions({
+      ...searchPageOptions,
+      owner: undefined,
+    });
+
   const refinePanelControls: RefinePanelControl[] = [
     {
       title: collectionSelectorTitle,
@@ -199,6 +212,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           quickOptionDropdownLabel={quickOptionDropdown}
           dateRange={searchPageOptions.lastModifiedDateRange}
           quickModeEnabled={searchPageOptions.dateRangeQuickModeEnabled}
+        />
+      ),
+    },
+    {
+      title: searchStrings.filterOwner.title,
+      component: (
+        <OwnerSelector
+          onClearSelect={handleOwnerClear}
+          onSelect={handleOwnerChange}
+          value={searchPageOptions.owner}
         />
       ),
     },

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
@@ -56,9 +56,7 @@ const OwnerSelector = ({
 }: OwnerSelectorProps) => {
   const [showFindUserDialog, setShowFindUserDialog] = useState<boolean>(false);
 
-  const handleCloseFindUserDialog = (
-    selection: OEQ.UserQuery.UserDetails | undefined
-  ) => {
+  const handleCloseFindUserDialog = (selection?: OEQ.UserQuery.UserDetails) => {
     setShowFindUserDialog(false);
     if (selection) {
       onSelect(selection);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
@@ -1,0 +1,168 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemSecondaryAction,
+  ListItemText,
+} from "@material-ui/core";
+import { AccountCircle } from "@material-ui/icons";
+import DeleteIcon from "@material-ui/icons/Delete";
+import UserSearch from "../../components/UserSearch";
+import { languageStrings } from "../../util/langstrings";
+
+interface OwnerSelectorProps {
+  /** The currently selected user or. */
+  value?: OEQ.UserQuery.UserDetails;
+  /** Handler for when current selection is cleared. */
+  onClearSelect: () => void;
+  /** Handler for when a user is selected. */
+  onSelect: (selection: OEQ.UserQuery.UserDetails) => void;
+  /** Function which will provide the list of users for UserSearch. */
+  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
+}
+
+const OwnerSelector = ({
+  value,
+  onClearSelect,
+  onSelect,
+  userListProvider,
+}: OwnerSelectorProps) => {
+  const [showFindUserDialog, setShowFindUserDialog] = useState<boolean>(false);
+
+  const handleCloseFindUserDialog = (
+    selection: OEQ.UserQuery.UserDetails | undefined
+  ) => {
+    setShowFindUserDialog(false);
+    if (selection) {
+      onSelect(selection);
+    }
+  };
+
+  return (
+    <>
+      <Grid container alignItems="center" spacing={1}>
+        {value ? (
+          <Grid item xs={12}>
+            <List disablePadding>
+              <ListItem dense>
+                <ListItemIcon>
+                  <AccountCircle color="secondary" />
+                </ListItemIcon>
+                <ListItemText
+                  style={{ overflowWrap: "anywhere" }}
+                  secondary={value.username}
+                />
+                <ListItemSecondaryAction>
+                  <IconButton
+                    aria-label={languageStrings.searchpage.filterOwner.clear}
+                    onClick={onClearSelect}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            </List>
+          </Grid>
+        ) : (
+          <Grid item>
+            <Button
+              variant="outlined"
+              onClick={() => setShowFindUserDialog(true)}
+            >
+              Find User
+            </Button>
+          </Grid>
+        )}
+      </Grid>
+      <SelectUserDialog
+        open={showFindUserDialog}
+        onClose={handleCloseFindUserDialog}
+        userListProvider={userListProvider}
+      />
+    </>
+  );
+};
+
+interface SelectUserDialogProps {
+  /** Controls displaying of dialog. */
+  open: boolean;
+  /** Handler for when dialog closes. */
+  onClose: (selection?: OEQ.UserQuery.UserDetails) => void;
+  /** Function which will provide the list of users for UserSearch. */
+  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
+}
+
+/**
+ * Simple dialog to prompt user to search and select a user to use in the owner filter.
+ */
+const SelectUserDialog = ({
+  open,
+  onClose,
+  userListProvider,
+}: SelectUserDialogProps) => {
+  const [selectedUser, setSelectedUser] = useState<
+    OEQ.UserQuery.UserDetails | undefined
+  >(undefined);
+
+  const handleClose = () => {
+    onClose(selectedUser);
+    setSelectedUser(undefined);
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth>
+      <DialogTitle>
+        {languageStrings.searchpage.filterOwner.selectTitle}
+      </DialogTitle>
+      <DialogContent>
+        <UserSearch
+          onSelect={setSelectedUser}
+          userListProvider={userListProvider}
+          listHeight={300}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => onClose()} color="primary">
+          {languageStrings.common.action.cancel}
+        </Button>
+        <Button
+          onClick={handleClose}
+          color="primary"
+          autoFocus
+          disabled={!selectedUser}
+        >
+          {languageStrings.common.action.select}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default OwnerSelector;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
@@ -96,7 +96,7 @@ const OwnerSelector = ({
               variant="outlined"
               onClick={() => setShowFindUserDialog(true)}
             >
-              Find User
+              {languageStrings.common.action.select}
             </Button>
           </Grid>
         )}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
@@ -38,7 +38,7 @@ import UserSearch from "../../components/UserSearch";
 import { languageStrings } from "../../util/langstrings";
 
 interface OwnerSelectorProps {
-  /** The currently selected user or. */
+  /** The currently selected user or undefined if none. */
   value?: OEQ.UserQuery.UserDetails;
   /** Handler for when current selection is cleared. */
   onClearSelect: () => void;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
@@ -30,6 +30,10 @@ import { RefinePanelControlHeading } from "./RefinePanelControlHeading";
 
 export interface RefinePanelControl {
   /**
+   * A suffix to use in the DOM id of this control which will be prefixed with `RefineSearchPanel-`.
+   */
+  idSuffix: string;
+  /**
    * Title of a Refine control.
    */
   title: string;
@@ -55,7 +59,11 @@ export const RefineSearchPanel = ({ controls }: RefinePanelProps) => {
         <List>
           {controls.map((control) => (
             <ListItem>
-              <Grid container direction="column">
+              <Grid
+                id={`RefineSearchPanel-${control.idSuffix}`}
+                container
+                direction="column"
+              >
                 <Grid item>
                   <RefinePanelControlHeading title={control.title} />
                 </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -333,6 +333,7 @@ export const languageStrings = {
     filterOwner: {
       title: "Owner",
       chip: "Owner: ",
+      clear: "Clear owner selector",
       selectTitle: "Select user to filter by",
     },
     filterLast: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Well this ended up a few more lines then first thought, so you can expect to see:

* The new `OwnerSelector` component consuming the `UserSearch` component and integrating to the `SearchPage` component.
* Various bits of existing tests refactored out to support re-usability and attempt an increased level of abstraction in tests to support maintainability
* Additional use of `id` attributes to assist with testing and future theming
* Continued use of React Testing Library
* Aux: Adding Roboto font to Storybook setup to ensure what we see in there is reflective of our actual running theme
  * This was added when a layout issue was found with the `UserSearch` component, which looked fine in Storybook, not so much when incorporated into oEQ. Hence, you also see some style/layout tweaks for `UserSearch`.
* Spinner added to `UserSearch` to support delays in server response - was meant to add it originally, but forgot. The mocked server response is also delayed by 500ms so that this can be seen.

@PenghaiZhang and I have been doing similar things, and as a result we're expecting conflicts between this PR and #2148 . We'll need to co-ordinate on merging.

#1306 

**Screenshots**

Before selecting a user:

![image](https://user-images.githubusercontent.com/43919233/89748264-c387d580-db05-11ea-8d71-2dbbc7fc208d.png)

Selecting a user:

![image](https://user-images.githubusercontent.com/43919233/89748290-d4d0e200-db05-11ea-886e-856d1531449e.png)

![image](https://user-images.githubusercontent.com/43919233/89748314-e5815800-db05-11ea-8d01-01c242a3f7b3.png)

![image](https://user-images.githubusercontent.com/43919233/89748348-0d70bb80-db06-11ea-983e-b783a09c0fa5.png)

After selecting a user:

![image](https://user-images.githubusercontent.com/43919233/89748253-b539b980-db05-11ea-976e-85094e2bdda1.png)


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
