### PR TITLE
EBP: Updates to legacy.scss do not show up properly until theme changes happen

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/service/impl/ThemeSettingsServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/service/impl/ThemeSettingsServiceImpl.java
@@ -167,22 +167,30 @@ public class ThemeSettingsServiceImpl implements ThemeSettingsService {
 
   public InputStream getLegacyCss() throws IOException {
     CustomisationFile customisationFile = new CustomisationFile();
-
-    // get last modified date of the scss file
-    URLConnection conn =
-        getClass().getResource("/web/sass/" + SASS_LEGACY_CSS_FILENAME).openConnection();
-    long lastMod = conn.getLastModified();
-    conn.getInputStream().close();
+    boolean needsUpdate = false;
 
     // compare against the modified date of the css file if it exists
     boolean legacyCssExists = fileSystemService.fileExists(customisationFile, LEGACY_CSS_FILENAME);
     if (legacyCssExists) {
+      // get last modified date of the scss file
+      URLConnection conn =
+          getClass().getResource("/web/sass/" + SASS_LEGACY_CSS_FILENAME).openConnection();
+      long lastMod = conn.getLastModified();
+      conn.getInputStream().close();
+
+      // get last modified of the compiled css file
       long cssLastMod = fileSystemService.lastModified(customisationFile, LEGACY_CSS_FILENAME);
-      boolean baseSassUpdated = lastMod > cssLastMod;
-      if (baseSassUpdated) {
-        compileSass();
+      if (lastMod > cssLastMod) {
+        needsUpdate = true;
       }
+    } else {
+      needsUpdate = true;
     }
+
+    if (needsUpdate) {
+      compileSass();
+    }
+
     return fileSystemService.read(customisationFile, LEGACY_CSS_FILENAME);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/service/impl/ThemeSettingsServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/service/impl/ThemeSettingsServiceImpl.java
@@ -165,27 +165,26 @@ public class ThemeSettingsServiceImpl implements ThemeSettingsService {
     return themeToString;
   }
 
-	public InputStream getLegacyCss() throws IOException {
-		CustomisationFile customisationFile = new CustomisationFile();
+  public InputStream getLegacyCss() throws IOException {
+    CustomisationFile customisationFile = new CustomisationFile();
 
-		//get last modified date of the scss file
-		URLConnection conn =
-			getClass().getResource("/web/sass/" + SASS_LEGACY_CSS_FILENAME).openConnection();
-		long lastMod = conn.getLastModified();
-		conn.getInputStream().close();
+    // get last modified date of the scss file
+    URLConnection conn =
+        getClass().getResource("/web/sass/" + SASS_LEGACY_CSS_FILENAME).openConnection();
+    long lastMod = conn.getLastModified();
+    conn.getInputStream().close();
 
-		//compare against the modified date of the css file if it exists
-		boolean legacyCssExists = fileSystemService
-			.fileExists(customisationFile, LEGACY_CSS_FILENAME);
-		if(legacyCssExists){
-			long cssLastMod = fileSystemService.lastModified(customisationFile, LEGACY_CSS_FILENAME);
-			boolean baseSassUpdated = lastMod > cssLastMod;
-			if (baseSassUpdated) {
-				compileSass();
-			}
-		}
-		return fileSystemService.read(customisationFile, LEGACY_CSS_FILENAME);
-	}
+    // compare against the modified date of the css file if it exists
+    boolean legacyCssExists = fileSystemService.fileExists(customisationFile, LEGACY_CSS_FILENAME);
+    if (legacyCssExists) {
+      long cssLastMod = fileSystemService.lastModified(customisationFile, LEGACY_CSS_FILENAME);
+      boolean baseSassUpdated = lastMod > cssLastMod;
+      if (baseSassUpdated) {
+        compileSass();
+      }
+    }
+    return fileSystemService.read(customisationFile, LEGACY_CSS_FILENAME);
+  }
 
   private InputStream compileSass() throws IOException {
     CustomisationFile customisationFile = new CustomisationFile();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
#2107 
The issue was caused by the lastModified check on the legacy.scss file. 
Creating a new File() with getResource().getFile() worked fine in a dev environment - but in an installed oEQ
this file would be inside a jar and wouldn't work. The lastModified date would always return 0. 
This PR changes to use an URLConnection to the same file to grab the value and then close the stream, and I have tested this via installerZip. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
