### PR TITLE
front-end: Display count of search results

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -107,7 +107,7 @@ export const SearchResultList = ({
   return (
     <Card>
       <CardHeader
-        title={searchPageStrings.subtitle}
+        title={searchPageStrings.subtitle + ` (${paginationProps.count})`}
         action={
           <SearchOrderSelect
             value={orderSelectProps.value}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Simple update to also show the number of search results at the top of the list.

#1306 

![image](https://user-images.githubusercontent.com/43919233/89763823-9f90b800-db36-11ea-9ec1-d4764e818511.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
