### PR TITLE
Make date range end inclusive in searches

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
@@ -86,4 +86,6 @@ public interface Search {
   String getPrivilegeToCollect();
 
   Collection<DateFilter> getDateFilters();
+
+  boolean isFromSearch2API();
 }

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
@@ -88,7 +88,7 @@ public interface Search {
   Collection<DateFilter> getDateFilters();
 
   /**
-   * Indicate if the server time zone is needed in searches.
+   * Indicates if the server time zone should be included in searches.
    *
    * @return True if server time zone is used or otherwise false.
    */

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
@@ -87,5 +87,10 @@ public interface Search {
 
   Collection<DateFilter> getDateFilters();
 
-  boolean isFromSearch2API();
+  /**
+   * Indicate if the server time zone is needed in searches.
+   *
+   * @return True if server time zone is used or otherwise false.
+   */
+  boolean useServerTimeZone();
 }

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/VeryBasicSearch.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/VeryBasicSearch.java
@@ -36,6 +36,7 @@ public class VeryBasicSearch implements Search, Serializable {
   protected String query;
   protected Collection<String> queryTokens;
   protected FreeTextQuery freeTextQuery;
+  private boolean fromSearch2API;
 
   public VeryBasicSearch() {}
 
@@ -135,6 +136,15 @@ public class VeryBasicSearch implements Search, Serializable {
   @Override
   public Collection<DateFilter> getDateFilters() {
     return null;
+  }
+
+  @Override
+  public boolean isFromSearch2API() {
+    return fromSearch2API;
+  }
+
+  public void setFromSearch2API(boolean fromSearch2API) {
+    this.fromSearch2API = fromSearch2API;
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/VeryBasicSearch.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/VeryBasicSearch.java
@@ -36,7 +36,7 @@ public class VeryBasicSearch implements Search, Serializable {
   protected String query;
   protected Collection<String> queryTokens;
   protected FreeTextQuery freeTextQuery;
-  private boolean fromSearch2API;
+  private boolean useServerTimeZone;
 
   public VeryBasicSearch() {}
 
@@ -139,12 +139,12 @@ public class VeryBasicSearch implements Search, Serializable {
   }
 
   @Override
-  public boolean isFromSearch2API() {
-    return fromSearch2API;
+  public boolean useServerTimeZone() {
+    return useServerTimeZone;
   }
 
-  public void setFromSearch2API(boolean fromSearch2API) {
-    this.fromSearch2API = fromSearch2API;
+  public void setUseServerTimeZone(boolean useServerTimeZone) {
+    this.useServerTimeZone = useServerTimeZone;
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -61,7 +61,7 @@ object SearchHelper {
     */
   def createSearch(params: SearchParam): DefaultSearch = {
     val search = new DefaultSearch
-    search.setFromSearch2API(true)
+    search.setUseServerTimeZone(true)
     search.setQuery(params.query)
     search.setOwner(params.owner)
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -75,8 +75,9 @@ object SearchHelper {
     val itemStatus = if (params.status.isEmpty) None else Some(params.status.toList.asJava)
     search.setItemStatuses(itemStatus.orNull)
 
-    val modifiedBefore = handleModifiedDate(params.modifiedBefore)
-    val modifiedAfter  = handleModifiedDate(params.modifiedAfter, isStart = true)
+    // The time of start should be '00:00:00' whereas the time of end should be '23:59:59'.
+    val modifiedAfter  = handleModifiedDate(params.modifiedAfter, LocalTime.MIN)
+    val modifiedBefore = handleModifiedDate(params.modifiedBefore, LocalTime.MAX)
     if (modifiedBefore.isDefined || modifiedAfter.isDefined) {
       search.setDateRange(Array(modifiedAfter.orNull, modifiedBefore.orNull))
     }
@@ -121,16 +122,14 @@ object SearchHelper {
   /**
     * Parse a string to a new instance of Date in the format of "yyyy-MM-dd".
     * @param dateString The string to parse.
-    * @param isStart True if the date is the start of a date range.
+    * @param time The time added to a date.
     * @return An option which wraps an instance of Date.
     */
-  def handleModifiedDate(dateString: String, isStart: Boolean = false): Option[Date] = {
+  def handleModifiedDate(dateString: String, time: LocalTime): Option[Date] = {
     if (Check.isEmpty(dateString)) {
       return None
     }
     try {
-      // The time of start should be '00:00:00' whereas the time of end should be '23:59:59'.
-      val time     = if (isStart) LocalTime.MIN else LocalTime.MAX
       val dateTime = LocalDateTime.of(LocalDate.parse(dateString), time)
       //Need to convert back to util.date to work compatibly with old methods.
       Some(Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant))

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -123,7 +123,7 @@ object SearchHelper {
     * Parse a string to a new instance of Date in the format of "yyyy-MM-dd".
     * @param dateString The string to parse.
     * @param time The time added to a date.
-    * @return An option which wraps an instance of Date.
+    * @return An Option which wraps an instance of Date, combining the successfully parsed dateString and provided time (based on the system's default timezone).
     */
   def handleModifiedDate(dateString: String, time: LocalTime): Option[Date] = {
     if (Check.isEmpty(dateString)) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
@@ -985,7 +985,12 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
 
     Date[] dateRange = request.getDateRange();
     if (dateRange != null) {
-      filters.add(createDateFilter(FreeTextQuery.FIELD_REALLASTMODIFIED, dateRange, Dates.ISO));
+      filters.add(
+          createDateFilter(
+              FreeTextQuery.FIELD_REALLASTMODIFIED,
+              dateRange,
+              Dates.ISO,
+              request.isFromSearch2API()));
     }
 
     Collection<com.tle.common.searching.DateFilter> dateFilters = request.getDateFilters();
@@ -994,7 +999,8 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
         Date[] range = dateFilter.getRange();
         String indexFieldName = dateFilter.getIndexFieldName();
         if (dateFilter.getFormat() == Format.ISO) {
-          filters.add(createDateFilter(indexFieldName, range, Dates.ISO));
+          filters.add(
+              createDateFilter(indexFieldName, range, Dates.ISO, request.isFromSearch2API()));
         } else {
           Long start = range[0] != null ? range[0].getTime() : null;
           Long end = range[1] != null ? range[1].getTime() : null;
@@ -1031,11 +1037,17 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
     return filters;
   }
 
-  protected DateFilter createDateFilter(String fieldName, Date[] range, Dates indexDateFormat) {
+  protected DateFilter createDateFilter(
+      String fieldName, Date[] range, Dates indexDateFormat, boolean isFromSearch2API) {
     if (range.length != 2 || (range[0] != null && range[1] != null && range[0].after(range[1]))) {
       throw new InvalidDateRangeException();
     }
-    return new DateFilter(fieldName, range[0], range[1], indexDateFormat, null);
+    return new DateFilter(
+        fieldName,
+        range[0],
+        range[1],
+        indexDateFormat,
+        isFromSearch2API ? TimeZone.getDefault() : null);
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
@@ -990,7 +990,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
               FreeTextQuery.FIELD_REALLASTMODIFIED,
               dateRange,
               Dates.ISO,
-              request.isFromSearch2API()));
+              request.useServerTimeZone()));
     }
 
     Collection<com.tle.common.searching.DateFilter> dateFilters = request.getDateFilters();
@@ -1000,7 +1000,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
         String indexFieldName = dateFilter.getIndexFieldName();
         if (dateFilter.getFormat() == Format.ISO) {
           filters.add(
-              createDateFilter(indexFieldName, range, Dates.ISO, request.isFromSearch2API()));
+              createDateFilter(indexFieldName, range, Dates.ISO, request.useServerTimeZone()));
         } else {
           Long start = range[0] != null ? range[0].getTime() : null;
           Long end = range[1] != null ? range[1].getTime() : null;
@@ -1038,7 +1038,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
   }
 
   protected DateFilter createDateFilter(
-      String fieldName, Date[] range, Dates indexDateFormat, boolean isFromSearch2API) {
+      String fieldName, Date[] range, Dates indexDateFormat, boolean useServerTimeZone) {
     if (range.length != 2 || (range[0] != null && range[1] != null && range[0].after(range[1]))) {
       throw new InvalidDateRangeException();
     }
@@ -1047,7 +1047,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
         range[0],
         range[1],
         indexDateFormat,
-        isFromSearch2API ? TimeZone.getDefault() : null);
+        useServerTimeZone ? TimeZone.getDefault() : null);
   }
 
   /**


### PR DESCRIPTION
#1306  

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR attempts to make the end of a date range inclusive in searches without making any change on the old Search page.

Also during the work, I found that in the old Search page, selected dates are always convert to UTC dates, which means the search results may be wrong. For example, if I select 1st Aug, the real date passed to Lucene is `31 July 14:00:00` because AEST is 10 hours ahead of UTC time. More info can be found in screenshots.

In new Search page: 
![image](https://user-images.githubusercontent.com/47203811/89860244-61eb6800-dbe6-11ea-953d-87480d9a68a2.png)
![image](https://user-images.githubusercontent.com/47203811/89860338-965f2400-dbe6-11ea-952a-028b62c82df0.png)


In old Search page:
![image](https://user-images.githubusercontent.com/47203811/89860400-b858a680-dbe6-11ea-98b5-2a6b9b5cb34c.png)
![image](https://user-images.githubusercontent.com/47203811/89860451-d1f9ee00-dbe6-11ea-8c38-767e0f99d56e.png)




