### PR TITLE
Refine Search - StatusSelector

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -65,6 +65,7 @@
       <option name="FORMATTER" value="1" />
     </ScalaCodeStyleSettings>
     <TypeScriptCodeStyleSettings version="0">
+      <option name="IMPORT_SORT_MODULE_NAME" value="true" />
       <option name="USE_PATH_MAPPING" value="NEVER" />
     </TypeScriptCodeStyleSettings>
     <codeStyleSettings language="JAVA">

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/StatusSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/StatusSelector.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { action } from "@storybook/addon-actions";
+import * as React from "react";
+import { liveStatuses, nonLiveStatuses } from "../../tsrc/modules/SearchModule";
+import StatusSelector from "../../tsrc/search/components/StatusSelector";
+
+export default {
+  title: "Search/StatusSelector",
+  component: StatusSelector,
+};
+
+const commonParams = {
+  onChange: action("onChange"),
+};
+
+export const DefaultSelection = () => <StatusSelector {...commonParams} />;
+
+export const LiveSelection = () => (
+  <StatusSelector {...commonParams} value={liveStatuses} />
+);
+
+export const AllSelection = () => (
+  <StatusSelector
+    {...commonParams}
+    value={liveStatuses.concat(nonLiveStatuses)}
+  />
+);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -136,7 +136,7 @@ describe("Refine search by status", () => {
   } = languageStrings.searchpage.statusSelector;
 
   const expectSearchItemsCalledWithStatus = (status: OEQ.Common.ItemStatus[]) =>
-    expect(mockSearch).toHaveBeenCalledWith({
+    expect(mockSearch).toHaveBeenLastCalledWith({
       ...defaultSearchPageOptions,
       status: status,
     });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -81,11 +81,22 @@ const defaultSearchPageOptions: SearchPageOptions = {
 };
 const defaultCollectionPrivileges = ["SEARCH_COLLECTION"];
 
+/**
+ * Simple helper to wrap the process of waiting for the execution of a search based on checking the
+ * `searchPromise`. Being that it is abstracted out, in the future could change as needed to be
+ * something other than the `searchPromise`.
+ */
 const waitForSearch = async () =>
   await act(async () => {
     await searchPromise;
   });
 
+/**
+ * Helper function for the initial render of the `<SearchPage>` for tests below. Also includes
+ * the wait for the initial search call.
+ *
+ * @returns The RenderResult from the `render` of the `<SearchPage>`
+ */
 const renderSearchPage = async (): Promise<RenderResult> => {
   window.history.replaceState({}, "Clean history state");
   const page = render(
@@ -99,6 +110,12 @@ const renderSearchPage = async (): Promise<RenderResult> => {
   return page;
 };
 
+/**
+ * Helper function to find individual Refine Search components based on the their `idSuffix`.
+ *
+ * @param container The root container to start the search from
+ * @param componentSuffix Typically the `idSuffix` provided in `SearchPage.tsx`
+ */
 const getRefineSearchComponent = (
   container: Element,
   componentSuffix: string
@@ -112,7 +129,7 @@ const getRefineSearchComponent = (
   return e as HTMLElement;
 };
 
-describe("Refine search to include all statuses", () => {
+describe("Refine search by status", () => {
   const {
     live: liveButtonLabel,
     all: allButtonLabel,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -63,6 +63,7 @@ export const searchItems = ({
   rawMode,
   lastModifiedDateRange,
   owner,
+  status = liveStatuses,
 }: SearchOptions): Promise<
   OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
 > => {
@@ -72,10 +73,7 @@ export const searchItems = ({
     query: processedQuery,
     start: currentPage * rowsPerPage,
     length: rowsPerPage,
-    status: [
-      "LIVE" as OEQ.Common.ItemStatus,
-      "REVIEW" as OEQ.Common.ItemStatus,
-    ],
+    status: status,
     order: sortOrder,
     collections: collections?.map((collection) => collection.uuid),
     modifiedAfter: getISODateString(lastModifiedDateRange?.start),
@@ -84,6 +82,30 @@ export const searchItems = ({
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
 };
+
+/**
+ * List of status which are considered 'live'.
+ */
+export const liveStatuses: OEQ.Common.ItemStatus[] = [
+  OEQ.Common.ItemStatus.LIVE,
+  OEQ.Common.ItemStatus.REVIEW,
+];
+
+/**
+ * Predicate for checking if a provided status is not one of `liveStatuses`.
+ * @param status a status to check for liveliness
+ */
+export const nonLiveStatus = (status: OEQ.Common.ItemStatus): boolean =>
+  !liveStatuses.find((liveStatus) => status === liveStatus);
+
+/**
+ * List of statuses which are considered non-live.
+ */
+export const nonLiveStatuses: OEQ.Common.ItemStatus[] = Object.keys(
+  OEQ.Common.ItemStatus
+)
+  .map((status) => status as OEQ.Common.ItemStatus)
+  .filter(nonLiveStatus);
 
 /**
  * Type of all search options on Search page
@@ -122,4 +144,8 @@ export interface SearchOptions {
    * A user for which to filter the search by based on ownership of items.
    */
   owner?: OEQ.UserQuery.UserDetails;
+  /**
+   * Filter search results to only include items with the specified statuses.
+   */
+  status?: OEQ.Common.ItemStatus[];
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -86,10 +86,7 @@ export const searchItems = ({
 /**
  * List of status which are considered 'live'.
  */
-export const liveStatuses: OEQ.Common.ItemStatus[] = [
-  OEQ.Common.ItemStatus.LIVE,
-  OEQ.Common.ItemStatus.REVIEW,
-];
+export const liveStatuses: OEQ.Common.ItemStatus[] = ["LIVE", "REVIEW"];
 
 /**
  * Predicate for checking if a provided status is not one of `liveStatuses`.
@@ -101,10 +98,8 @@ export const nonLiveStatus = (status: OEQ.Common.ItemStatus): boolean =>
 /**
  * List of statuses which are considered non-live.
  */
-export const nonLiveStatuses: OEQ.Common.ItemStatus[] = Object.keys(
-  OEQ.Common.ItemStatus
-)
-  .map((status) => status as OEQ.Common.ItemStatus)
+export const nonLiveStatuses: OEQ.Common.ItemStatus[] = OEQ.Common.ItemStatuses.alternatives
+  .map((status) => status.value)
   .filter(nonLiveStatus);
 
 /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -22,11 +22,31 @@ import { Collection } from "./CollectionsModule";
 import { DateRange } from "../components/DateRangeSelector";
 import { getISODateString } from "../util/Date";
 
+/**
+ * List of status which are considered 'live'.
+ */
+export const liveStatuses: OEQ.Common.ItemStatus[] = ["LIVE", "REVIEW"];
+
+/**
+ * Predicate for checking if a provided status is not one of `liveStatuses`.
+ * @param status a status to check for liveliness
+ */
+export const nonLiveStatus = (status: OEQ.Common.ItemStatus): boolean =>
+  !liveStatuses.find((liveStatus) => status === liveStatus);
+
+/**
+ * List of statuses which are considered non-live.
+ */
+export const nonLiveStatuses: OEQ.Common.ItemStatus[] = OEQ.Common.ItemStatuses.alternatives
+  .map((status) => status.value)
+  .filter(nonLiveStatus);
+
 export const defaultSearchOptions: SearchOptions = {
   rowsPerPage: 10,
   currentPage: 0,
   sortOrder: undefined,
   rawMode: false,
+  status: liveStatuses,
 };
 
 export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
@@ -82,25 +102,6 @@ export const searchItems = ({
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
 };
-
-/**
- * List of status which are considered 'live'.
- */
-export const liveStatuses: OEQ.Common.ItemStatus[] = ["LIVE", "REVIEW"];
-
-/**
- * Predicate for checking if a provided status is not one of `liveStatuses`.
- * @param status a status to check for liveliness
- */
-export const nonLiveStatus = (status: OEQ.Common.ItemStatus): boolean =>
-  !liveStatuses.find((liveStatus) => status === liveStatus);
-
-/**
- * List of statuses which are considered non-live.
- */
-export const nonLiveStatuses: OEQ.Common.ItemStatus[] = OEQ.Common.ItemStatuses.alternatives
-  .map((status) => status.value)
-  .filter(nonLiveStatus);
 
 /**
  * Type of all search options on Search page

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -48,6 +48,7 @@ import { Collection } from "../modules/CollectionsModule";
 import { useHistory } from "react-router";
 import { DateRange, DateRangeSelector } from "../components/DateRangeSelector";
 import OwnerSelector from "./components/OwnerSelector";
+import StatusSelector from "./components/StatusSelector";
 
 /**
  * Type of search options that are specific to Search page presentation layer.
@@ -200,6 +201,12 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       owner: undefined,
     });
 
+  const handleStatusChange = (status: OEQ.Common.ItemStatus[]) =>
+    setSearchPageOptions({
+      ...searchPageOptions,
+      status: [...status],
+    });
+
   const refinePanelControls: RefinePanelControl[] = [
     {
       idSuffix: "CollectionSelector",
@@ -232,6 +239,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           onClearSelect={handleOwnerClear}
           onSelect={handleOwnerChange}
           value={searchPageOptions.owner}
+        />
+      ),
+    },
+    {
+      idSuffix: "StatusSelector",
+      title: searchStrings.statusSelector.title,
+      component: (
+        <StatusSelector
+          onChange={handleStatusChange}
+          value={searchPageOptions.status}
         />
       ),
     },

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/StatusSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/StatusSelector.tsx
@@ -1,0 +1,75 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, ButtonGroup } from "@material-ui/core";
+import * as OEQ from "@openequella/rest-api-client";
+import { isEqual } from "lodash";
+import * as React from "react";
+import { liveStatuses, nonLiveStatuses } from "../../modules/SearchModule";
+import { languageStrings } from "../../util/langstrings";
+
+interface StatusSelectorProps {
+  /**
+   * A list of the currently selected statuses. This list is then used to determine one of two
+   * possible sets: live OR all. The main reason to not simply abstract this out to a boolean, is
+   * to support the easy passing and storing of a value used in calls to the `SearchModule`.
+   */
+  value?: OEQ.Common.ItemStatus[];
+  /**
+   * Handler to call when the selection is modified. The resulting value being what would be passed
+   * back as `value` for future renderings.
+   *
+   * @param value a list representing the new selection.
+   */
+  onChange: (value: OEQ.Common.ItemStatus[]) => void;
+}
+
+/**
+ * A button toggle to provide a simple means of either seeing items which are 'live' or otherwise
+ * all. To do this, it basically considers that if the provided `value` contains only those known
+ * as live then then status is 'live', otherwise it's all. Very simplistic.
+ */
+const StatusSelector = ({
+  value = liveStatuses,
+  onChange,
+}: StatusSelectorProps) => {
+  // iff it contains only those specified in the live status list then we consider
+  // the selection to be the 'live' option, otherwise we will go with 'all'
+  const isLive = (statusList: OEQ.Common.ItemStatus[]): boolean =>
+    isEqual(statusList, liveStatuses);
+  const variant = (determiner: () => boolean) =>
+    determiner() ? "contained" : "outlined";
+
+  return (
+    <ButtonGroup color="secondary">
+      <Button
+        variant={variant(() => isLive(value))}
+        onClick={() => onChange(liveStatuses)}
+      >
+        {languageStrings.searchpage.statusSelector.live}
+      </Button>
+      <Button
+        variant={variant(() => !isLive(value))}
+        onClick={() => onChange(nonLiveStatuses.concat(liveStatuses))}
+      >
+        {languageStrings.searchpage.statusSelector.all}
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+export default StatusSelector;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/StatusSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/StatusSelector.tsx
@@ -64,7 +64,7 @@ const StatusSelector = ({
       </Button>
       <Button
         variant={variant(() => !isLive(value))}
-        onClick={() => onChange(nonLiveStatuses.concat(liveStatuses))}
+        onClick={() => onChange(liveStatuses.concat(nonLiveStatuses))}
       >
         {languageStrings.searchpage.statusSelector.all}
       </Button>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/SearchPageSettings.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/SearchPageSettings.tsx
@@ -135,8 +135,8 @@ function SearchPageSettings({ updateTemplate }: TemplateUpdateProps) {
             {/*Non-Live Results*/}
             <SettingsListControl
               divider
-              primaryText={searchPageSettingsStrings.allowNonLive}
-              secondaryText={searchPageSettingsStrings.allowNonLiveLabel}
+              primaryText={searchPageSettingsStrings.allowStatusControl}
+              secondaryText={searchPageSettingsStrings.allowStatusControlLabel}
               control={
                 <SettingsToggleSwitch
                   value={searchSettings.searchingShowNonLiveCheckbox}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -413,9 +413,9 @@ export const languageStrings = {
         dateCreated: "Date created",
         title: "Title",
         userRating: "User rating",
-        allowNonLive: "Non-live results",
-        allowNonLiveLabel:
-          "Show the 'Include results that are not live' checkbox",
+        allowStatusControl: "Enable status selector",
+        allowStatusControlLabel:
+          "Allow users to toggle between live and all statuses via the status selector",
         authFeed: "Authenticated feeds",
         authFeedLabel: "Generate authenticated RSS and Atom feed links ",
         gallery: "Gallery",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -368,6 +368,11 @@ export const languageStrings = {
       attachments: "Attachments",
       dateModified: "Modified",
     },
+    statusSelector: {
+      all: "All",
+      live: "Live",
+      title: "Status",
+    },
   },
   "com.equella.core.searching.search": {
     title: "Search",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -321,22 +321,8 @@ export const languageStrings = {
     rawSearchTooltip: "Supports use of Apache Lucene search syntax",
     newSearch: "New search",
     newSearchHelperText: "Clears search text and filters",
-    searchresult: {
-      attachments: "Attachments",
-      dateModified: "Modified",
-    },
-    order: {
-      relevance: "Relevance",
-      name: "Name",
-      datemodified: "Date modifed",
-      datecreated: "Date created",
-      rating: "Rating",
-    },
-    filterOwner: {
-      title: "Owner",
-      chip: "Owner: ",
-      clear: "Clear owner selector",
-      selectTitle: "Select user to filter by",
+    collectionSelector: {
+      title: "Collections",
     },
     filterLast: {
       label: "Modified within last",
@@ -349,6 +335,25 @@ export const languageStrings = {
       week: "Week",
       day: "Day",
     },
+    filterOwner: {
+      title: "Owner",
+      chip: "Owner: ",
+      clear: "Clear owner selector",
+      selectTitle: "Select user to filter by",
+    },
+    lastModifiedDateSelector: {
+      title: "Date modified",
+      startDatePicker: "Modified after",
+      endDatePicker: "Modified before",
+      quickOptionDropdown: "Last modified date",
+    },
+    order: {
+      relevance: "Relevance",
+      name: "Name",
+      datemodified: "Date modifed",
+      datecreated: "Date created",
+      rating: "Rating",
+    },
     pagination: {
       firstPageButton: "First page",
       previousPageButton: "Previous page",
@@ -359,14 +364,9 @@ export const languageStrings = {
     refineSearchPanel: {
       title: "Refine search",
     },
-    collectionSelector: {
-      title: "Collections",
-    },
-    lastModifiedDateSelector: {
-      title: "Date modified",
-      startDatePicker: "Modified after",
-      endDatePicker: "Modified before",
-      quickOptionDropdown: "Last modified date",
+    searchresult: {
+      attachments: "Attachments",
+      dateModified: "Modified",
     },
   },
   "com.equella.core.searching.search": {

--- a/oeq-ts-rest-api/package-lock.json
+++ b/oeq-ts-rest-api/package-lock.json
@@ -5080,8 +5080,7 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -5905,6 +5904,11 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
+    },
+    "runtypes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.0.1.tgz",
+      "integrity": "sha512-+TWVlCmFsgrG4Nd2u+ambpNFO8Yp4heAflGQi9oNj6GRkxZo8aSDBxO1Y0vlKIQCWKKFxato+8Hn67XeAqKhRA=="
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -30,10 +30,11 @@
   "dependencies": {
     "axios": "^0.19.2",
     "axios-cookiejar-support": "^1.0.0",
+    "lodash": "^4.17.15",
     "query-string": "^6.12.1",
+    "runtypes": "^5.0.1",
     "tough-cookie": "^4.0.0",
-    "typescript-is": "^0.16.0",
-    "lodash": "^4.17.15"
+    "typescript-is": "^0.16.0"
   },
   "devDependencies": {
     "@types/jest": "26.0.8",

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -1,5 +1,6 @@
-import * as Security from './Security';
+import { Literal, Static, Union } from 'runtypes';
 import { is } from 'typescript-is';
+import * as Security from './Security';
 
 export type i18nString = string;
 
@@ -55,17 +56,19 @@ export interface BaseEntityReference {
   // which means there's potential for additional fields added dynamically at runtime.
 }
 
-export enum ItemStatus {
-  DRAFT = 'DRAFT',
-  LIVE = 'LIVE',
-  REJECTED = 'REJECTED',
-  MODERATING = 'MODERATING',
-  ARCHIVED = 'ARCHIVED',
-  SUSPENDED = 'SUSPENDED',
-  DELETED = 'DELETED',
-  REVIEW = 'REVIEW',
-  PERSONAL = 'PERSONAL',
-}
+export const ItemStatuses = Union(
+  Literal('ARCHIVED'),
+  Literal('DELETED'),
+  Literal('DRAFT'),
+  Literal('LIVE'),
+  Literal('MODERATING'),
+  Literal('PERSONAL'),
+  Literal('REJECTED'),
+  Literal('REVIEW'),
+  Literal('SUSPENDED')
+);
+
+export type ItemStatus = Static<typeof ItemStatuses>;
 
 export interface PagedResult<T> {
   start: number;

--- a/oeq-ts-rest-api/test/search.test.ts
+++ b/oeq-ts-rest-api/test/search.test.ts
@@ -18,7 +18,7 @@ describe('Search for items', () => {
     const collection = 'a77112e6-3370-fd02-6ac6-6bc5aec22001';
     const searchParams: OEQ.Search.SearchParams = {
       query: 'API',
-      status: [OEQ.Common.ItemStatus.LIVE],
+      status: ['LIVE'],
       collections: [collection],
     };
     const searchResult = await OEQ.Search.search(TC.API_PATH, searchParams);
@@ -27,7 +27,7 @@ describe('Search for items', () => {
     expect(searchResult).toHaveLength(searchResult.results.length);
     expect(uuid).toBeTruthy();
     // Status returned is in lowercase so have to convert to uppercase.
-    expect(status.toUpperCase()).toBe(OEQ.Common.ItemStatus.LIVE);
+    expect(status.toUpperCase()).toBe<OEQ.Common.ItemStatus>('LIVE');
     expect(collectionId).toBe(collection);
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Another Refine Search control, this time for status.

Also needed to refactor the `OEQ.Common.ItemStatus` from an `enum` to essentially a string literal union. Triggered due to issues with Jest losing visibility of the enum post transpilation. To provide the full power I was after, rather than just a plain ol' string literal union, I brought in [runtypes](https://www.npmjs.com/package/runtypes).

Further auxilary items:

* A wording change for the configuration of whether to display this control - previously worded around non-live statuses;
* For IntelliJ project turned on sort imports by module - so that <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>o</kbd> gives a nice tidy up (which was done in some files); and
* Sorted the sub groups of the Search Page language strings, as it was become rather unwieldy.

![image](https://user-images.githubusercontent.com/43919233/89976969-557e1280-dcad-11ea-8d67-d558bbc26156.png) 
![image](https://user-images.githubusercontent.com/43919233/89976991-66c71f00-dcad-11ea-8837-b8c7199fe7bd.png)

#1306 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
