### PR TITLE
docs: add security policy for openEquella

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,21 @@
+# openEQUELLA Coordinated Vulnerability Process (CVP)
+
+If you discover any security concerns with openEQUELLA or associated technology please let the security group know by sending an email to <security@apereo.org>, or through your commercial service partner. Please do not raise security issues on the public tracker.
+
+Team members of the openEQUELLA Security Group will field the issues and open a Draft Advisory on GitHub as needed - <https://github.com/openequella/openEQUELLA/security/advisories>
+
+The openEQUELLA Security Group will then review the issue and help determine next steps. The openEQUELLA Security Group team member that originally fielded the issue will then respond to the originator with the recommended path forward.
+
+When deemed appropriate by the above review:
+
+- An embargo date is chosen (when will the issue become public)
+- A CVE issue is opened
+- A fix is created (ideally on a private fork)
+- On the embargo date:
+  - The fix is released
+  - The Advisory is published
+  - Notices are sent out on the [equella-users](https://groups.google.com/a/apereo.org/g/equella-users) and [equella-dev](https://groups.google.com/a/apereo.org/g/equella-dev) mail lists.
+
+The openEQUELLA Security Group is not responsible for fixing a given security issue. They are responsible to do the initial review, recommend a path forward, and guide the advisory to completion.
+
+The openEQUELLA Security Group generally focuses on the latest release for security issues, as of August 12th, 2020, the focus would be on security issues in openEQUELLA 2020.1.3.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [x] documentation is changed or added

##### Description of change

Adds security policy into .github/SECURITY.md, which GitHub automatically will associate with the security tab in the UI.
https://docs.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
