### PR TITLE
Support being able to set the theme for the paper / card elements

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/ThemePage.tsx
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
 import {
   Button,
   Card,
@@ -27,26 +26,27 @@ import {
   WithStyles,
   withStyles,
 } from "@material-ui/core";
-import ColorPickerComponent from "./ColorPickerComponent";
 import axios, { AxiosError } from "axios";
-import { API_BASE_URL } from "../config";
-import { languageStrings } from "../util/langstrings";
-import { commonString } from "../util/commonstrings";
+import * as React from "react";
+import { IThemeSettings } from ".";
 import {
   ErrorResponse,
   generateFromError,
   generateNewErrorID,
 } from "../api/errors";
+import SettingPageTemplate from "../components/SettingPageTemplate";
+import SettingsList from "../components/SettingsList";
+import SettingsListControl from "../components/SettingsListControl";
+import { API_BASE_URL } from "../config";
+import { routes } from "../mainui/routes";
 import {
   templateDefaults,
   templateError,
   TemplateUpdate,
 } from "../mainui/Template";
-import { IThemeSettings } from ".";
-import SettingPageTemplate from "../components/SettingPageTemplate";
-import SettingsListControl from "../components/SettingsListControl";
-import SettingsList from "../components/SettingsList";
-import { routes } from "../mainui/routes";
+import { commonString } from "../util/commonstrings";
+import { languageStrings } from "../util/langstrings";
+import ColorPickerComponent from "./ColorPickerComponent";
 
 declare const themeSettings: IThemeSettings;
 declare const logoURL: string;
@@ -73,6 +73,7 @@ interface ThemeColors {
   primary: string;
   secondary: string;
   background: string;
+  paper: string;
   menu: string;
   menuText: string;
   menuIcon: string;
@@ -100,6 +101,7 @@ class ThemePage extends React.Component<
     primary: themeSettings.primaryColor,
     secondary: themeSettings.secondaryColor,
     background: themeSettings.backgroundColor,
+    paper: themeSettings.paperColor,
     menu: themeSettings.menuItemColor,
     menuText: themeSettings.menuItemTextColor,
     menuIcon: themeSettings.menuItemIconColor,
@@ -125,6 +127,7 @@ class ThemePage extends React.Component<
         primary: "#186caf",
         secondary: "#ff9800",
         background: "#fafafa",
+        paper: "#ffffff",
         menuText: "#000000",
         menu: "#ffffff",
         menuIcon: "#000000",
@@ -141,6 +144,7 @@ class ThemePage extends React.Component<
       primary: themeSettings.primaryColor,
       secondary: themeSettings.secondaryColor,
       background: themeSettings.backgroundColor,
+      paper: themeSettings.paperColor,
       menu: themeSettings.menuItemColor,
       menuText: themeSettings.menuItemTextColor,
       menuIcon: themeSettings.menuItemIconColor,
@@ -175,10 +179,11 @@ class ThemePage extends React.Component<
   };
 
   submitTheme = () =>
-    axios.put(`${API_BASE_URL}/theme/settings/`, {
+    axios.put<IThemeSettings>(`${API_BASE_URL}/theme/settings/`, {
       primaryColor: this.state.primary,
       secondaryColor: this.state.secondary,
       backgroundColor: this.state.background,
+      paperColor: this.state.paper,
       menuItemColor: this.state.menu,
       menuItemIconColor: this.state.menuIcon,
       menuItemTextColor: this.state.menuText,
@@ -316,6 +321,11 @@ class ThemePage extends React.Component<
             <SettingsListControl
               primaryText={strings.colourschemesettings.backgroundcolour}
               control={this.colorPicker("background")}
+              divider
+            />
+            <SettingsListControl
+              primaryText={strings.colourschemesettings.paperColor}
+              control={this.colorPicker("paper")}
               divider
             />
             <SettingsListControl

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/theme/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/theme/index.ts
@@ -22,6 +22,7 @@ export interface IThemeSettings {
   primaryColor: string;
   secondaryColor: string;
   backgroundColor: string;
+  paperColor: string;
   menuItemColor: string;
   menuItemTextColor: string;
   menuItemIconColor: string;
@@ -48,6 +49,7 @@ const standardThemeSettings: ThemeOptions = {
     },
     background: {
       default: themeSettings.backgroundColor,
+      paper: themeSettings.paperColor,
     },
     text: {
       primary: themeSettings.primaryTextColor,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -251,6 +251,7 @@ export const languageStrings = {
       primarycolour: "Primary Colour",
       menubackgroundcolour: "Menu Background Colour",
       backgroundcolour: "Background Colour",
+      paperColor: "Paper Colour",
       secondarycolour: "Secondary Colour",
       sidebartextcolour: "Sidebar Text Colour",
       primarytextcolour: "Primary Text Colour",

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1007,11 +1007,12 @@ div.error-receipt ul li {
 Generic layout
 *****************************************************************************/
 
-.area {
-  background: white;
+div.area {
+  @include boxShadow;
+  background: $paperColor;
   padding: 25px 33px 33px;
+  border-radius: 4px;
   border: none;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
 }
 
 .area .indent {
@@ -1113,7 +1114,7 @@ Generic layout
 
 .area h3 {
   @include typography-headline-6;
-  color: #444444;
+  color: $primaryTextColor;
   word-wrap: break-word;
   padding-top: 8px;
 }
@@ -1127,7 +1128,7 @@ Generic layout
 
 .area h2 {
   @include typography-headline-4;
-  color: #444444;
+  color: $primaryTextColor;
 }
 
 .button-strip {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/newuitheme/impl/NewUITheme.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/newuitheme/impl/NewUITheme.java
@@ -26,6 +26,7 @@ public class NewUITheme {
   private String primaryColor = "#186caf";
   private String secondaryColor = "#ff9800";
   private String backgroundColor = "#fafafa";
+  private String paperColor = "#ffffff";
   private String menuItemColor = "#ffffff";
   private String menuItemIconColor = "#000000";
   private String menuItemTextColor = "#000000";
@@ -105,15 +106,22 @@ public class NewUITheme {
     this.menuTextColor = menuTextColor;
   }
 
+  public String getPaperColor() {
+    return paperColor;
+  }
+
+  public void setPaperColor(String paperColor) {
+    this.paperColor = paperColor;
+  }
+
   public String toSassVars() {
     ObjectMapper objectMapper = new ObjectMapper();
     Map<String, ?> themeVars = objectMapper.convertValue(this, Map.class);
     StringBuilder sassTheme = new StringBuilder();
 
     themeVars.forEach(
-        (key, value) -> {
-          sassTheme.append("$" + key + " : " + value + ";\r\n");
-        });
+        (key, value) ->
+            sassTheme.append("$").append(key).append(" : ").append(value).append(";\r\n"));
 
     return sassTheme.toString();
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes
- [x] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

I noticed it was not possible to properly setup a dark theme as the cards were fixed at white. So this change supports being able to theme the colour of the cards, as well as some minor tweaks to the look of EBP cards.

(We may want to cherry-pick the EBP commit 45f43de back to `develop` with the other EBP updates.)

![image](https://user-images.githubusercontent.com/43919233/90195577-21b9fe80-de0d-11ea-87a2-e77974f83df2.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
