### PR TITLE
Add the support of whether to search attachments to Search2 API

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -46,7 +46,10 @@ class SearchResource {
   )
   def searchItems(@BeanParam params: SearchParam): Response = {
     val searchResults: FreetextSearchResults[FreetextResult] =
-      LegacyGuice.freeTextService.search(createSearch(params), params.start, params.length)
+      LegacyGuice.freeTextService.search(createSearch(params),
+                                         params.start,
+                                         params.length,
+                                         params.searchAttachments)
     val freetextResults         = searchResults.getSearchResults.asScala.toList
     val itemIds                 = freetextResults.map(_.getItemIdKey)
     val serializer              = createSerializer(itemIds)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -52,6 +52,10 @@ class SearchParam {
   @QueryParam("reverseOrder")
   var reverseOrder: Boolean = _
 
+  @ApiParam("Whether to search attachments or not")
+  @QueryParam("searchAttachments")
+  var searchAttachments: Boolean = _
+
   @ApiParam(
     "An advanced search UUID. If a value is supplied, the collections in the advanced search will be used and the collections parameter will be ignored.")
   @QueryParam("advancedSearch")

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -53,6 +53,7 @@ class SearchParam {
   var reverseOrder: Boolean = _
 
   @ApiParam("Whether to search attachments or not")
+  @DefaultValue("true")
   @QueryParam("searchAttachments")
   var searchAttachments: Boolean = _
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/FreeTextService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/FreeTextService.java
@@ -43,6 +43,18 @@ public interface FreeTextService {
   <T extends FreetextResult> FreetextSearchResults<T> search(
       Search searchreq, int nStart, int nCount);
 
+  /**
+   * Another search method which allows users to specify if they want to search attachments.
+   *
+   * @param searchReq An search request
+   * @param start The first record of a search result
+   * @param count The number of records of a search result
+   * @param searchAttachments Whether to search attachments
+   * @return An instance of SearchResults
+   */
+  <T extends FreetextResult> FreetextSearchResults<T> search(
+      Search searchReq, int start, int count, boolean searchAttachments);
+
   SearchResults<ItemIdKey> searchIds(Search searchreq, int nStart, int nCount);
 
   LongSet searchIdsBitSet(Search searchreq);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/FreeTextService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/FreeTextService.java
@@ -35,22 +35,22 @@ public interface FreeTextService {
 
   /**
    * @param <T>
-   * @param searchreq
-   * @param nStart
-   * @param nCount Use -1 for all
+   * @param searchReq
+   * @param start
+   * @param count Use -1 for all
    * @return
    */
   <T extends FreetextResult> FreetextSearchResults<T> search(
-      Search searchreq, int nStart, int nCount);
+      Search searchReq, int start, int count);
 
   /**
    * Another search method which allows users to specify if they want to search attachments.
    *
-   * @param searchReq An search request
-   * @param start The first record of a search result
-   * @param count The number of records of a search result
-   * @param searchAttachments Whether to search attachments
-   * @return An instance of SearchResults
+   * @param searchReq A search request.
+   * @param start The first record of a search result.
+   * @param count The maximum number of results requested, or -1 for all.
+   * @param searchAttachments Whether to search attachments.
+   * @return Search results matching the specified criteria, with a maximum length of count.
    */
   <T extends FreetextResult> FreetextSearchResults<T> search(
       Search searchReq, int start, int count, boolean searchAttachments);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/impl/FreeTextServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/impl/FreeTextServiceImpl.java
@@ -264,6 +264,13 @@ public class FreeTextServiceImpl
   }
 
   @Override
+  public <T extends FreetextResult> FreetextSearchResults<T> search(
+      Search searchReq, int start, int count, boolean searchAttachments) {
+    SearchResults<T> fTextResults = indexer.search(searchReq, start, count, searchAttachments);
+    return new StdFreetextResults<T>(itemService, fTextResults, searchReq);
+  }
+
+  @Override
   public SearchResults<ItemIdKey> searchIds(Search searchreq, int nStart, int nCount) {
     SearchResults<FreetextResult> results = indexer.search(searchreq, nStart, nCount);
     return new ItemIdKeySearchResults(

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/impl/FreeTextServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/service/impl/FreeTextServiceImpl.java
@@ -258,16 +258,16 @@ public class FreeTextServiceImpl
 
   @Override
   public <T extends FreetextResult> FreetextSearchResults<T> search(
-      Search searchreq, int nStart, int nCount) {
-    SearchResults<T> fTextResults = indexer.search(searchreq, nStart, nCount);
-    return new StdFreetextResults<T>(itemService, fTextResults, searchreq);
+      Search searchReq, int start, int count) {
+    SearchResults<T> results = indexer.search(searchReq, start, count);
+    return new StdFreetextResults<T>(itemService, results, searchReq);
   }
 
   @Override
   public <T extends FreetextResult> FreetextSearchResults<T> search(
       Search searchReq, int start, int count, boolean searchAttachments) {
-    SearchResults<T> fTextResults = indexer.search(searchReq, start, count, searchAttachments);
-    return new StdFreetextResults<T>(itemService, fTextResults, searchReq);
+    SearchResults<T> results = indexer.search(searchReq, start, count, searchAttachments);
+    return new StdFreetextResults<T>(itemService, results, searchReq);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/FreetextIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/FreetextIndex.java
@@ -59,6 +59,9 @@ public interface FreetextIndex {
    */
   <T extends FreetextResult> SearchResults<T> search(Search searchReq, int start, int count);
 
+  <T extends FreetextResult> SearchResults<T> search(
+      Search searchReq, int start, int count, boolean searchAttachments);
+
   LongSet searchBitSet(Search searchReq);
 
   int count(Search searchReq);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/FreetextIndexImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/FreetextIndexImpl.java
@@ -153,15 +153,19 @@ public class FreetextIndexImpl
     return userPrefs.isSearchAttachment();
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public <T extends FreetextResult> SearchResults<T> search(
       Search searchReq, int start, int count) {
+    return search(searchReq, start, count, isSearchAttachment());
+  }
 
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T extends FreetextResult> SearchResults<T> search(
+      Search searchReq, int start, int count, boolean searchAttachments) {
     try {
       return (SearchResults<T>)
-          getIndexer(searchReq.getSearchType())
-              .search(searchReq, start, count, isSearchAttachment());
+          getIndexer(searchReq.getSearchType()).search(searchReq, start, count, searchAttachments);
     } catch (SearchingException ex) {
       if (!ex.isLogged()) {
         LOGGER.error(ex);

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -8,6 +8,7 @@ import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.codehaus.jackson.JsonNode;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class Search2ApiTest extends AbstractRestApiTest {
@@ -116,6 +117,27 @@ public class Search2ApiTest extends AbstractRestApiTest {
   @Test(description = "Search by a invalid date format")
   public void invalidDateSearch() throws IOException {
     doSearch(400, new NameValuePair("modifiedAfter", "2020/05/05"));
+  }
+
+  @DataProvider(name = "searchAttachmentsData")
+  public static Object[][] searchAttachmentsData() {
+    return new Object[][] {
+      // Four item should be returned if searching attachments is enabled or otherwise return 3
+      // items.
+      {true, 4}, {false, 3}
+    };
+  }
+
+  @Test(
+      description = "Include or exclude attachments in a search",
+      dataProvider = "searchAttachmentsData")
+  public void notSearchAttachments(boolean searchAttachment, int expectNumber) throws IOException {
+    JsonNode result =
+        doSearch(
+            200,
+            new NameValuePair("query", "size"),
+            new NameValuePair("searchAttachments", Boolean.toString(searchAttachment)));
+    assertEquals(result.get("available").asInt(), expectNumber);
   }
 
   private JsonNode doSearch(int expectedCode, NameValuePair... queryVals) throws IOException {


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR includes back-end changes for the feature of whether to search attachments or not. As we don't want to use `User Preference` to check if the option of searching attachments is enabled, added a new search param which represents the option, and overloaded method  `search` to accept a boolean.