### PR TITLE
[WIP] refactor: replace any types with more specific types

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/api/bridge.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/api/bridge.ts
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import { AclEditorProps } from "./acleditor";
-import { TemplateProps } from "tsrc/mainui/Template";
+import type { ComponentType } from "react";
+import type { AclEditorProps } from "./acleditor";
+import type { TemplateProps } from "tsrc/mainui/Template";
 
-interface GenericPageProps {
+export interface GenericPageProps {
   updateTemplate: (update: (template: TemplateProps) => TemplateProps) => void;
 }
 
@@ -28,7 +28,7 @@ interface SettingsPageProps extends GenericPageProps {
 }
 
 export interface Bridge {
-  AclEditor: React.ComponentType<AclEditorProps>;
-  SettingsPage: React.ComponentType<SettingsPageProps>;
-  SearchPage: React.ComponentType<GenericPageProps>;
+  AclEditor: ComponentType<AclEditorProps>;
+  SettingsPage: ComponentType<SettingsPageProps>;
+  SearchPage: ComponentType<GenericPageProps>;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/cloudcontrol/index.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/cloudcontrol/index.ts
@@ -76,6 +76,7 @@ interface CommandsPromise {
 }
 
 interface Registration {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mount: (api: ControlApi<any>) => void;
   unmount: (removed: Element) => void;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -30,7 +30,7 @@ import { Template, TemplateProps, TemplateUpdate } from "./Template";
 import { ThemeProvider } from "@material-ui/core";
 import { Provider } from "react-redux";
 import store from "../store";
-import { routes, OEQRoute, OEQRouteComponentProps } from "./routes";
+import { routes, Routes, OEQRouteComponentProps } from "./routes";
 import { shallowEqual } from "shallow-equal-object";
 import { startHeartbeat } from "../util/heartbeat";
 import { NavAwayDialog, defaultNavMessage } from "./PreventNavigation";
@@ -122,9 +122,11 @@ function IndexPage() {
       return shallowEqual(edited, tp) ? tp : edited;
     });
   }, []);
-  const oeqRoutes: { [key: string]: OEQRoute } = routes;
+  const oeqRoutes: Routes = routes;
 
-  function mkRouteProps(p: RouteComponentProps<any>): OEQRouteComponentProps {
+  function mkRouteProps<T>(
+    p: RouteComponentProps<T>
+  ): OEQRouteComponentProps<T> {
     return {
       ...p,
       updateTemplate,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -18,10 +18,10 @@
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
 import { LocationDescriptor } from "history";
-import { TemplateUpdate } from "./Template";
+import { TemplateUpdate, TemplateUpdateProps } from "./Template";
 import ThemePage from "../theme/ThemePage";
 import CloudProviderListPage from "../cloudprovider/CloudProviderListPage";
-import { Bridge } from "../api/bridge";
+import { Bridge, GenericPageProps } from "../api/bridge";
 import SearchPageSettings from "../settings/Search/SearchPageSettings";
 import SettingsPage from "../settings/SettingsPage";
 import SearchFilterPage from "../settings/Search/searchfilter/SearchFilterSettingsPage";
@@ -31,24 +31,30 @@ import FacetedSearchSettingsPage from "../settings/Search/facetedsearch/FacetedS
 
 declare const bridge: Bridge;
 
-export interface OEQRouteComponentProps<T = any>
-  extends RouteComponentProps<T> {
+export interface OEQRouteComponentProps<T> extends RouteComponentProps<T> {
   updateTemplate(edit: TemplateUpdate): void;
   redirect(to: LocationDescriptor): void;
   setPreventNavigation(b: boolean): void;
   refreshUser(): void;
 }
 
-export interface OEQRoute {
+type To = (uuid: string, version: number) => string;
+
+export interface OEQRoute<T> {
   component?:
-    | React.ComponentType<OEQRouteComponentProps<any>>
-    | React.ComponentType<any>;
-  render?: (props: OEQRouteComponentProps<any>) => React.ReactNode;
+    | React.ComponentType<OEQRouteComponentProps<T>>
+    | React.ComponentType<T>;
+  render?: (props: OEQRouteComponentProps<T>) => React.ReactNode;
   path?: string;
   exact?: boolean;
   sensitive?: boolean;
   strict?: boolean;
-  to?: any;
+  to?: string | To;
+}
+
+export interface Routes {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [route: string]: OEQRoute<any>;
 }
 
 export const routes = {
@@ -59,23 +65,31 @@ export const routes = {
   },
   Search: {
     path: "/page/search",
-    render: (p: OEQRouteComponentProps<any>) => <bridge.SearchPage {...p} />,
+    render: (p: OEQRouteComponentProps<GenericPageProps>) => (
+      <bridge.SearchPage {...p} />
+    ),
   },
   SearchSettings: {
     path: "/page/searchsettings",
-    render: (p: OEQRouteComponentProps<any>) => <SearchPageSettings {...p} />,
+    render: (p: OEQRouteComponentProps<TemplateUpdateProps>) => (
+      <SearchPageSettings {...p} />
+    ),
   },
   SearchFilterSettings: {
     path: "/page/searchfiltersettings",
-    render: (p: OEQRouteComponentProps<any>) => <SearchFilterPage {...p} />,
+    render: (p: OEQRouteComponentProps<TemplateUpdateProps>) => (
+      <SearchFilterPage {...p} />
+    ),
   },
   ContentIndexSettings: {
     path: "/page/contentindexsettings",
-    render: (p: OEQRouteComponentProps<any>) => <ContentIndexSettings {...p} />,
+    render: (p: OEQRouteComponentProps<TemplateUpdateProps>) => (
+      <ContentIndexSettings {...p} />
+    ),
   },
   FacetedSearchSetting: {
     path: "/page/facetedsearchsettings",
-    render: (p: OEQRouteComponentProps<any>) => (
+    render: (p: OEQRouteComponentProps<TemplateUpdateProps>) => (
       <FacetedSearchSettingsPage {...p} />
     ),
   },

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
@@ -240,7 +240,7 @@ const SearchFilterPage = ({ updateTemplate }: TemplateUpdateProps) => {
       : Promise.resolve()
     )
       .then(
-        (): Promise<any> =>
+        (): Promise<number | void> =>
           changedMimeTypeFilters.length
             ? batchUpdateOrAdd(changedMimeTypeFilters)
                 .then((messages) => errorMessages.push(...messages))
@@ -248,7 +248,7 @@ const SearchFilterPage = ({ updateTemplate }: TemplateUpdateProps) => {
             : Promise.resolve()
       )
       .then(
-        (): Promise<any> =>
+        (): Promise<number | void> =>
           // Filters stored in 'deletedMimeTypeFilters' always have an ID.
           deletedMimeTypeFilters.length
             ? batchDelete(deletedMimeTypeFilters.map(idExtractor))

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -17,7 +17,7 @@
  */
 import { sprintf } from "sprintf-js";
 
-declare let bundle: any;
+declare let bundle: { [prefix: string]: string };
 
 export interface Sizes {
   zero: string;

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
             "error",
             "interface"
           ],
+          "@typescript-eslint/no-explicit-any": "error",
           "@typescript-eslint/no-inferrable-types": "error",
           "@typescript-eslint/no-non-null-assertion": "error",
           "@typescript-eslint/no-unnecessary-type-assertion": "error",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] the [contributor license agreement][] is signed
- [ ] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

> all the convenience of `any` comes at the cost of losing type safety. Type safety is one of the main motivations for using TypeScript and you should try to avoid using any when not necessary.

https://www.typescriptlang.org/docs/handbook/basic-types.html#any

This works to replace usage of `any` with more specific types.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
