### PR TITLE
Search attachment Selector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchAttachmentsSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchAttachmentsSelector.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { action } from "@storybook/addon-actions";
+import { SearchAttachmentsSelector } from "../../tsrc/search/components/SearchAttachmentsSelector";
+
+export default {
+  title: "Search/SearchAttachmentsSelector",
+  component: SearchAttachmentsSelector,
+};
+
+const commonParams = {
+  onChange: action("onChange"),
+};
+
+export const yesSelected = () => (
+  <SearchAttachmentsSelector value {...commonParams} />
+);
+
+export const noSelected = () => (
+  <SearchAttachmentsSelector value={false} {...commonParams} />
+);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -154,6 +154,7 @@ const getRefineSearchComponent = (
 
 describe("Refine search by searching attachments", () => {
   let page: RenderResult;
+
   beforeEach(async () => {
     page = await renderSearchPage();
   });
@@ -166,10 +167,7 @@ describe("Refine search by searching attachments", () => {
     getRefineSearchComponent(container, "SearchAttachmentsSelector");
   const changeOption = (selector: HTMLElement, option: string) =>
     fireEvent.click(getByText(selector, option));
-  const {
-    yes: yesLabel,
-    no: noLabel,
-  } = languageStrings.searchpage.searchAttachmentsSelector;
+  const { yes: yesLabel, no: noLabel } = languageStrings.common.action;
 
   it("Should default to searching attachments", async () => {
     expect(mockSearch).toHaveBeenLastCalledWith(defaultSearchPageOptions);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -152,6 +152,45 @@ const getRefineSearchComponent = (
   return e as HTMLElement;
 };
 
+describe("Refine search by searching attachments", () => {
+  let page: RenderResult;
+  beforeEach(async () => {
+    page = await renderSearchPage();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const getSearchAttachmentsSelector = (container: Element): HTMLElement =>
+    getRefineSearchComponent(container, "SearchAttachmentsSelector");
+  const changeOption = (selector: HTMLElement, option: string) =>
+    fireEvent.click(getByText(selector, option));
+  const {
+    yes: yesLabel,
+    no: noLabel,
+  } = languageStrings.searchpage.searchAttachmentsSelector;
+
+  it("Should default to searching attachments", async () => {
+    expect(mockSearch).toHaveBeenLastCalledWith(defaultSearchPageOptions);
+  });
+
+  it("Should not search attachments if No is selected", async () => {
+    changeOption(getSearchAttachmentsSelector(page.container), noLabel);
+    await waitForSearch();
+    expect(mockSearch).toHaveBeenLastCalledWith({
+      ...defaultSearchPageOptions,
+      searchAttachments: false,
+    });
+  });
+
+  it("Should search attachments if Yes is selected", async () => {
+    changeOption(getSearchAttachmentsSelector(page.container), yesLabel);
+    await waitForSearch();
+    expect(mockSearch).toHaveBeenLastCalledWith(defaultSearchPageOptions);
+  });
+});
+
 describe("Refine search by status", () => {
   const {
     live: liveButtonLabel,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -47,6 +47,7 @@ export const defaultSearchOptions: SearchOptions = {
   sortOrder: undefined,
   rawMode: false,
   status: liveStatuses,
+  searchAttachments: true,
 };
 
 export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
@@ -84,6 +85,7 @@ export const searchItems = ({
   lastModifiedDateRange,
   owner,
   status = liveStatuses,
+  searchAttachments,
 }: SearchOptions): Promise<
   OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
 > => {
@@ -99,6 +101,7 @@ export const searchItems = ({
     modifiedAfter: getISODateString(lastModifiedDateRange?.start),
     modifiedBefore: getISODateString(lastModifiedDateRange?.end),
     owner: owner?.id,
+    searchAttachments: searchAttachments,
   };
   return OEQ.Search.search(API_BASE_URL, searchParams);
 };
@@ -144,4 +147,8 @@ export interface SearchOptions {
    * Filter search results to only include items with the specified statuses.
    */
   status?: OEQ.Common.ItemStatus[];
+  /**
+   * Whether to search attachments or not.
+   */
+  searchAttachments?: boolean;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -42,6 +42,7 @@ import {
   RefinePanelControl,
   RefineSearchPanel,
 } from "./components/RefineSearchPanel";
+import { SearchAttachmentsSelector } from "./components/SearchAttachmentsSelector";
 import { SearchResultList } from "./components/SearchResultList";
 import { CollectionSelector } from "./components/CollectionSelector";
 import { Collection } from "../modules/CollectionsModule";
@@ -207,6 +208,12 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       status: [...status],
     });
 
+  const handleSearchAttachmentsChange = (searchAttachments: boolean) => {
+    setSearchPageOptions({
+      ...searchPageOptions,
+      searchAttachments: searchAttachments,
+    });
+  };
   const refinePanelControls: RefinePanelControl[] = [
     {
       idSuffix: "CollectionSelector",
@@ -256,6 +263,17 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         />
       ),
       disabled: !searchSettings?.searchingShowNonLiveCheckbox ?? true,
+    },
+    {
+      idSuffix: "SearchAttachmentsSelector",
+      title: searchStrings.searchAttachmentsSelector.title,
+      component: (
+        <SearchAttachmentsSelector
+          value={searchPageOptions.searchAttachments}
+          onChange={handleSearchAttachmentsChange}
+        />
+      ),
+      disabled: false,
     },
   ];
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
@@ -22,7 +22,6 @@ import { languageStrings } from "../../util/langstrings";
 interface SearchAttachmentsSelectorProps {
   /**
    * A boolean value indicating whether 'yes' or 'no' is selected.
-   * True if 'yes' is selected.
    */
   value?: boolean;
   /**
@@ -31,6 +30,7 @@ interface SearchAttachmentsSelectorProps {
    */
   onChange: (value: boolean) => void;
 }
+
 export const SearchAttachmentsSelector = ({
   value,
   onChange,
@@ -39,10 +39,10 @@ export const SearchAttachmentsSelector = ({
   return (
     <ButtonGroup color="secondary">
       <Button variant={variant(value)} onClick={() => onChange(true)}>
-        {languageStrings.searchpage.searchAttachmentsSelector.yes}
+        {languageStrings.common.action.yes}
       </Button>
       <Button variant={variant(!value)} onClick={() => onChange(false)}>
-        {languageStrings.searchpage.searchAttachmentsSelector.no}
+        {languageStrings.common.action.no}
       </Button>
     </ButtonGroup>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
@@ -1,0 +1,49 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, ButtonGroup } from "@material-ui/core";
+import * as React from "react";
+import { languageStrings } from "../../util/langstrings";
+
+interface SearchAttachmentsSelectorProps {
+  /**
+   * A boolean value indicating whether 'yes' or 'no' is selected.
+   * True if 'yes' is selected.
+   */
+  value?: boolean;
+  /**
+   * Fired when a different option is selected.
+   * @param value A boolean representing the selected option.
+   */
+  onChange: (value: boolean) => void;
+}
+export const SearchAttachmentsSelector = ({
+  value,
+  onChange,
+}: SearchAttachmentsSelectorProps) => {
+  const variant = (option?: boolean) => (option ? "contained" : "outlined");
+  return (
+    <ButtonGroup color="secondary">
+      <Button variant={variant(value)} onClick={() => onChange(true)}>
+        {languageStrings.searchpage.searchAttachmentsSelector.yes}
+      </Button>
+      <Button variant={variant(!value)} onClick={() => onChange(false)}>
+        {languageStrings.searchpage.searchAttachmentsSelector.no}
+      </Button>
+    </ButtonGroup>
+  );
+};

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
@@ -47,3 +47,5 @@ export const SearchAttachmentsSelector = ({
     </ButtonGroup>
   );
 };
+
+export default SearchAttachmentsSelector;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -299,6 +299,8 @@ export const languageStrings = {
       register: "Register",
       refresh: "Refresh",
       done: "Done",
+      yes: "Yes",
+      no: "No",
     },
     result: {
       success: "Saved successfully.",
@@ -367,8 +369,6 @@ export const languageStrings = {
     },
     searchAttachmentsSelector: {
       title: "Search attachments",
-      yes: "Yes",
-      no: "No",
     },
     searchresult: {
       attachments: "Attachments",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -365,6 +365,11 @@ export const languageStrings = {
     refineSearchPanel: {
       title: "Refine search",
     },
+    searchAttachmentsSelector: {
+      title: "Search attachments",
+      yes: "Yes",
+      no: "No",
+    },
     searchresult: {
       attachments: "Attachments",
       dateModified: "Modified",

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -59,6 +59,10 @@ export interface SearchParams {
    * single dynamic collection uuid.
    */
   dynaCollection?: string;
+  /**
+   * A flag indicating whether to search attachments or not.
+   */
+  searchAttachments?: boolean;
 }
 
 /**

--- a/oeq-ts-rest-api/test/search.test.ts
+++ b/oeq-ts-rest-api/test/search.test.ts
@@ -37,3 +37,24 @@ describe('Search for items', () => {
     ).rejects.toHaveProperty('status', 404);
   });
 });
+
+describe('Search for attachments', () => {
+  test.each([
+    ['include attachments', true, 4],
+    ['exclude attachments', false, 3],
+  ])(
+    'should be possible to %s in a search',
+    async (
+      _testName: string,
+      searchAttachments: boolean,
+      expectResultCount: number
+    ) => {
+      const searchParams: OEQ.Search.SearchParams = {
+        query: 'size',
+        searchAttachments: searchAttachments,
+      };
+      const searchResult = await OEQ.Search.search(TC.API_PATH, searchParams);
+      expect(searchResult.results).toHaveLength(expectResultCount);
+    }
+  );
+});


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

So here is another Refine Search control - Search attachment Selector. By default, the option of 'yes' is selected. And because there are no Search settings controlling this component's visibility, it's always visible. 

The structure of this component is almost same as `StatusSelector`, and so are its tests and stories. So we can create an abstract component called `TwoOptionsSelector` , but I am not sure how much value we will gain at this stage so I did not implement this.

![image](https://user-images.githubusercontent.com/47203811/90366125-55fe1b00-e0aa-11ea-9030-895969244edf.png)
