### PR TITLE
EBP: Add margin to the right of portlets

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1233,7 +1233,8 @@ div.rightPanel {
 
 //portlet IDs are formatted as pportlet_{uuid}, so we must wildcard the selector with ^
 div[id^="pportlet"] {
-  margin-right: 16px;
+  margin-left: 8px;
+  margin-right: 8px;
 }
 
 //scripted portlet

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1231,6 +1231,11 @@ div.rightPanel {
   color: $menuTextColor;
 }
 
+//portlet IDs are formatted as pportlet_{uuid}, so we must wildcard the selector with ^
+div[id^="pportlet"] {
+  margin-right: 16px;
+}
+
 //scripted portlet
 .load-action {
   .dropdown-toggle {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#1983  
Margins were off for side-by-side portlets- the leftmost portlet merged into the rightmost one. This simply adds a margin to the right of each portlet.

![image](https://user-images.githubusercontent.com/24543345/90455902-a329cd80-e13a-11ea-864e-e85a48d9e919.png)
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
