### PR TITLE
Feature/attachment search indicator

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/getSearchResult.js
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/getSearchResult.js
@@ -56,7 +56,7 @@ exports.getSearchResult = {
       ],
       thumbnail: "initial",
       displayFields: [],
-      keywordFoundInAttachment: true,
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/",

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/getSearchResult.js
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/getSearchResult.js
@@ -56,6 +56,7 @@ exports.getSearchResult = {
       ],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: true,
       links: {
         view:
           "http://localhost:8080/rest/items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/",
@@ -74,6 +75,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -92,6 +94,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/2534e329-e37e-4851-896e-51d8b39104c4/1/",
@@ -126,6 +129,7 @@ exports.getSearchResult = {
       ],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/925f5dd2-66eb-4b68-85be-93837af785d0/1/",
@@ -145,6 +149,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -164,6 +169,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -183,6 +189,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -202,6 +209,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -221,6 +229,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -240,6 +249,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -259,6 +269,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -278,6 +289,7 @@ exports.getSearchResult = {
       attachments: [],
       thumbnail: "initial",
       displayFields: [],
+      keywordFoundInAttachment: false,
       links: {
         view:
           "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
@@ -306,6 +318,7 @@ exports.getSearchResultsCustom = (numberOfResults) => ({
     attachments: [],
     thumbnail: "initial",
     displayFields: [],
+    keywordFoundInAttachment: false,
     links: {
       view:
         "http://localhost:8080/rest/items/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/searchresult_mock_data.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/searchresult_mock_data.ts
@@ -37,6 +37,7 @@ const basicSearchObj: OEQ.Search.SearchResultItem = {
     standardOpen: true,
     integrationOpen: true,
   },
+  keywordFoundInAttachment: false,
   links: {
     view:
       "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/",
@@ -78,6 +79,49 @@ const attachSearchObj: OEQ.Search.SearchResultItem = {
     standardOpen: true,
     integrationOpen: true,
   },
+  keywordFoundInAttachment: false,
+  links: {
+    view:
+      "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/",
+    self:
+      "http://localhost:8080/rest/api/item/72558c1d-8788-4515-86c8-b24a28cc451e/1/",
+  },
+};
+
+const keywordFoundInAttachmentObj: OEQ.Search.SearchResultItem = {
+  uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
+  version: 1,
+  name: "Little Larry",
+  description: "A description of a bird",
+  status: "live",
+  createdDate: new Date("2020-05-26T13:24:00.889+10:00"),
+  modifiedDate: new Date("2020-05-26T12:45:06.857+10:00"),
+  collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
+  commentCount: 0,
+  attachments: [
+    {
+      attachmentType: "file",
+      id: "78b8af7e-f0f5-4b5c-9f44-16f212583fe8",
+      description: "config.json",
+      preview: false,
+      mimeType: "image/png",
+      hasGeneratedThumb: true,
+      links: {
+        view:
+          "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/?attachment.uuid=78b8af7e-f0f5-4b5c-9f44-16f212583fe8",
+        thumbnail: "./thumb.jpg",
+      },
+    },
+  ],
+  thumbnail: "default",
+  displayFields: [],
+  displayOptions: {
+    attachmentType: "STRUCTURED",
+    disableThumbnail: false,
+    standardOpen: true,
+    integrationOpen: true,
+  },
+  keywordFoundInAttachment: true,
   links: {
     view:
       "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/",
@@ -136,6 +180,7 @@ const customMetaSearchObj: OEQ.Search.SearchResultItem = {
     standardOpen: true,
     integrationOpen: true,
   },
+  keywordFoundInAttachment: true,
   links: {
     view:
       "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/",
@@ -143,4 +188,9 @@ const customMetaSearchObj: OEQ.Search.SearchResultItem = {
       "http://localhost:8080/rest/api/item/72558c1d-8788-4515-86c8-b24a28cc451e/1/",
   },
 };
-export { basicSearchObj, attachSearchObj, customMetaSearchObj };
+export {
+  basicSearchObj,
+  attachSearchObj,
+  customMetaSearchObj,
+  keywordFoundInAttachmentObj,
+};

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import * as mockData from "../../__mocks__/searchresult_mock_data";
 import SearchResult from "../../tsrc/search/components/SearchResult";
-import { number, object, text } from "@storybook/addon-knobs";
+import { boolean, number, object, text } from "@storybook/addon-knobs";
 
 export default {
   title: "Search/SearchResult",
@@ -48,6 +48,10 @@ export const BasicSearchResultComponent = () => (
     collectionId={text("collection ID", mockData.basicSearchObj.collectionId)}
     commentCount={number("comment count", mockData.basicSearchObj.commentCount)}
     thumbnail={text("thumbnail", mockData.basicSearchObj.thumbnail)}
+    keywordFoundInAttachment={boolean(
+      "keywordFoundInAttachment",
+      mockData.basicSearchObj.keywordFoundInAttachment
+    )}
   />
 );
 
@@ -80,6 +84,10 @@ export const AttachmentSearchResultComponent = () => (
       mockData.attachSearchObj.commentCount
     )}
     thumbnail={text("thumbnail", mockData.attachSearchObj.thumbnail)}
+    keywordFoundInAttachment={boolean(
+      "keywordFoundInAttachment",
+      mockData.basicSearchObj.keywordFoundInAttachment
+    )}
   />
 );
 
@@ -118,5 +126,9 @@ export const CustomMetadataSearchResultComponent = () => (
       mockData.customMetaSearchObj.commentCount
     )}
     thumbnail={text("thumbnail", mockData.customMetaSearchObj.thumbnail)}
+    keywordFoundInAttachment={boolean(
+      "keywordFoundInAttachment",
+      mockData.basicSearchObj.keywordFoundInAttachment
+    )}
   />
 );

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -17,25 +17,25 @@
  */
 import { render, queryByTestId } from "@testing-library/react";
 import * as React from "react";
-import { getSearchResult } from "../../../../__mocks__/getSearchResult";
+import * as mockData from "../../../../__mocks__/searchresult_mock_data";
 import SearchResult from "../../../../tsrc/search/components/SearchResult";
+import * as OEQ from "@openequella/rest-api-client";
 
 import "@testing-library/jest-dom/extend-expect";
 import { BrowserRouter } from "react-router-dom";
 
 describe("<SearchResult/>", () => {
-  const renderSearchResult = (itemResult) => {
-    const item = itemResult;
+  const renderSearchResult = (itemResult: OEQ.Search.SearchResultItem) => {
     return render(
       //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error
       <BrowserRouter>
-        <SearchResult {...item} key={item.uuid} />
+        <SearchResult {...itemResult} key={itemResult.uuid} />
       </BrowserRouter>
     );
   };
 
   it("Should show indicator in Attachment panel if keyword was found inside attachment", () => {
-    const itemWithSearchTermFound = getSearchResult.results[0];
+    const itemWithSearchTermFound = mockData.keywordFoundInAttachmentObj;
     const { container } = renderSearchResult(itemWithSearchTermFound);
     expect(
       queryByTestId(container, "keywordFoundInAttachment")
@@ -43,7 +43,7 @@ describe("<SearchResult/>", () => {
   });
 
   it("Should not show indicator in Attachment panel if keyword was found inside attachment", () => {
-    const itemWithNoSearchTermFound = getSearchResult.results[1];
+    const itemWithNoSearchTermFound = mockData.attachSearchObj;
     const { container } = renderSearchResult(itemWithNoSearchTermFound);
     expect(
       queryByTestId(container, "keywordFoundInAttachment")

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, queryByTestId } from "@testing-library/react";
+import * as React from "react";
+import { getSearchResult } from "../../../../__mocks__/getSearchResult";
+import SearchResult from "../../../../tsrc/search/components/SearchResult";
+
+import "@testing-library/jest-dom/extend-expect";
+
+describe("<SearchResult/>", () => {
+  it("Should show indicator in Attachment panel if keyword was found inside attachment", () => {
+    const itemWithSearchTermFound = getSearchResult.results[0];
+    const { container } = render(
+      <SearchResult
+        {...itemWithSearchTermFound}
+        key={itemWithSearchTermFound.uuid}
+      />
+    );
+    expect(
+      queryByTestId(container, "keywordFoundInAttachment")
+    ).toBeInTheDocument();
+  });
+
+  it("Should not show indicator in Attachment panel if keyword was found inside attachment", () => {
+    const itemWithNoSearchTermFound = getSearchResult.results[1];
+    const { container } = render(
+      <SearchResult
+        {...itemWithNoSearchTermFound}
+        key={itemWithNoSearchTermFound.uuid}
+      />
+    );
+    expect(
+      queryByTestId(container, "keywordFoundInAttachment")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -21,16 +21,22 @@ import { getSearchResult } from "../../../../__mocks__/getSearchResult";
 import SearchResult from "../../../../tsrc/search/components/SearchResult";
 
 import "@testing-library/jest-dom/extend-expect";
+import { BrowserRouter } from "react-router-dom";
 
 describe("<SearchResult/>", () => {
+  const renderSearchResult = (itemResult) => {
+    const item = itemResult;
+    return render(
+      //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error
+      <BrowserRouter>
+        <SearchResult {...item} key={item.uuid} />
+      </BrowserRouter>
+    );
+  };
+
   it("Should show indicator in Attachment panel if keyword was found inside attachment", () => {
     const itemWithSearchTermFound = getSearchResult.results[0];
-    const { container } = render(
-      <SearchResult
-        {...itemWithSearchTermFound}
-        key={itemWithSearchTermFound.uuid}
-      />
-    );
+    const { container } = renderSearchResult(itemWithSearchTermFound);
     expect(
       queryByTestId(container, "keywordFoundInAttachment")
     ).toBeInTheDocument();
@@ -38,12 +44,7 @@ describe("<SearchResult/>", () => {
 
   it("Should not show indicator in Attachment panel if keyword was found inside attachment", () => {
     const itemWithNoSearchTermFound = getSearchResult.results[1];
-    const { container } = render(
-      <SearchResult
-        {...itemWithNoSearchTermFound}
-        key={itemWithNoSearchTermFound.uuid}
-      />
-    );
+    const { container } = renderSearchResult(itemWithNoSearchTermFound);
     expect(
       queryByTestId(container, "keywordFoundInAttachment")
     ).not.toBeInTheDocument();

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render, queryByTestId } from "@testing-library/react";
+import { render, queryByLabelText } from "@testing-library/react";
 import * as React from "react";
 import * as mockData from "../../../../__mocks__/searchresult_mock_data";
 import SearchResult from "../../../../tsrc/search/components/SearchResult";
@@ -27,26 +27,29 @@ import { BrowserRouter } from "react-router-dom";
 describe("<SearchResult/>", () => {
   const renderSearchResult = (itemResult: OEQ.Search.SearchResultItem) => {
     return render(
-      //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error
+      //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error  because of the <Link/> tag within SearchResult
       <BrowserRouter>
         <SearchResult {...itemResult} key={itemResult.uuid} />
       </BrowserRouter>
     );
   };
 
+  const keywordFoundInAttachmentLabel =
+    "Search term found in attachment content";
+
   it("Should show indicator in Attachment panel if keyword was found inside attachment", () => {
     const itemWithSearchTermFound = mockData.keywordFoundInAttachmentObj;
     const { container } = renderSearchResult(itemWithSearchTermFound);
     expect(
-      queryByTestId(container, "keywordFoundInAttachment")
+      queryByLabelText(container, keywordFoundInAttachmentLabel)
     ).toBeInTheDocument();
   });
 
-  it("Should not show indicator in Attachment panel if keyword was found inside attachment", () => {
+  it("Should not show indicator in Attachment panel if keyword was not found inside attachment", () => {
     const itemWithNoSearchTermFound = mockData.attachSearchObj;
     const { container } = renderSearchResult(itemWithNoSearchTermFound);
     expect(
-      queryByTestId(container, "keywordFoundInAttachment")
+      queryByLabelText(container, keywordFoundInAttachmentLabel)
     ).not.toBeInTheDocument();
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -74,9 +74,6 @@ const useStyles = makeStyles((theme: Theme) => {
       marginTop: theme.spacing(2),
       marginBottom: theme.spacing(2),
     },
-    attachmentIcon: {
-      marginRight: theme.spacing(2),
-    },
     attachmentBadge: {
       backgroundColor: theme.palette.background.paper,
       color: theme.palette.secondary.main,
@@ -188,11 +185,14 @@ export default function SearchResult({
                     vertical: "bottom",
                     horizontal: "right",
                   }}
+                  overlap="circle"
                   badgeContent={
                     keywordFoundInAttachment ? (
                       <Tooltip
-                        title="Search term found in attachment content"
-                        aria-label="Search term found in attachment content"
+                        title={searchResultStrings.keywordFoundInAttachment}
+                        aria-label={
+                          searchResultStrings.keywordFoundInAttachment
+                        }
                       >
                         <Search
                           fontSize="small"
@@ -201,7 +201,6 @@ export default function SearchResult({
                       </Tooltip>
                     ) : undefined
                   }
-                  overlap="circle"
                 >
                   <AttachFile />
                 </Badge>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -170,6 +170,28 @@ export default function SearchResult({
       }
     );
 
+    const attachFileBadge = (includeIndicator: boolean) => (
+      <Badge
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        overlap="circle"
+        badgeContent={
+          includeIndicator ? (
+            <Tooltip
+              title={searchResultStrings.keywordFoundInAttachment}
+              aria-label={searchResultStrings.keywordFoundInAttachment}
+            >
+              <Search fontSize="small" className={classes.attachmentBadge} />
+            </Tooltip>
+          ) : undefined
+        }
+      >
+        <AttachFile />
+      </Badge>
+    );
+
     if (attachmentsList.length > 0)
       return (
         <Accordion
@@ -179,33 +201,7 @@ export default function SearchResult({
         >
           <AccordionSummary expandIcon={<ExpandMore />}>
             <Grid container spacing={2} alignItems="center">
-              <Grid item>
-                <Badge
-                  anchorOrigin={{
-                    vertical: "bottom",
-                    horizontal: "right",
-                  }}
-                  overlap="circle"
-                  badgeContent={
-                    keywordFoundInAttachment ? (
-                      <Tooltip
-                        title={searchResultStrings.keywordFoundInAttachment}
-                        aria-label={
-                          searchResultStrings.keywordFoundInAttachment
-                        }
-                      >
-                        <Search
-                          fontSize="small"
-                          className={classes.attachmentBadge}
-                          data-testid="keywordFoundInAttachment"
-                        />
-                      </Tooltip>
-                    ) : undefined
-                  }
-                >
-                  <AttachFile />
-                </Badge>
-              </Grid>
+              <Grid item>{attachFileBadge(keywordFoundInAttachment)}</Grid>
               <Grid item>
                 <Typography>{searchResultStrings.attachments}</Typography>
               </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -197,6 +197,7 @@ export default function SearchResult({
                         <Search
                           fontSize="small"
                           className={classes.attachmentBadge}
+                          data-testid="keywordFoundInAttachment"
                         />
                       </Tooltip>
                     ) : undefined

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -17,6 +17,7 @@
  */
 import * as React from "react";
 import { SyntheticEvent } from "react";
+import Tooltip from "@material-ui/core/Tooltip";
 import { makeStyles } from "@material-ui/core/styles";
 import { languageStrings } from "../../util/langstrings";
 import ReactHtmlParser from "react-html-parser";
@@ -31,9 +32,16 @@ import {
   ListItemText,
   Theme,
   Typography,
+  Grid,
+  Badge,
 } from "@material-ui/core";
 import { Date as DateDisplay } from "../../components/Date";
-import { AttachFile, ExpandMore, InsertDriveFile } from "@material-ui/icons";
+import {
+  AttachFile,
+  ExpandMore,
+  InsertDriveFile,
+  Search,
+} from "@material-ui/icons";
 import * as OEQ from "@openequella/rest-api-client";
 import { Link } from "react-router-dom";
 import { routes } from "../../mainui/routes";
@@ -69,6 +77,11 @@ const useStyles = makeStyles((theme: Theme) => {
     attachmentIcon: {
       marginRight: theme.spacing(2),
     },
+    attachmentBadge: {
+      backgroundColor: theme.palette.background.paper,
+      color: theme.palette.secondary.main,
+      borderRadius: "50%",
+    },
   };
 });
 
@@ -82,6 +95,7 @@ export default function SearchResult({
   status,
   displayOptions,
   attachments,
+  keywordFoundInAttachment,
   links,
 }: OEQ.Search.SearchResultItem) {
   const classes = useStyles();
@@ -167,8 +181,35 @@ export default function SearchResult({
           onClick={(event) => handleAttachmentPanelClick(event)}
         >
           <AccordionSummary expandIcon={<ExpandMore />}>
-            <AttachFile className={classes.attachmentIcon} />
-            <Typography>{searchResultStrings.attachments}</Typography>
+            <Grid container spacing={2} alignItems="center">
+              <Grid item>
+                <Badge
+                  anchorOrigin={{
+                    vertical: "bottom",
+                    horizontal: "right",
+                  }}
+                  badgeContent={
+                    keywordFoundInAttachment ? (
+                      <Tooltip
+                        title="Search term found in attachment content"
+                        aria-label="Search term found in attachment content"
+                      >
+                        <Search
+                          fontSize="small"
+                          className={classes.attachmentBadge}
+                        />
+                      </Tooltip>
+                    ) : undefined
+                  }
+                  overlap="circle"
+                >
+                  <AttachFile />
+                </Badge>
+              </Grid>
+              <Grid item>
+                <Typography>{searchResultStrings.attachments}</Typography>
+              </Grid>
+            </Grid>
           </AccordionSummary>
           <AccordionDetails>
             <List component="div" disablePadding>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -368,7 +368,7 @@ export const languageStrings = {
     searchresult: {
       attachments: "Attachments",
       dateModified: "Modified",
-      keywordFoundInAttachment: "",
+      keywordFoundInAttachment: "Search term found in attachment content",
     },
     statusSelector: {
       all: "All",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -368,6 +368,7 @@ export const languageStrings = {
     searchresult: {
       attachments: "Attachments",
       dateModified: "Modified",
+      keywordFoundInAttachment: "",
     },
     statusSelector: {
       all: "All",

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -201,6 +201,10 @@ export interface SearchResultItem {
    */
   displayOptions?: DisplayOptions;
   /**
+   * Indicates if a search term was found inside attachment content
+   */
+  keywordFoundInAttachment: boolean;
+  /**
    * Links to an item.
    */
   links: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
This feature displays a search icon in the attachment panel if the Search query was found in attachment content. 
A tooltip is also displayed to provide more explanation to the user

![attachment indicator](https://user-images.githubusercontent.com/4625498/90467490-ae3f2680-e157-11ea-88db-328cc0a014e5.gif)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
