### PR TITLE
Fix support for CsvList params in SearchFacets

### DIFF
--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -48,7 +48,7 @@ export const GET = <T>(
   axios
     .get(path, {
       params: queryParams,
-      paramsSerializer: (params) => stringify(params, { arrayFormat: 'comma' }),
+      paramsSerializer: (params) => stringify(params),
     })
     .then(({ data: rawData }: AxiosResponse<unknown>) => {
       const data = transformer ? transformer(rawData) : rawData;

--- a/oeq-ts-rest-api/src/SearchFacets.ts
+++ b/oeq-ts-rest-api/src/SearchFacets.ts
@@ -18,9 +18,10 @@
 /**
  * Params to pass to a call for search facets.
  */
-import { is } from 'typescript-is/index';
+import { is } from 'typescript-is';
 import { GET } from './AxiosInstance';
 import { UuidString } from './Common';
+import { asCsvList } from './Utils';
 
 export interface SearchFacetsParams {
   /**
@@ -102,10 +103,14 @@ const SEARCH_FACETS_API_PATH = '/search/facet';
 
 export const searchFacets = (
   apiBasePath: string,
-  params?: SearchFacetsParams
+  params: SearchFacetsParams
 ): Promise<SearchFacetsResult> =>
   GET<SearchFacetsResult>(
     apiBasePath + SEARCH_FACETS_API_PATH,
     (data): data is SearchFacetsResult => is<SearchFacetsResult>(data),
-    params
+    {
+      ...params,
+      nodes: asCsvList<string>(params.nodes),
+      collections: asCsvList<string>(params.collections),
+    }
   );

--- a/oeq-ts-rest-api/src/Utils.ts
+++ b/oeq-ts-rest-api/src/Utils.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import { cloneDeep } from 'lodash';
+
 /**
  * Performs inplace conversion of specified fields with supplied converter.
  *
@@ -59,3 +60,12 @@ export const convertDateFields = <T>(input: unknown, fields: string[]): T => {
   );
   return inputClone;
 };
+
+/**
+ * openEQUELLA has a `CsvList` type which is used to receive an array of items in a single param
+ * comma delimited. This utility function assists with those cases.
+ *
+ * @param list the list of items to be stringified and comma delimited.
+ */
+export const asCsvList = <T>(list: T[] | undefined): string | undefined =>
+  list?.join(',');

--- a/oeq-ts-rest-api/test/Utils.test.ts
+++ b/oeq-ts-rest-api/test/Utils.test.ts
@@ -17,6 +17,7 @@
  */
 import * as OEQ from '../src';
 import { is } from 'typescript-is';
+import { asCsvList } from '../src/Utils';
 
 describe('Convert date fields', () => {
   interface StringDate {
@@ -66,4 +67,16 @@ describe('Convert date fields', () => {
     ]);
     expect(is<InvalidDate>(dates)).toBe(true);
   });
+});
+
+describe('Support for server CsvList params', () => {
+  it('with lists of strings', () =>
+    expect(
+      asCsvList<string>(['one', 'two', 'three'])
+    ).toEqual('one,two,three'));
+
+  it('with lists of numbers', () =>
+    expect(
+      asCsvList<number>([1, 2, 3])
+    ).toEqual('1,2,3'));
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

An incorrect assumption was made back in 861e4b1, and due to a missing test didn't realise this broke `searchItems`. So this PR reverts 861e4b1 and does it differently, as well as adding a test of `searchItems` for the missing coverage. (Although it looks like we could do with a fair bit more testing there.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
