### PR TITLE
Feature/front end search facets module

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchFacetsModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchFacetsModule.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { Facet } from "../../../tsrc/modules/FacetedSearchSettingsModule";
+import * as FacetedSearchSettingsModule from "../../../tsrc/modules/FacetedSearchSettingsModule";
+import {
+  Classification,
+  listClassifications,
+} from "../../../tsrc/modules/SearchFacetsModule";
+
+const CLASSIFICATION_SUBJECT: Facet = {
+  name: "Classification 1",
+  schemaNode: "/item/subject",
+  maxResults: 1,
+  orderIndex: 0,
+};
+const CLASSIFICATION_KEYWORD: Facet = {
+  name: "Classification 2",
+  schemaNode: "/item/keyword",
+  orderIndex: 1,
+};
+const CATEGORIES_SUBJECT: OEQ.SearchFacets.Facet[] = [
+  { term: "subject1", count: 10 },
+  { term: "subject2", count: 20 },
+  { term: "subject3", count: 30 },
+];
+const CATEGORIES_KEYWORD: OEQ.SearchFacets.Facet[] = [
+  { term: "keyword1", count: 101 },
+  { term: "keyword2", count: 202 },
+  { term: "keyword3", count: 303 },
+];
+
+jest
+  .spyOn(FacetedSearchSettingsModule, "getFacetsFromServer")
+  .mockResolvedValue([CLASSIFICATION_SUBJECT, CLASSIFICATION_KEYWORD]);
+
+jest.mock("@openequella/rest-api-client");
+const mockedSearchFacets = (OEQ.SearchFacets.searchFacets as jest.Mock<
+  Promise<OEQ.SearchFacets.SearchFacetsResult>
+>).mockImplementation(
+  (
+    _: string,
+    params?: OEQ.SearchFacets.SearchFacetsParams
+  ): Promise<OEQ.SearchFacets.SearchFacetsResult> => {
+    const mockData = new Map<string, OEQ.SearchFacets.Facet[]>([
+      [CLASSIFICATION_SUBJECT.schemaNode, CATEGORIES_SUBJECT],
+      [CLASSIFICATION_KEYWORD.schemaNode, CATEGORIES_KEYWORD],
+    ]);
+    if (!params?.nodes[0]) {
+      throw new Error("Issue with test data, no schema node provided!");
+    }
+    return Promise.resolve({
+      results: mockData.get(params.nodes[0]),
+    } as OEQ.SearchFacets.SearchFacetsResult);
+  }
+);
+
+describe("SearchFacetsModule", () => {
+  it("Listing classifications", async () => {
+    // Do a fully defined call to listClassifications
+    const queryString = "some query";
+    const collections = ["uuid1", "uuid2"];
+    const dateStart = "2020-01-01";
+    const dateEnd = "2020-02-02";
+    const ownerUuid = "uuidOwner";
+    const classifications = await listClassifications({
+      query: queryString,
+      rowsPerPage: 10, // n/a
+      currentPage: 1, // n/a
+      collections: collections.map((id) => ({
+        uuid: id,
+        name: `name of ${id}`,
+      })),
+      rawMode: false, // n/a
+      lastModifiedDateRange: {
+        start: new Date(dateStart),
+        end: new Date(dateEnd),
+      },
+      owner: {
+        id: ownerUuid,
+        username: "jest",
+        firstName: "Test",
+        lastName: "Owner",
+      },
+      status: OEQ.Common.ItemStatuses.alternatives.map((i) => i.value), // i.e. All statuses
+      sortOrder: undefined,
+    });
+
+    // Expect the correct data is generated
+    expect(classifications).toEqual([
+      {
+        name: CLASSIFICATION_SUBJECT.name,
+        maxDisplay: CLASSIFICATION_SUBJECT.maxResults,
+        categories: CATEGORIES_SUBJECT,
+        orderIndex: CLASSIFICATION_SUBJECT.orderIndex,
+      },
+      {
+        name: CLASSIFICATION_KEYWORD.name,
+        maxDisplay: CLASSIFICATION_KEYWORD.maxResults,
+        categories: CATEGORIES_KEYWORD,
+        orderIndex: CLASSIFICATION_KEYWORD.orderIndex,
+      },
+    ] as Classification[]);
+    // ... and that the SearchOptions are correctly converted
+    expect(mockedSearchFacets).toHaveBeenLastCalledWith("api", {
+      nodes: [CLASSIFICATION_KEYWORD.schemaNode],
+      q: queryString,
+      collections: collections,
+      modifiedAfter: dateStart,
+      modifiedBefore: dateEnd,
+      owner: ownerUuid,
+      showall: true,
+    } as OEQ.SearchFacets.SearchFacetsParams);
+  });
+});

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
@@ -1,0 +1,107 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { isEqual, memoize } from "lodash";
+import { API_BASE_URL } from "../config";
+import { getISODateString } from "../util/Date";
+import { getFacetsFromServer } from "./FacetedSearchSettingsModule";
+import { SearchOptions } from "./SearchModule";
+
+/**
+ * Represents a Classification and its generated categories ready for display.
+ */
+export interface Classification {
+  /**
+   * The name for this group of categories - typically one which has been configured on the system.
+   */
+  name: string;
+  /**
+   * The maximum number of categories which should be displayed - based on what was configured for
+   * this classification. If `undefined` then the system default number of categories should be
+   * displayed.
+   */
+  maxDisplay?: number;
+  /**
+   * The actual list of categories for this classification. This will be the full list returned
+   * from the server - as no paging is currently provided.
+   */
+  categories: OEQ.SearchFacets.Facet[];
+  /**
+   * The configured order in which this classification should be displayed.
+   */
+  orderIndex: number;
+}
+
+/**
+ * Helper function to convert the commonly used `SearchOptions` into the params we need to
+ * list facets. This is a memoized function, so that it can be used in an `Array.map()`
+ * with reasonable performance. (Important seeing it's also doing some data conversion.)
+ */
+const convertSearchOptions: (
+  options: SearchOptions
+) => OEQ.SearchFacets.SearchFacetsParams = memoize(
+  (options: SearchOptions): OEQ.SearchFacets.SearchFacetsParams => ({
+    nodes: [],
+    q: options.query,
+    collections: options.collections?.map((c) => c.uuid),
+    modifiedAfter: getISODateString(options.lastModifiedDateRange?.start),
+    modifiedBefore: getISODateString(options.lastModifiedDateRange?.end),
+    owner: options.owner?.id,
+    showall: isEqual(
+      options.status?.sort(),
+      OEQ.Common.ItemStatuses.alternatives.map((i) => i.value).sort()
+    ),
+  })
+);
+
+/**
+ * Provides a list of categories as defined and filtered by the `options`.
+ *
+ * @param options The control parameters for the generation of the categories
+ */
+export const listCategories = async (
+  options: OEQ.SearchFacets.SearchFacetsParams
+): Promise<OEQ.SearchFacets.Facet[]> =>
+  (await OEQ.SearchFacets.searchFacets(API_BASE_URL, options)).results;
+
+/**
+ * Uses the system's configured facets/classifications to generate a set of categories for
+ * each. Thereby, generating All the classifications and categories for the system based on
+ * configured facets.
+ *
+ * It is intended that this can be run alongside other search filters, and thereby provide
+ * matching categories.
+ *
+ * @param options The standard options used for searching, as these also filter the generated categories
+ */
+export const listClassifications = async (
+  options: SearchOptions
+): Promise<Classification[]> =>
+  Promise.all(
+    (await getFacetsFromServer()).map<Promise<Classification>>(
+      async (settings) => ({
+        name: settings.name,
+        maxDisplay: settings.maxResults,
+        orderIndex: settings.orderIndex,
+        categories: await listCategories({
+          ...convertSearchOptions(options),
+          nodes: [settings.schemaNode],
+        }),
+      })
+    )
+  );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

A new module to provide for easy consumption of the /search/facet endpoint. The main method the UI will use is  `listClassifications` which will both query the configured classifications, and then go about generating the categories for all of them.

This work, and the work @PenghaiZhang has been doing for the category selector component has also highlighted we have a bit of a naming issue. We have a `Facet` interface for dealing with the Classification configurations. Then here we have under the hood the real facets (categories) - `OEQ.SearchFacets.Facet`. After we get this full feature in, we'll need to go and rename the settings/configuration side of things.

#1306 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
