### PR TITLE
Feature/Facet Selector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { SearchPageClassification } from "../tsrc/search/SearchPage";
+import type { SearchPageClassification } from "../tsrc/search/components/FacetSelector";
 
 export const classifications: SearchPageClassification[] = [
   {

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SearchPageClassification } from "../tsrc/search/SearchPage";
+import type { SearchPageClassification } from "../tsrc/search/SearchPage";
 
 export const classifications: SearchPageClassification[] = [
   {

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
@@ -1,0 +1,79 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SearchPageClassification } from "../tsrc/search/SearchPage";
+
+export const classifications: SearchPageClassification[] = [
+  {
+    name: "Language",
+    categories: [
+      {
+        term: "scala",
+        count: 312,
+      },
+      {
+        term: "java",
+        count: 1212,
+      },
+      {
+        term: "python",
+        count: 222,
+      },
+      {
+        term: "php",
+        count: 612,
+      },
+      {
+        term: "c#",
+        count: 888,
+      },
+      {
+        term: "purescript",
+        count: 1,
+      },
+    ],
+    maxDisplay: 7,
+    orderIndex: 1,
+    showMore: false,
+  },
+  {
+    name: "City",
+    categories: [
+      {
+        term: "Hobart",
+        count: 111,
+      },
+      {
+        term: "Sydney",
+        count: 222,
+      },
+      {
+        term: "Adelaide",
+        count: 333,
+      },
+    ],
+    maxDisplay: 2,
+    orderIndex: 0,
+    showMore: true,
+  },
+  {
+    name: "Color",
+    categories: [],
+    orderIndex: 2,
+    showMore: false,
+  },
+];

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
@@ -42,7 +42,8 @@ export const classifications: SearchPageClassification[] = [
         count: 888,
       },
       {
-        term: "purescript",
+        term:
+          "purescript - the last version is xxxxxxxxx because maintenance is so hard!!!",
         count: 1,
       },
     ],

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/FacetSelector.mock.ts
@@ -19,6 +19,7 @@ import type { SearchPageClassification } from "../tsrc/search/components/FacetSe
 
 export const classifications: SearchPageClassification[] = [
   {
+    id: 766942,
     name: "Language",
     categories: [
       {
@@ -52,6 +53,7 @@ export const classifications: SearchPageClassification[] = [
     showMore: false,
   },
   {
+    id: 766943,
     name: "City",
     categories: [
       {
@@ -72,6 +74,7 @@ export const classifications: SearchPageClassification[] = [
     showMore: true,
   },
   {
+    id: 766944,
     name: "Color",
     categories: [],
     orderIndex: 2,

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { action } from "@storybook/addon-actions";
+import * as React from "react";
+import { FacetSelector } from "../../tsrc/search/components/FacetSelector";
+import * as FacetSelectorMock from "../../__mocks__/FacetSelector.mock";
+
+export default {
+  title: "Search/FacetSelector",
+  component: FacetSelector,
+};
+const commonProps = {
+  classifications: FacetSelectorMock.classifications,
+  onSelectTermsChange: action("on select terms"),
+  onShowMore: action("on Show more"),
+};
+export const termsSelected = () => (
+  <FacetSelector selectedTerms={["scala", "QLD"]} {...commonProps} />
+);
+
+export const noTermsSelected = () => <FacetSelector {...commonProps} />;

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
@@ -32,39 +32,43 @@ export default {
   },
 } as Meta<FacetSelectorProps>;
 
+const FacetSelectorTemplate = (args: FacetSelectorProps) => (
+  <FacetSelector {...args} />
+);
 const selectedClassificationTerms = new Map<string, string[]>([
   ["Language", ["scala"]],
   ["City", ["Hobart"]],
 ]);
-export const termsSelected: Story<FacetSelectorProps> = (args) => (
-  <FacetSelector {...args} />
-);
-termsSelected.args = {
-  classifications: FacetSelectorMock.classifications,
-  selectedClassificationTerms: selectedClassificationTerms,
+const showMoreClassification = {
+  ...FacetSelectorMock.classifications[0],
+  showMore: true,
 };
 
-export const noTermsSelected: Story<FacetSelectorProps> = (args) => (
-  <FacetSelector {...args} />
+export const noTermsSelected: Story<FacetSelectorProps> = FacetSelectorTemplate.bind(
+  {}
 );
 noTermsSelected.args = {
   classifications: FacetSelectorMock.classifications,
 };
 
-export const showMore: Story<FacetSelectorProps> = (args) => (
-  <FacetSelector {...args} />
+export const termsSelected: Story<FacetSelectorProps> = FacetSelectorTemplate.bind(
+  {}
 );
-showMore.args = {
-  classifications: [
-    { ...FacetSelectorMock.classifications[0], showMore: true },
-  ],
+termsSelected.args = {
+  ...noTermsSelected.args,
+  selectedClassificationTerms: selectedClassificationTerms,
 };
 
-export const notShowMore: Story<FacetSelectorProps> = (args) => (
-  <FacetSelector {...args} />
+export const showMore: Story<FacetSelectorProps> = FacetSelectorTemplate.bind(
+  {}
+);
+showMore.args = {
+  classifications: [showMoreClassification],
+};
+
+export const notShowMore: Story<FacetSelectorProps> = FacetSelectorTemplate.bind(
+  {}
 );
 notShowMore.args = {
-  classifications: [
-    { ...FacetSelectorMock.classifications[0], showMore: false },
-  ],
+  classifications: [{ ...showMoreClassification, showMore: false }],
 };

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
@@ -15,22 +15,52 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { action } from "@storybook/addon-actions";
 import * as React from "react";
-import { FacetSelector } from "../../tsrc/search/components/FacetSelector";
+import {
+  FacetSelector,
+  FacetSelectorProps,
+} from "../../tsrc/search/components/FacetSelector";
 import * as FacetSelectorMock from "../../__mocks__/FacetSelector.mock";
+import type { Meta, Story } from "@storybook/react";
 
 export default {
   title: "Search/FacetSelector",
   component: FacetSelector,
-};
-const commonProps = {
-  classifications: FacetSelectorMock.classifications,
-  onSelectTermsChange: action("on select terms"),
-  onShowMore: action("on Show more"),
-};
-export const termsSelected = () => (
-  <FacetSelector selectedTerms={["scala", "QLD"]} {...commonProps} />
-);
+  argType: {
+    onSelectTermsChange: { action: "on select terms" },
+    onShowMore: { action: "on Show more" },
+  },
+} as Meta<FacetSelectorProps>;
 
-export const noTermsSelected = () => <FacetSelector {...commonProps} />;
+export const termsSelected: Story<FacetSelectorProps> = (args) => (
+  <FacetSelector {...args} />
+);
+termsSelected.args = {
+  classifications: FacetSelectorMock.classifications,
+  selectedTerms: ["scala", "QLD"],
+};
+
+export const noTermsSelected: Story<FacetSelectorProps> = (args) => (
+  <FacetSelector {...args} />
+);
+noTermsSelected.args = {
+  classifications: FacetSelectorMock.classifications,
+};
+
+export const showMore: Story<FacetSelectorProps> = (args) => (
+  <FacetSelector {...args} />
+);
+showMore.args = {
+  classifications: [
+    { ...FacetSelectorMock.classifications[0], showMore: true },
+  ],
+};
+
+export const notShowMore: Story<FacetSelectorProps> = (args) => (
+  <FacetSelector {...args} />
+);
+notShowMore.args = {
+  classifications: [
+    { ...FacetSelectorMock.classifications[0], showMore: false },
+  ],
+};

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
@@ -32,12 +32,16 @@ export default {
   },
 } as Meta<FacetSelectorProps>;
 
+const selectedClassificationTerms = new Map<string, string[]>([
+  ["Language", ["scala"]],
+  ["City", ["Hobart"]],
+]);
 export const termsSelected: Story<FacetSelectorProps> = (args) => (
   <FacetSelector {...args} />
 );
 termsSelected.args = {
   classifications: FacetSelectorMock.classifications,
-  selectedTerms: ["scala", "QLD"],
+  selectedClassificationTerms: selectedClassificationTerms,
 };
 
 export const noTermsSelected: Story<FacetSelectorProps> = (args) => (

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/FacetSelector.stories.tsx
@@ -35,9 +35,9 @@ export default {
 const FacetSelectorTemplate = (args: FacetSelectorProps) => (
   <FacetSelector {...args} />
 );
-const selectedClassificationTerms = new Map<string, string[]>([
-  ["Language", ["scala"]],
-  ["City", ["Hobart"]],
+const selectedClassificationTerms = new Map<number, string[]>([
+  [766942, ["scala"]],
+  [766943, ["Hobart"]],
 ]);
 const showMoreClassification = {
   ...FacetSelectorMock.classifications[0],

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchFacetsModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchFacetsModule.test.ts
@@ -24,12 +24,14 @@ import {
 } from "../../../tsrc/modules/SearchFacetsModule";
 
 const CLASSIFICATION_SUBJECT: Facet = {
+  id: 0,
   name: "Classification 1",
   schemaNode: "/item/subject",
   maxResults: 1,
   orderIndex: 0,
 };
 const CLASSIFICATION_KEYWORD: Facet = {
+  id: 1,
   name: "Classification 2",
   schemaNode: "/item/keyword",
   orderIndex: 1,
@@ -104,12 +106,14 @@ describe("SearchFacetsModule", () => {
     // Expect the correct data is generated
     expect(classifications).toEqual([
       {
+        id: CLASSIFICATION_SUBJECT.id,
         name: CLASSIFICATION_SUBJECT.name,
         maxDisplay: CLASSIFICATION_SUBJECT.maxResults,
         categories: CATEGORIES_SUBJECT,
         orderIndex: CLASSIFICATION_SUBJECT.orderIndex,
       },
       {
+        id: CLASSIFICATION_KEYWORD.id,
         name: CLASSIFICATION_KEYWORD.name,
         maxDisplay: CLASSIFICATION_KEYWORD.maxResults,
         categories: CATEGORIES_KEYWORD,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
@@ -27,6 +27,7 @@ import {
 import { FacetSelector } from "../../../../tsrc/search/components/FacetSelector";
 import * as FacetSelectorMock from "../../../../__mocks__/FacetSelector.mock";
 import "@testing-library/jest-dom/extend-expect";
+import { languageStrings } from "../../../../tsrc/util/langstrings";
 
 describe("<FacetSelector />", () => {
   // Mocked callbacks
@@ -40,7 +41,7 @@ describe("<FacetSelector />", () => {
   // Mocked facet
   const HOBART = "Hobart";
   // The text of 'SHOW MORE' button
-  const SHOW_MORE = "Show more";
+  const SHOW_MORE = languageStrings.searchpage.facetSelector.showMoreButton;
 
   const renderFacetSelector = () =>
     render(
@@ -52,7 +53,10 @@ describe("<FacetSelector />", () => {
     );
 
   // Return a 'li' that represents a Classification.
-  const getClassificationByName = (container: HTMLElement, name: string) => {
+  const getClassificationByName = (
+    container: HTMLElement,
+    name: string
+  ): HTMLElement => {
     const id = `#classification_${name}`;
     const classification = container.querySelector(id);
     if (!classification) {
@@ -62,7 +66,7 @@ describe("<FacetSelector />", () => {
   };
 
   // Return a Classification's 'SHOW MORE' button.
-  const getShowMoreButton = (
+  const queryShowMoreButton = (
     container: HTMLElement,
     classificationName: string
   ) => {
@@ -78,10 +82,6 @@ describe("<FacetSelector />", () => {
     page = renderFacetSelector();
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("should display a list of classifications that have categories", () => {
     // Language and City should be displayed.
     [CITY, LANGUAGE].forEach((name) => {
@@ -92,17 +92,14 @@ describe("<FacetSelector />", () => {
   });
 
   it("should display the 'SHOW MORE' button when 'showMore' is true", () => {
-    let showMoreButton;
     // City can show more categories.
-    showMoreButton = getShowMoreButton(page.container, CITY);
-    expect(showMoreButton).toBeInTheDocument();
+    expect(queryShowMoreButton(page.container, CITY)).toBeInTheDocument();
     // Language does not have more categories to show.
-    showMoreButton = getShowMoreButton(page.container, LANGUAGE);
-    expect(showMoreButton).toBeNull();
+    expect(queryShowMoreButton(page.container, LANGUAGE)).toBeNull();
   });
 
   it("should call 'onShowMore' when a 'SHOW MORE' button is clicked", () => {
-    const showMoreButton = getShowMoreButton(page.container, CITY);
+    const showMoreButton = queryShowMoreButton(page.container, CITY);
     if (!showMoreButton) {
       throw new Error(
         "Unable to find 'SHOW MORE' button for Classification City."

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
@@ -36,11 +36,12 @@ describe("<FacetSelector />", () => {
 
   // Mocked Classifications
   const CITY = "City";
+  const CITY_ID = 766943;
   const LANGUAGE = "Language";
   const COLOR = "Color";
   // Mocked facet
   const HOBART = "Hobart";
-  const mockedSelectedTerms = new Map([[CITY, [HOBART]]]);
+  const mockedSelectedTerms = new Map([[CITY_ID, [HOBART]]]);
   // The text of 'SHOW MORE' button
   const SHOW_MORE = languageStrings.searchpage.facetSelector.showMoreButton;
 
@@ -107,7 +108,7 @@ describe("<FacetSelector />", () => {
       );
     }
     fireEvent.click(showMoreButton);
-    expect(onShowMore).toHaveBeenLastCalledWith(CITY);
+    expect(onShowMore).toHaveBeenLastCalledWith(CITY_ID);
   });
 
   it("should sort Classifications based on their order indexes", () => {

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
@@ -57,12 +57,12 @@ describe("<FacetSelector />", () => {
     container: HTMLElement,
     name: string
   ): HTMLElement => {
-    const id = `#classification_${name}`;
-    const classification = container.querySelector(id);
+    // All needed information of a Classification is contained inside a 'li'.
+    const classification = queryByText(container, name)?.closest("li");
     if (!classification) {
       throw new Error(`Unable to find Classification ${name}`);
     }
-    return classification as HTMLElement;
+    return classification;
   };
 
   // Return a Classification's 'SHOW MORE' button.

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
@@ -29,15 +29,17 @@ import * as FacetSelectorMock from "../../../../__mocks__/FacetSelector.mock";
 import "@testing-library/jest-dom/extend-expect";
 
 describe("<FacetSelector />", () => {
-  // Mocked callbacks.
+  // Mocked callbacks
   const onSelectTermsChange = jest.fn();
   const onShowMore = jest.fn();
 
-  // Three mocked Classifications.
+  // Mocked Classifications
   const CITY = "City";
   const LANGUAGE = "Language";
   const COLOR = "Color";
-  // The text of 'SHOW MORE' button.
+  // Mocked facet
+  const HOBART = "Hobart";
+  // The text of 'SHOW MORE' button
   const SHOW_MORE = "Show more";
 
   const renderFacetSelector = () =>
@@ -115,5 +117,12 @@ describe("<FacetSelector />", () => {
     // The order should be: CITY, Language.
     expect(classifications[0].textContent).toBe(CITY);
     expect(classifications[1].textContent).toBe(LANGUAGE);
+  });
+
+  it("should call onSelectTermsChange when a facet is selected", () => {
+    // Select the facet of Hobart.
+    const hobart = getByText(page.container, HOBART, { selector: "p" });
+    fireEvent.click(hobart);
+    expect(onSelectTermsChange).toHaveBeenLastCalledWith([HOBART]);
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
@@ -1,0 +1,119 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import {
+  render,
+  queryByText,
+  getByText,
+  fireEvent,
+  RenderResult,
+  getAllByRole,
+} from "@testing-library/react";
+import { FacetSelector } from "../../../../tsrc/search/components/FacetSelector";
+import * as FacetSelectorMock from "../../../../__mocks__/FacetSelector.mock";
+import "@testing-library/jest-dom/extend-expect";
+
+describe("<FacetSelector />", () => {
+  // Mocked callbacks.
+  const onSelectTermsChange = jest.fn();
+  const onShowMore = jest.fn();
+
+  // Three mocked Classifications.
+  const CITY = "City";
+  const LANGUAGE = "Language";
+  const COLOR = "Color";
+  // The text of 'SHOW MORE' button.
+  const SHOW_MORE = "Show more";
+
+  const renderFacetSelector = () =>
+    render(
+      <FacetSelector
+        classifications={FacetSelectorMock.classifications}
+        onSelectTermsChange={onSelectTermsChange}
+        onShowMore={onShowMore}
+      />
+    );
+
+  // Return a 'li' that represents a Classification.
+  const getClassificationByName = (container: HTMLElement, name: string) => {
+    const id = `#classification_${name}`;
+    const classification = container.querySelector(id);
+    if (!classification) {
+      throw new Error(`Unable to find Classification ${name}`);
+    }
+    return classification as HTMLElement;
+  };
+
+  // Return a Classification's 'SHOW MORE' button.
+  const getShowMoreButton = (
+    container: HTMLElement,
+    classificationName: string
+  ) => {
+    const classification = getClassificationByName(
+      container,
+      classificationName
+    );
+    return queryByText(classification, SHOW_MORE);
+  };
+
+  let page: RenderResult;
+  beforeEach(() => {
+    page = renderFacetSelector();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should display a list of classifications that have categories", () => {
+    // Language and City should be displayed.
+    [CITY, LANGUAGE].forEach((name) => {
+      expect(getByText(page.container, name)).toBeInTheDocument();
+    });
+    // Color should not be displayed because it does not have categories.
+    expect(queryByText(page.container, COLOR)).not.toBeInTheDocument();
+  });
+
+  it("should display the 'SHOW MORE' button when 'showMore' is true", () => {
+    let showMoreButton;
+    // City can show more categories.
+    showMoreButton = getShowMoreButton(page.container, CITY);
+    expect(showMoreButton).toBeInTheDocument();
+    // Language does not have more categories to show.
+    showMoreButton = getShowMoreButton(page.container, LANGUAGE);
+    expect(showMoreButton).toBeNull();
+  });
+
+  it("should call 'onShowMore' when a 'SHOW MORE' button is clicked", () => {
+    const showMoreButton = getShowMoreButton(page.container, CITY);
+    if (!showMoreButton) {
+      throw new Error(
+        "Unable to find 'SHOW MORE' button for Classification City."
+      );
+    }
+    fireEvent.click(showMoreButton);
+    expect(onShowMore).toHaveBeenLastCalledWith(CITY);
+  });
+
+  it("should sort Classifications based on their order indexes", () => {
+    const classifications = getAllByRole(page.container, "heading");
+    // The order should be: CITY, Language.
+    expect(classifications[0].textContent).toBe(CITY);
+    expect(classifications[1].textContent).toBe(LANGUAGE);
+  });
+});

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/FacetSelector.test.tsx
@@ -40,6 +40,7 @@ describe("<FacetSelector />", () => {
   const COLOR = "Color";
   // Mocked facet
   const HOBART = "Hobart";
+  const mockedSelectedTerms = new Map([[CITY, [HOBART]]]);
   // The text of 'SHOW MORE' button
   const SHOW_MORE = languageStrings.searchpage.facetSelector.showMoreButton;
 
@@ -120,6 +121,6 @@ describe("<FacetSelector />", () => {
     // Select the facet of Hobart.
     const hobart = getByText(page.container, HOBART, { selector: "p" });
     fireEvent.click(hobart);
-    expect(onSelectTermsChange).toHaveBeenLastCalledWith([HOBART]);
+    expect(onSelectTermsChange).toHaveBeenLastCalledWith(mockedSelectedTerms);
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
@@ -27,6 +27,10 @@ import { SearchOptions } from "./SearchModule";
  */
 export interface Classification {
   /**
+   * The unique ID of a Classification.
+   */
+  id: number;
+  /**
    * The name for this group of categories - typically one which has been configured on the system.
    */
   name: string;
@@ -94,7 +98,10 @@ export const listClassifications = async (
 ): Promise<Classification[]> =>
   Promise.all(
     (await getFacetsFromServer()).map<Promise<Classification>>(
-      async (settings) => ({
+      async (settings, index) => ({
+        // We know IDs won't be undefined here, but due to its type being number | undefined,
+        // we have to do a nullish coalescing
+        id: settings.id ?? index,
         name: settings.name,
         maxDisplay: settings.maxResults,
         orderIndex: settings.orderIndex,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -22,6 +22,7 @@ import {
   templateError,
   TemplateUpdateProps,
 } from "../mainui/Template";
+import { Classification } from "../modules/SearchFacetsModule";
 import { languageStrings } from "../util/langstrings";
 import { Grid } from "@material-ui/core";
 import {
@@ -60,6 +61,30 @@ export interface SearchPageOptions extends SearchOptions {
    */
   dateRangeQuickModeEnabled: boolean;
 }
+
+/**
+ * Represents a Classification that is specific to Search page.
+ */
+export interface SearchPageClassification extends Classification {
+  /**
+   * A boolean indicating if a classification has hidden categories to show.
+   */
+  showMore: boolean;
+}
+
+/**
+ * Convert a list of standard Classifications to a list of SearchPage Classifications.
+ * @param classifications The standard Classifications to be processed.
+ */
+const classificationTransformer = (
+  classifications: Classification[]
+): SearchPageClassification[] =>
+  classifications.map((c) => {
+    // If 'maxDisplay' is undefined, it will be 10 by default.
+    const maxDisplay = c.maxDisplay ?? 10;
+    const showMore = c.categories.length > maxDisplay;
+    return { ...c, showMore: showMore, maxDisplay: maxDisplay };
+  });
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -72,20 +72,6 @@ export interface SearchPageClassification extends Classification {
   showMore: boolean;
 }
 
-/**
- * Convert a list of standard Classifications to a list of SearchPage Classifications.
- * @param classifications The standard Classifications to be processed.
- */
-const classificationTransformer = (
-  classifications: Classification[]
-): SearchPageClassification[] =>
-  classifications.map((c) => {
-    // If 'maxDisplay' is undefined, it will be 10 by default.
-    const maxDisplay = c.maxDisplay ?? 10;
-    const showMore = c.categories.length > maxDisplay;
-    return { ...c, showMore: showMore, maxDisplay: maxDisplay };
-  });
-
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const searchStrings = languageStrings.searchpage;
   const {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -22,7 +22,6 @@ import {
   templateError,
   TemplateUpdateProps,
 } from "../mainui/Template";
-import { Classification } from "../modules/SearchFacetsModule";
 import { languageStrings } from "../util/langstrings";
 import { Grid } from "@material-ui/core";
 import {
@@ -60,16 +59,6 @@ export interface SearchPageOptions extends SearchOptions {
    * Whether to enable Quick mode (true) or to use custom date pickers (false).
    */
   dateRangeQuickModeEnabled: boolean;
-}
-
-/**
- * Represents a Classification that is specific to Search page.
- */
-export interface SearchPageClassification extends Classification {
-  /**
-   * A boolean indicating if a classification has hidden categories to show.
-   */
-  showMore: boolean;
 }
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -47,7 +47,7 @@ export interface SearchPageClassification extends Classification {
   showMore: boolean;
 }
 
-interface FacetSelectorProps {
+export interface FacetSelectorProps {
   /**
    * A list of Classifications.
    */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -196,9 +196,9 @@ export const FacetSelector = ({
         prevClassification.orderIndex - nextClassification.orderIndex
     )
     .map((classification) => {
-      const { name, showMore } = classification;
+      const { id, name, showMore } = classification;
       return (
-        <ListItem divider key={name}>
+        <ListItem divider key={id}>
           <Grid container direction="column">
             <Grid item>
               <Typography variant="subtitle1">{name}</Typography>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -54,20 +54,20 @@ export interface FacetSelectorProps {
    */
   classifications: SearchPageClassification[];
   /**
-   * A map where the key is a Classification's name and value is
+   * A map where the key is a Classification's ID and value is
    * a list of terms.
    */
-  selectedClassificationTerms?: Map<string, string[]>;
+  selectedClassificationTerms?: Map<number, string[]>;
   /**
    * Handler for selecting/deselecting Classification terms.
    * @param terms A list of currently selected terms.
    */
-  onSelectTermsChange: (terms: Map<string, string[]>) => void;
+  onSelectTermsChange: (terms: Map<number, string[]>) => void;
   /**
    * Handler for clicking a 'SHOW MORE' button.
    * @param classificationName The name of a Classification.
    */
-  onShowMore: (classificationName: string) => void;
+  onShowMore: (classificationID: number) => void;
 }
 
 export const FacetSelector = ({
@@ -84,11 +84,11 @@ export const FacetSelector = ({
    * A copy of the map and a copy of the array of terms are created internally
    * to avoid mutating parent component's state.
    *
-   * @param classificationName The name of a Classification
+   * @param classificationID The ID of a Classification
    * @param term The selected or unselected term
    */
-  const handleSelectTerms = (classificationName: string, term: string) => {
-    const terms = selectedClassificationTerms?.get(classificationName);
+  const handleSelectTerms = (classificationID: number, term: string) => {
+    const terms = selectedClassificationTerms?.get(classificationID);
     const copiedTerms = terms ? [...terms] : [];
     const termIndex = copiedTerms.indexOf(term);
     if (termIndex === -1) {
@@ -97,19 +97,19 @@ export const FacetSelector = ({
       copiedTerms.splice(termIndex, 1);
     }
     const copiedMap = new Map(selectedClassificationTerms ?? []);
-    copiedMap.set(classificationName, copiedTerms);
+    copiedMap.set(classificationID, copiedTerms);
     onSelectTermsChange(copiedMap);
   };
 
   /**
    * Render a 'SHOW MORE' button for each Classification.
-   * @param classificationName The name of a Classification.
+   * @param classificationID The ID of a Classification.
    */
-  const showMoreButton = (classificationName: string): ReactElement => (
+  const showMoreButton = (classificationID: number): ReactElement => (
     <ListItem>
       <Grid container justify="center">
         <Grid item>
-          <Button variant="text" onClick={() => onShowMore(classificationName)}>
+          <Button variant="text" onClick={() => onShowMore(classificationID)}>
             {languageStrings.searchpage.facetSelector.showMoreButton}
           </Button>
         </Grid>
@@ -138,11 +138,11 @@ export const FacetSelector = ({
 
   /**
    * Build a ListItem consisting of a MUI Checkbox and a Label for a facet.
-   * @param classificationName The name of a Classification
+   * @param classificationID The name of a Classification
    * @param facet A facet
    */
   const facetListItem = (
-    classificationName: string,
+    classificationID: number,
     facet: OEQ.SearchFacets.Facet
   ): ReactElement => {
     const { term, count } = facet;
@@ -153,10 +153,10 @@ export const FacetSelector = ({
             <Checkbox
               checked={
                 selectedClassificationTerms
-                  ?.get(classificationName)
+                  ?.get(classificationID)
                   ?.includes(term) ?? false
               }
-              onChange={() => handleSelectTerms(classificationName, term)}
+              onChange={() => handleSelectTerms(classificationID, term)}
             />
           }
           label={facetLabel(facet)}
@@ -169,20 +169,20 @@ export const FacetSelector = ({
    * Build a list for a Classification's categories. Some categories may have facets
    * not displayed due to the configured maximum display number.
    *
-   * @param name The name of a Classification
+   * @param id The ID of a Classification
    * @param categories A list of terms to build into a list
    * @param showMore Whether to show more facets or not
    * @param maxDisplay Default maximum number of displayed facets
    */
   const listCategories = ({
-    name,
+    id,
     categories,
     showMore,
     maxDisplay,
   }: SearchPageClassification): ReactElement[] =>
     categories
       .slice(0, showMore ? maxDisplay : undefined)
-      .map((facet) => facetListItem(name, facet));
+      .map((facet) => facetListItem(id, facet));
 
   /**
    * Sort and build Classifications that have categories.
@@ -209,7 +209,7 @@ export const FacetSelector = ({
                 className={!showMore ? classes.classificationList : ""}
               >
                 {listCategories(classification)}
-                {showMore && showMoreButton(name)}
+                {showMore && showMoreButton(id)}
               </List>
             </Grid>
           </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -150,16 +150,18 @@ export const FacetSelector = ({
    * Build a list for a Classification's categories. Some categories may have facets
    * not displayed due to the configured maximum display number.
    *
-   * @param classification A fully defined Classification with a list of terms to build
-   * into a list - including metadata detailing how many to include.
+   * @param categories A list of terms to build into a list
+   * @param showMore Whether to show more facets or not
+   * @param maxDisplay Default maximum number of displayed facets
    */
-  const listCategories = (classification: SearchPageClassification) => {
-    const { categories, maxDisplay, showMore } = classification;
-    const facets = categories.map((facet) => facetListItem(facet));
-    // The number of displayed facets depends on whether to show more
-    // and the maximum display number.
-    return facets.slice(0, showMore ? maxDisplay : undefined);
-  };
+  const listCategories = (
+    categories: OEQ.SearchFacets.Facet[],
+    showMore: boolean,
+    maxDisplay?: number
+  ) =>
+    categories
+      .slice(0, showMore ? maxDisplay : undefined)
+      .map((facet) => facetListItem(facet));
 
   /**
    * Sort and build Classifications that have categories.
@@ -172,8 +174,7 @@ export const FacetSelector = ({
       (prevClassification, nextClassification) =>
         prevClassification.orderIndex - nextClassification.orderIndex
     )
-    .map((classification) => {
-      const { name, showMore } = classification;
+    .map(({ name, categories, maxDisplay, showMore }) => {
       return (
         <ListItem divider key={name} id={`classification_${name}`}>
           <Grid container direction="column">
@@ -185,7 +186,7 @@ export const FacetSelector = ({
                 dense
                 className={!showMore ? classes.classificationList : ""}
               >
-                {listCategories(classification)}
+                {listCategories(categories, showMore, maxDisplay)}
                 {showMore && showMoreButton(name)}
               </List>
             </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -101,11 +101,7 @@ export const FacetSelector = ({
     <ListItem>
       <Grid container justify="center">
         <Grid item>
-          <Button
-            id={`${classificationName}_show_more`}
-            variant="text"
-            onClick={() => onShowMore(classificationName)}
-          >
+          <Button variant="text" onClick={() => onShowMore(classificationName)}>
             {languageStrings.searchpage.facetSelector.showMoreButton}
           </Button>
         </Grid>
@@ -176,7 +172,7 @@ export const FacetSelector = ({
     )
     .map(({ name, categories, maxDisplay, showMore }) => {
       return (
-        <ListItem divider key={name} id={`classification_${name}`}>
+        <ListItem divider key={name}>
           <Grid container direction="column">
             <Grid item>
               <Typography variant="subtitle1">{name}</Typography>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -147,7 +147,7 @@ export const FacetSelector = ({
   ): ReactElement => {
     const { term, count } = facet;
     return (
-      <ListItem key={`${facet} ${count}`} style={{ padding: 0 }}>
+      <ListItem key={`${term} ${count}`} style={{ padding: 0 }}>
         <FormControlLabel
           control={
             <Checkbox

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -27,15 +27,13 @@ import {
 import { makeStyles } from "@material-ui/core/styles";
 import * as React from "react";
 import * as OEQ from "@openequella/rest-api-client";
+import { languageStrings } from "../../util/langstrings";
 import { SearchPageClassification } from "../SearchPage";
 
 const useStyles = makeStyles({
   classificationList: {
     maxHeight: 500,
     overflow: "auto",
-  },
-  facetListItem: {
-    padding: 0,
   },
 });
 
@@ -98,7 +96,7 @@ export const FacetSelector = ({
             variant="text"
             onClick={() => onShowMore(classificationName)}
           >
-            Show more
+            {languageStrings.searchpage.facetSelector.showMoreButton}
           </Button>
         </Grid>
       </Grid>
@@ -125,10 +123,7 @@ export const FacetSelector = ({
    * @param facet A facet.
    */
   const renderFacet = (facet: OEQ.SearchFacets.Facet) => (
-    <ListItem
-      className={classes.facetListItem}
-      key={`${facet.term} ${facet.count}`}
-    >
+    <ListItem key={`${facet.term} ${facet.count}`} style={{ padding: 0 }}>
       <FormControlLabel
         control={
           <Checkbox
@@ -151,7 +146,7 @@ export const FacetSelector = ({
   const renderCategories = (classification: SearchPageClassification) => {
     const { categories, maxDisplay, showMore } = classification;
     const facets = categories.map((facet) => renderFacet(facet));
-    // The number of displayed facets Depends on whether to show more
+    // The number of displayed facets depends on whether to show more
     // and the maximum display number.
     return facets.slice(0, showMore ? maxDisplay : undefined);
   };
@@ -162,10 +157,13 @@ export const FacetSelector = ({
    * be added, depending on whether a classification has more categories to show or not.
    */
   const renderClassifications = classifications
-    .filter((c) => c.categories.length > 0)
-    .sort((c1, c2) => c1.orderIndex - c2.orderIndex)
-    .map((c) => {
-      const { name, showMore } = c;
+    .filter((classification) => classification.categories.length > 0)
+    .sort(
+      (prevClassification, nextClassification) =>
+        prevClassification.orderIndex - nextClassification.orderIndex
+    )
+    .map((classification) => {
+      const { name, showMore } = classification;
       return (
         <ListItem divider key={name} id={`classification_${name}`}>
           <Grid container direction="column">
@@ -177,7 +175,7 @@ export const FacetSelector = ({
                 dense
                 className={!showMore ? classes.classificationList : ""}
               >
-                {renderCategories(c)}
+                {renderCategories(classification)}
                 {showMore && showMoreButton(name)}
               </List>
             </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -27,8 +27,8 @@ import {
 import { makeStyles } from "@material-ui/core/styles";
 import * as React from "react";
 import * as OEQ from "@openequella/rest-api-client";
+import { Classification } from "../../modules/SearchFacetsModule";
 import { languageStrings } from "../../util/langstrings";
-import type { SearchPageClassification } from "../SearchPage";
 
 const useStyles = makeStyles({
   classificationList: {
@@ -36,6 +36,16 @@ const useStyles = makeStyles({
     overflow: "auto",
   },
 });
+
+/**
+ * Represents a Classification that is specific to Search page.
+ */
+export interface SearchPageClassification extends Classification {
+  /**
+   * A boolean indicating if a classification has hidden categories to show.
+   */
+  showMore: boolean;
+}
 
 interface FacetSelectorProps {
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -145,9 +145,9 @@ export const FacetSelector = ({
     classificationID: number,
     facet: OEQ.SearchFacets.Facet
   ): ReactElement => {
-    const { term, count } = facet;
+    const { term } = facet;
     return (
-      <ListItem key={`${term} ${count}`} style={{ padding: 0 }}>
+      <ListItem key={`${classificationID}:${term}`} style={{ padding: 0 }}>
         <FormControlLabel
           control={
             <Checkbox

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -127,9 +127,7 @@ export const FacetSelector = ({
       <FormControlLabel
         control={
           <Checkbox
-            checked={
-              selectedTerms ? selectedTerms.includes(facet.term) : false
-            }
+            checked={selectedTerms?.includes(facet.term) ?? false}
             onChange={() => handleSelectTerms(facet.term)}
           />
         }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -28,7 +28,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import * as React from "react";
 import * as OEQ from "@openequella/rest-api-client";
 import { languageStrings } from "../../util/langstrings";
-import { SearchPageClassification } from "../SearchPage";
+import type { SearchPageClassification } from "../SearchPage";
 
 const useStyles = makeStyles({
   classificationList: {
@@ -128,7 +128,7 @@ export const FacetSelector = ({
         control={
           <Checkbox
             checked={
-              selectedTerms ? selectedTerms.indexOf(facet.term) !== -1 : false
+              selectedTerms ? selectedTerms.includes(facet.term) : false
             }
             onChange={() => handleSelectTerms(facet.term)}
           />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -129,10 +129,10 @@ export const FacetSelector = ({
   );
 
   /**
-   * Render a MUI Checkbox and a Label for a facet.
+   * Build a ListItem consisting of a MUI Checkbox and a Label for a facet.
    * @param facet A facet.
    */
-  const renderFacet = (facet: OEQ.SearchFacets.Facet) => (
+  const facetListItem = (facet: OEQ.SearchFacets.Facet) => (
     <ListItem key={`${facet.term} ${facet.count}`} style={{ padding: 0 }}>
       <FormControlLabel
         control={
@@ -147,24 +147,26 @@ export const FacetSelector = ({
   );
 
   /**
-   * Render a list for a Classification's categories. Some categories
-   * may have facets not displayed due to the configured maximum display number.
-   * @param classification A Classification..
+   * Build a list for a Classification's categories. Some categories may have facets
+   * not displayed due to the configured maximum display number.
+   *
+   * @param classification A fully defined Classification with a list of terms to build
+   * into a list - including metadata detailing how many to include.
    */
-  const renderCategories = (classification: SearchPageClassification) => {
+  const listCategories = (classification: SearchPageClassification) => {
     const { categories, maxDisplay, showMore } = classification;
-    const facets = categories.map((facet) => renderFacet(facet));
+    const facets = categories.map((facet) => facetListItem(facet));
     // The number of displayed facets depends on whether to show more
     // and the maximum display number.
     return facets.slice(0, showMore ? maxDisplay : undefined);
   };
 
   /**
-   * Sort and render Classifications that have categories.
+   * Sort and build Classifications that have categories.
    * For each Classification, a scroll bar and a 'Show more' button may or may not
    * be added, depending on whether a classification has more categories to show or not.
    */
-  const renderClassifications = classifications
+  const buildClassifications = classifications
     .filter((classification) => classification.categories.length > 0)
     .sort(
       (prevClassification, nextClassification) =>
@@ -183,7 +185,7 @@ export const FacetSelector = ({
                 dense
                 className={!showMore ? classes.classificationList : ""}
               >
-                {renderCategories(classification)}
+                {listCategories(classification)}
                 {showMore && showMoreButton(name)}
               </List>
             </Grid>
@@ -191,5 +193,6 @@ export const FacetSelector = ({
         </ListItem>
       );
     });
-  return <List>{renderClassifications}</List>;
+
+  return <List>{buildClassifications}</List>;
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/FacetSelector.tsx
@@ -1,0 +1,189 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  List,
+  ListItem,
+  Typography,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import * as React from "react";
+import * as OEQ from "@openequella/rest-api-client";
+import { SearchPageClassification } from "../SearchPage";
+
+const useStyles = makeStyles({
+  classificationList: {
+    maxHeight: 500,
+    overflow: "auto",
+  },
+  facetListItem: {
+    padding: 0,
+  },
+});
+
+interface FacetSelectorProps {
+  /**
+   * A list of Classifications.
+   */
+  classifications: SearchPageClassification[];
+  /**
+   * A list of selected facets.
+   */
+  selectedTerms?: string[];
+  /**
+   * Handler for selecting/deselecting Classification terms.
+   * @param terms A list of currently selected terms.
+   */
+  onSelectTermsChange: (terms: string[]) => void;
+  /**
+   * Handler for clicking a 'SHOW MORE' button.
+   * @param classificationName The name of a Classification.
+   */
+  onShowMore: (classificationName: string) => void;
+}
+
+export const FacetSelector = ({
+  classifications,
+  selectedTerms,
+  onSelectTermsChange,
+  onShowMore,
+}: FacetSelectorProps) => {
+  const classes = useStyles();
+
+  /**
+   * Updates the list of selected Classification terms. If the term exists then remove it
+   * from the list. Add it to the list otherwise.
+   *
+   * @param term The selected or unselected term.
+   */
+  const handleSelectTerms = (term: string) => {
+    const copiedSelectedTerms = selectedTerms ? [...selectedTerms] : [];
+    const termIndex = copiedSelectedTerms.indexOf(term);
+    if (termIndex === -1) {
+      copiedSelectedTerms.push(term);
+    } else {
+      copiedSelectedTerms.splice(termIndex, 1);
+    }
+    onSelectTermsChange(copiedSelectedTerms);
+  };
+
+  /**
+   * Render a 'SHOW MORE' button for each Classification.
+   * @param classificationName The name of a Classification.
+   */
+  const showMoreButton = (classificationName: string) => (
+    <ListItem>
+      <Grid container justify="center">
+        <Grid item>
+          <Button
+            id={`${classificationName}_show_more`}
+            variant="text"
+            onClick={() => onShowMore(classificationName)}
+          >
+            Show more
+          </Button>
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+
+  /**
+   * Generate texts in the format of 'term (count)' for displaying a facet.
+   * @param facet A facet
+   */
+  const facetLabel = (facet: OEQ.SearchFacets.Facet) => (
+    <Grid container spacing={1}>
+      <Grid item>
+        <Typography>{facet.term}</Typography>
+      </Grid>
+      <Grid item>
+        <Typography color="textSecondary">{`(${facet.count})`}</Typography>
+      </Grid>
+    </Grid>
+  );
+
+  /**
+   * Render a MUI Checkbox and a Label for a facet.
+   * @param facet A facet.
+   */
+  const renderFacet = (facet: OEQ.SearchFacets.Facet) => (
+    <ListItem
+      className={classes.facetListItem}
+      key={`${facet.term} ${facet.count}`}
+    >
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={
+              selectedTerms ? selectedTerms.indexOf(facet.term) !== -1 : false
+            }
+            onChange={() => handleSelectTerms(facet.term)}
+          />
+        }
+        label={facetLabel(facet)}
+      />
+    </ListItem>
+  );
+
+  /**
+   * Render a list for a Classification's categories. Some categories
+   * may have facets not displayed due to the configured maximum display number.
+   * @param classification A Classification..
+   */
+  const renderCategories = (classification: SearchPageClassification) => {
+    const { categories, maxDisplay, showMore } = classification;
+    const facets = categories.map((facet) => renderFacet(facet));
+    // The number of displayed facets Depends on whether to show more
+    // and the maximum display number.
+    return facets.slice(0, showMore ? maxDisplay : undefined);
+  };
+
+  /**
+   * Sort and render Classifications that have categories.
+   * For each Classification, a scroll bar and a 'Show more' button may or may not
+   * be added, depending on whether a classification has more categories to show or not.
+   */
+  const renderClassifications = classifications
+    .filter((c) => c.categories.length > 0)
+    .sort((c1, c2) => c1.orderIndex - c2.orderIndex)
+    .map((c) => {
+      const { name, showMore } = c;
+      return (
+        <ListItem divider key={name} id={`classification_${name}`}>
+          <Grid container direction="column">
+            <Grid item>
+              <Typography variant="subtitle1">{name}</Typography>
+            </Grid>
+            <Grid item>
+              <List
+                dense
+                className={!showMore ? classes.classificationList : ""}
+              >
+                {renderCategories(c)}
+                {showMore && showMoreButton(name)}
+              </List>
+            </Grid>
+          </Grid>
+        </ListItem>
+      );
+    });
+  return <List>{renderClassifications}</List>;
+};

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -338,6 +338,9 @@ export const languageStrings = {
       week: "Week",
       day: "Day",
     },
+    facetSelector: {
+      showMoreButton: "Show more",
+    },
     filterOwner: {
       title: "Owner",
       chip: "Owner: ",


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Here is another refine control - Facet Selector.  A new type representing Search page specific Classifications was firstly added in `SearchPage.tsx`.  A function transforming standard Classifications to the Search page Classifications was also added in and will be consumed in the next integration. 

The component does not have its own state so at this stage only props changes can trigger a re-render. 
Jest tests and Storybooks for this component are also included.

![image](https://user-images.githubusercontent.com/47203811/90856592-98cf3400-e3c5-11ea-92c0-dd4235684240.png)
