### PR TITLE
Fix migration issue caused by 'RemoveLastKnownUserConstraint'

### DIFF
--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6028,13 +6028,13 @@
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint20192">
     <parameter id="id" value="com.tle.core.institution.migration.v20192.RemoveLastKnownUserConstraint" />
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20192.RemoveLastKnownUserConstraint" />
-    <parameter id="date" value="2020-08-31" />
+    <parameter id="date" value="2020-06-10" />
     <parameter id="obsoletedby" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
   </extension>
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint20201">
     <parameter id="id" value="com.tle.core.institution.migration.v20201.RemoveLastKnownUserConstraint" />
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20201.RemoveLastKnownUserConstraint" />
-    <parameter id="date" value="2020-08-31" />
+    <parameter id="date" value="2020-06-10" />
     <parameter id="obsoletedby" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
   </extension>
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint">

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6024,6 +6024,19 @@
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.CreateFacetedSearchClassificationTable" />
     <parameter id="date" value="2020-04-22" />
   </extension>
+  <!-- Let 2020.2 know v20192 and v20201 of RemoveLastKnownUserConstraint-->
+  <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint20192">
+    <parameter id="id" value="com.tle.core.institution.migration.v20192.RemoveLastKnownUserConstraint" />
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20192.RemoveLastKnownUserConstraint" />
+    <parameter id="date" value="2020-08-31" />
+    <parameter id="obsoletedby" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
+  </extension>
+  <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint20201">
+    <parameter id="id" value="com.tle.core.institution.migration.v20201.RemoveLastKnownUserConstraint" />
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20201.RemoveLastKnownUserConstraint" />
+    <parameter id="date" value="2020-08-31" />
+    <parameter id="obsoletedby" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
+  </extension>
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint">
     <parameter id="id" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20202/RemoveLastKnownUserConstraint.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20202/RemoveLastKnownUserConstraint.java
@@ -53,6 +53,11 @@ public class RemoveLastKnownUserConstraint extends AbstractHibernateSchemaMigrat
   }
 
   @Override
+  public boolean isBackwardsCompatible() {
+    return true;
+  }
+
+  @Override
   protected void executeDataMigration(
       HibernateMigrationHelper helper, MigrationResult result, Session session) throws Exception {
     // Copy data from username1 to username.


### PR DESCRIPTION
#2210 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The PR fixes the bug about failing to upgrade from `2019.2.4` or `2020.1.3` to 2020.2 . The approach is to let 2020.2 replace both  `v20192` and `v20201` of `RemoveLastKnownUserConstraint`  with the `v20202` one.

I can locally upgrade from 2019.2.4 to 2020.2 and upgrade from 2020.1.3 to 2020.2 without the errors.