### PR TITLE
Modify /search2 to return a list of words to highlight

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
@@ -404,29 +404,26 @@ public class DefaultSearch extends VeryBasicSearch {
   }
 
   public static class QueryParser {
-    private final List<QueryToken> tokens;
+
     private final List<String> hilight;
 
     public QueryParser(String query) {
-      hilight = new ArrayList<String>();
-      tokens = new ArrayList<QueryToken>();
+      hilight = new ArrayList<>();
       parseQuery(query);
     }
 
     protected void parseQuery(final String query) {
       final List<QueryToken> newTokens = QueryToken.tokenize(query);
-      tokens.addAll(newTokens);
 
-      for (int i = 0; i < newTokens.size(); i++) {
-        final QueryToken qtok = newTokens.get(i);
+      for (final QueryToken qtok : newTokens) {
         final String token = qtok.token;
 
         boolean isFullWord = qtok.isaword;
-        isFullWord = isFullWord && !token.equalsIgnoreCase("AND"); // $NON-NLS-1$
-        isFullWord = isFullWord && !token.equalsIgnoreCase("OR"); // $NON-NLS-1$
-        isFullWord = isFullWord && !token.equalsIgnoreCase("NOT"); // $NON-NLS-1$
-        isFullWord = isFullWord && !token.startsWith("?"); // $NON-NLS-1$
-        isFullWord = isFullWord && !token.startsWith("*"); // $NON-NLS-1$
+        isFullWord = isFullWord && !token.equalsIgnoreCase("AND");
+        isFullWord = isFullWord && !token.equalsIgnoreCase("OR");
+        isFullWord = isFullWord && !token.equalsIgnoreCase("NOT");
+        isFullWord = isFullWord && !token.startsWith("?");
+        isFullWord = isFullWord && !token.startsWith("*");
 
         if (isFullWord) {
           hilight.add(token);

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -19,15 +19,16 @@
 package com.tle.web.api.search
 
 import com.tle.beans.item.ItemIdKey
+import com.tle.common.search.DefaultSearch
 import com.tle.core.item.serializer.ItemSerializerItemBean
 import com.tle.core.services.item.{FreetextResult, FreetextSearchResults}
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.item.equella.interfaces.beans.EquellaItemBean
-import com.tle.web.api.search.model.{SearchParam, SearchResult, SearchResultItem}
 import com.tle.web.api.search.SearchHelper._
+import com.tle.web.api.search.model.{SearchParam, SearchResult, SearchResultItem}
 import io.swagger.annotations.{Api, ApiOperation}
-import javax.ws.rs.{BeanParam, GET, Path, Produces}
 import javax.ws.rs.core.Response
+import javax.ws.rs.{BeanParam, GET, Path, Produces}
 import org.jboss.resteasy.annotations.cache.NoCache
 
 import scala.collection.JavaConverters._
@@ -54,10 +55,15 @@ class SearchResource {
     val itemIds                 = freetextResults.map(_.getItemIdKey)
     val serializer              = createSerializer(itemIds)
     val items: List[SearchItem] = freetextResults.map(result => SearchItem(result, serializer))
-    val result = SearchResult(searchResults.getOffset,
-                              searchResults.getCount,
-                              searchResults.getAvailable,
-                              items.map(convertToItem))
+    val highlight =
+      new DefaultSearch.QueryParser(params.query).getHilightedList.asScala.toList
+    val result = SearchResult(
+      searchResults.getOffset,
+      searchResults.getCount,
+      searchResults.getAvailable,
+      items.map(convertToItem),
+      highlight
+    )
     Response.ok.entity(result).build()
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResult.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResult.scala
@@ -18,4 +18,17 @@
 
 package com.tle.web.api.search.model
 
-case class SearchResult[T](start: Int, length: Int, available: Int, results: List[T])
+/**
+  * Represents the results for a search query.
+  *
+  * @param start The starting offset into the total search results
+  * @param length How many results can be found in `results`
+  * @param available The maximum number of results available for paging
+  * @param results The individual items which match the search
+  * @param highlight List of words to use to highlight when displaying the results
+  */
+case class SearchResult[T](start: Int,
+                           length: Int,
+                           available: Int,
+                           results: List[T],
+                           highlight: List[String])

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -1,9 +1,17 @@
 package io.github.openequella.rest;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -16,47 +24,56 @@ public class Search2ApiTest extends AbstractRestApiTest {
 
   @Test(description = "Search without parameters")
   public void noParamSearchTest() throws IOException {
-    JsonNode result = doSearch(200);
-    assertTrue(result.get("available").asInt() > 0);
+    JsonNode result = doSearch(200, null);
+    assertTrue(getAvailable(result) > 0);
   }
 
   @Test(description = "Search for a specific item")
   public void queryTest() throws IOException {
-    JsonNode result =
-        doSearch(200, new NameValuePair("query", "ActivationApiTest - Book Holding Clone"));
-    assertEquals(result.get("available").asInt(), 1);
+    JsonNode result = doSearch(200, "ActivationApiTest - Book Holding Clone");
+    final Set<String> highlights =
+        StreamSupport.stream(result.get("highlight").spliterator(), false)
+            .map(JsonNode::asText)
+            .collect(Collectors.toSet());
+
+    assertEquals(getAvailable(result), 1);
+    assertEquals(
+        highlights, new HashSet<>(Arrays.asList("ActivationApiTest", "Book", "Holding", "Clone")));
   }
 
   @Test(description = "Search for specific items by Item status")
   public void itemStatusTest() throws IOException {
-    JsonNode result =
-        doSearch(200, new NameValuePair("query", "loaf"), new NameValuePair("status", "LIVE"));
-    assertEquals(result.get("available").asInt(), 3);
+    JsonNode result = doSearch(200, "loaf", new NameValuePair("status", "LIVE"));
+    assertEquals(getAvailable(result), 3);
   }
 
   @Test(description = "Search for items from a specific collection")
   public void collectionTest() throws IOException {
     JsonNode result =
-        doSearch(200, new NameValuePair("collections", "4c147089-cddb-e67c-b5ab-189614eb1463"));
-    assertEquals(result.get("available").asInt(), 2);
+        doSearch(
+            200, null, new NameValuePair("collections", "4c147089-cddb-e67c-b5ab-189614eb1463"));
+    assertEquals(getAvailable(result), 2);
   }
 
   @Test(description = "Search for items belonging to a specific owner")
   public void ownerTest() throws IOException {
     JsonNode result =
-        doSearch(200, new NameValuePair("owner", "adfcaf58-241b-4eca-9740-6a26d1c3dd58"));
-    assertTrue(result.get("available").asInt() > 0);
+        doSearch(200, null, new NameValuePair("owner", "adfcaf58-241b-4eca-9740-6a26d1c3dd58"));
+    assertTrue(getAvailable(result) > 0);
   }
 
   @Test(description = "Search by items' created date.")
   public void orderTest() throws IOException {
-    doSearch(200, new NameValuePair("order", "created"));
+    doSearch(200, null, new NameValuePair("order", "created"));
   }
 
   @Test(description = "Search by items' modified date and the order of results is reversed.")
   public void reverseOrderTest() throws IOException {
     doSearch(
-        200, new NameValuePair("order", "modified"), new NameValuePair("reverseOrder", "true"));
+        200,
+        null,
+        new NameValuePair("order", "modified"),
+        new NameValuePair("reverseOrder", "true"));
   }
 
   @Test(description = "Search within a specific date range")
@@ -64,33 +81,32 @@ public class Search2ApiTest extends AbstractRestApiTest {
     JsonNode result =
         doSearch(
             200,
+            null,
             new NameValuePair("modifiedAfter", "2014-04-01"),
             new NameValuePair("modifiedBefore", "2014-04-30"));
-    assertEquals(result.get("available").asInt(), 6);
+    assertEquals(getAvailable(result), 6);
   }
 
   @Test(description = "Limit the search result to include only 2 items")
   public void startLengthTest() throws IOException {
     JsonNode result =
-        doSearch(200, new NameValuePair("start", "1"), new NameValuePair("length", "2"));
+        doSearch(200, null, new NameValuePair("start", "1"), new NameValuePair("length", "2"));
     assertEquals(result.get("results").size(), 2);
   }
 
   @Test(description = "Search for a term that is found inside an attachment")
   public void termFoundInAttachmentTest() throws IOException {
     // Perform a search for a term found inside item attachment content
-    JsonNode itemResult = doSearch(200, new NameValuePair("query", "frogs")).get("results").get(0);
-    assertEquals(itemResult.get("keywordFoundInAttachment").asBoolean(), true);
+    JsonNode itemResult = doSearch(200, "frogs").get("results").get(0);
+    assertTrue(itemResult.get("keywordFoundInAttachment").asBoolean());
   }
 
   @Test(description = "Search for a term that is not found inside an attachment")
   public void noTermFoundInAttachmentTest() throws IOException {
     // Perform a search for a term found inside item metadata
     JsonNode itemResult =
-        doSearch(200, new NameValuePair("query", "Keyword found in attachment test item"))
-            .get("results")
-            .get(0);
-    assertEquals(itemResult.get("keywordFoundInAttachment").asBoolean(), false);
+        doSearch(200, "Keyword found in attachment test item").get("results").get(0);
+    assertFalse(itemResult.get("keywordFoundInAttachment").asBoolean());
   }
 
   @Test(description = "Search by a specific where clause")
@@ -98,25 +114,26 @@ public class Search2ApiTest extends AbstractRestApiTest {
     JsonNode result =
         doSearch(
             200,
+            null,
             new NameValuePair(
                 "whereClause",
                 "where /xml/item/itembody/name = 'ActivationApiTest - Book Holding Clone'"));
-    assertEquals(result.get("available").asInt(), 1);
+    assertEquals(getAvailable(result), 1);
   }
 
   @Test(description = "Search by an invalid item status")
   public void invalidItemStatusSearch() throws IOException {
-    doSearch(404, new NameValuePair("status", "ALIVE"));
+    doSearch(404, null, new NameValuePair("status", "ALIVE"));
   }
 
   @Test(description = "Search from a non-existing collection")
   public void invalidCollectionSearch() throws IOException {
-    doSearch(404, new NameValuePair("collections", "bad collection"));
+    doSearch(404, null, new NameValuePair("collections", "bad collection"));
   }
 
   @Test(description = "Search by a invalid date format")
   public void invalidDateSearch() throws IOException {
-    doSearch(400, new NameValuePair("modifiedAfter", "2020/05/05"));
+    doSearch(400, null, new NameValuePair("modifiedAfter", "2020/05/05"));
   }
 
   @DataProvider(name = "searchAttachmentsData")
@@ -135,19 +152,31 @@ public class Search2ApiTest extends AbstractRestApiTest {
     JsonNode result =
         doSearch(
             200,
-            new NameValuePair("query", "size"),
+            "size",
             new NameValuePair("searchAttachments", Boolean.toString(searchAttachment)));
-    assertEquals(result.get("available").asInt(), expectNumber);
+    assertEquals(getAvailable(result), expectNumber);
   }
 
-  private JsonNode doSearch(int expectedCode, NameValuePair... queryVals) throws IOException {
+  private JsonNode doSearch(int expectedCode, String query, NameValuePair... queryVals)
+      throws IOException {
     final HttpMethod method = new GetMethod(SEARCH_API_ENDPOINT);
-    if (queryVals != null) {
-      method.setQueryString(queryVals);
+    final List<NameValuePair> queryParams = new LinkedList<>();
+
+    if (query != null) {
+      queryParams.add(new NameValuePair("query", query));
     }
+    if (queryVals != null) {
+      queryParams.addAll(Arrays.asList(queryVals));
+    }
+    method.setQueryString(queryParams.toArray(new NameValuePair[0]));
+
     int statusCode = makeClientRequest(method);
     assertEquals(statusCode, expectedCode);
 
     return mapper.readTree(method.getResponseBody());
+  }
+
+  private int getAvailable(JsonNode result) {
+    return result.get("available").asInt();
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

In the New Search UI we plan to highlight matching terms as they were done in the legacy UI. To emulate this, we need the search endpoint to return the list of words to highlight based on the query. This here PR does that.

As well as that, I did some minor unrelated refactoring of `DefaultSearch.QueryParser` as I was reading code - so I thought I might as well include it here (contained in ce0e9cc). Also while adding a test for this, I did some tidy-up of `Search2ApiTest`. And also as an aside, so that I could document the new `SearchResult` param, I also documented all the others.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
