### PR TITLE
Ensure no more complaints about migration for last known owner

### DIFF
--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6024,16 +6024,20 @@
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.CreateFacetedSearchClassificationTable" />
     <parameter id="date" value="2020-04-22" />
   </extension>
-  <!-- Let 2020.2 know v20192 and v20201 of RemoveLastKnownUserConstraint-->
+  <!-- Let 2020.2 know v20192 and v20201 of RemoveLastKnownUserConstraint.
+       Firstly, below two extension's IDs must match the ID of v20192 and v20201.
+       Secondly, Because we don't have a bean for v20192 and v20201 in 2020.2, we must reuse v20202's bean.
+       Lastly, make the two extensions obsoleted by v20202.
+  -->
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint20192">
     <parameter id="id" value="com.tle.core.institution.migration.v20192.RemoveLastKnownUserConstraint" />
-    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20192.RemoveLastKnownUserConstraint" />
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
     <parameter id="date" value="2020-06-10" />
     <parameter id="obsoletedby" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
   </extension>
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="RemoveLastKnownUserConstraint20201">
     <parameter id="id" value="com.tle.core.institution.migration.v20201.RemoveLastKnownUserConstraint" />
-    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20201.RemoveLastKnownUserConstraint" />
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
     <parameter id="date" value="2020-06-10" />
     <parameter id="obsoletedby" value="com.tle.core.institution.migration.v20202.RemoveLastKnownUserConstraint" />
   </extension>


### PR DESCRIPTION
#2210 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Previous fix can still cause trouble.
For example, on unstable, `v20202` of this migration has been applied,  but `v20192` and `v20201` are never applied. So database does not have records for these two migrations. As a result, the migration task finds two new migrations  `v20192` and `v20201` and try to run them, but fails because we don't actually provide matched files (beans) for them.

The builds in previous PR were green because none of `v20192`, `v20201` and `v20202` exist in the database. I am still not 100% sure the logic behind. From my understanding, the migration task should have found three migrations to run and failed due to the same reason, but it actually did succeed...

But anyway, the solution is to make sure  `v20192` and `v20201` have an available bean in 2020.2.

Manually done testing includes:
1. from 2019.1 to the latest; 
2. from 2019.2.4 to the latest; 
3. from 2020.1.3 to the latest;
4. from 2020.2 which is a few commits behind the latest to the latest (most importantly, did not apply 2020.1.3 and 2019.2.4 before); 