### PR TITLE
Add support to REST Module for new Search term highlights 

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/SearchResult.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/SearchResult.mock.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
-import * as _ from "lodash";
+import { range } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 export const getEmptySearchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
@@ -309,7 +309,7 @@ export const getSearchResultsCustom = (
   start: 0,
   length: 10,
   available: numberOfResults,
-  results: _.range(numberOfResults).map((i) => ({
+  results: range(numberOfResults).map((i) => ({
     uuid: uuidv4(),
     name: `item ${i}`,
     version: 1,

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/SearchResult.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/SearchResult.mock.ts
@@ -16,15 +16,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as OEQ from "@openequella/rest-api-client";
+import * as _ from "lodash";
+import { v4 as uuidv4 } from "uuid";
 
-exports.getEmptySearchResult = {
+export const getEmptySearchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
   start: 0,
   length: 0,
   available: 0,
   results: [],
+  highlight: [],
 };
 
-exports.getSearchResult = {
+export const getSearchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
   start: 0,
   length: 10,
   available: 12,
@@ -296,11 +300,12 @@ exports.getSearchResult = {
       },
     },
   ],
+  highlight: [],
 };
 
-const { v4: uuidv4 } = require("uuid");
-const _ = require("lodash");
-exports.getSearchResultsCustom = (numberOfResults) => ({
+export const getSearchResultsCustom = (
+  numberOfResults: number
+): OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> => ({
   start: 0,
   length: 10,
   available: numberOfResults,

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResultList.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResultList.stories.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import {
   getEmptySearchResult as emptySearch,
   getSearchResult as singlePageSearch,
-} from "../../__mocks__/getSearchResult";
+} from "../../__mocks__/SearchResult.mock";
 import { defaultSearchOptions } from "../../tsrc/modules/SearchModule";
 import {
   SearchResultList,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
+import { getSearchResult } from "../../../__mocks__/SearchResult.mock";
 import { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
-import { getSearchResult } from "../../../__mocks__/getSearchResult";
 
 jest.mock("@openequella/rest-api-client");
 const mockedSearch = (OEQ.Search.search as jest.Mock<
-  Promise<OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>>
+  Promise<OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>>
 >).mockResolvedValue(getSearchResult);
 
 describe("SearchModule", () => {

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -34,7 +34,7 @@ import {
   getEmptySearchResult,
   getSearchResult,
   getSearchResultsCustom,
-} from "../../../__mocks__/getSearchResult";
+} from "../../../__mocks__/SearchResult.mock";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -102,11 +102,12 @@ export const defaultSearchOptions: SearchOptions = {
   searchAttachments: true,
 };
 
-export const defaultPagedSearchResult: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem> = {
+export const defaultPagedSearchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
   start: 0,
   length: 10,
   available: 10,
   results: [],
+  highlight: [],
 };
 
 /**
@@ -167,7 +168,7 @@ export const searchItems = ({
   searchAttachments,
   selectedCategories,
 }: SearchOptions): Promise<
-  OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
+  OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>
 > => {
   const processedQuery = query ? formatQuery(query, !rawMode) : undefined;
   const searchParams: OEQ.Search.SearchParams = {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -88,7 +88,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     (history.location.state as SearchPageOptions) ?? defaultSearchPageOptions
   );
   const [pagedSearchResult, setPagedSearchResult] = useState<
-    OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>
+    OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>
   >(defaultPagedSearchResult);
   const [showSpinner, setShowSpinner] = useState<boolean>(false);
   const [searchSettings, setSearchSettings] = useState<SearchSettings>();
@@ -140,7 +140,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const search = (): void => {
     setShowSpinner(true);
     searchItems(searchPageOptions)
-      .then((items: OEQ.Common.PagedResult<OEQ.Search.SearchResultItem>) => {
+      .then((items: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>) => {
         setPagedSearchResult(items);
         history.replace({ ...history.location, state: searchPageOptions });
         // scroll back up to the top of the page

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -240,6 +240,32 @@ export interface SearchResultItem {
   };
 }
 
+/**
+ * Represents the results for a search query.
+ */
+export interface SearchResult<T> {
+  /**
+   * The starting offset into the total search results
+   */
+  start: number;
+  /**
+   * How many results can be found in `results`
+   */
+  length: number;
+  /**
+   * The maximum number of results available for paging
+   */
+  available: number;
+  /**
+   * The individual items which match the search
+   */
+  results: T[];
+  /**
+   * List of words to use to highlight when displaying the results
+   */
+  highlight: string[];
+}
+
 const SEARCH2_API_PATH = '/search2';
 
 /**
@@ -251,14 +277,14 @@ const SEARCH2_API_PATH = '/search2';
 export const search = (
   apiBasePath: string,
   params?: SearchParams
-): Promise<Common.PagedResult<SearchResultItem>> => {
-  return GET<Common.PagedResult<SearchResultItem>>(
+): Promise<SearchResult<SearchResultItem>> => {
+  return GET<SearchResult<SearchResultItem>>(
     apiBasePath + SEARCH2_API_PATH,
-    (data): data is Common.PagedResult<SearchResultItem> =>
-      is<Common.PagedResult<SearchResultItem>>(data),
+    (data): data is SearchResult<SearchResultItem> =>
+      is<SearchResult<SearchResultItem>>(data),
     params,
     (data) =>
-      Utils.convertDateFields<Common.PagedResult<SearchResultItem>>(data, [
+      Utils.convertDateFields<SearchResult<SearchResultItem>>(data, [
         'createdDate',
         'modifiedDate',
       ])

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -47,7 +47,8 @@ describe('Search for items', () => {
     const searchResult = await doSearch(searchParams);
     const { uuid, status, collectionId } = searchResult.results[0];
 
-    expect(searchResult).toHaveLength(searchResult.results.length);
+    expect(searchResult.results).toHaveLength(searchResult.results.length);
+    expect(searchResult.highlight).toEqual([searchParams.query]);
     expect(uuid).toBeTruthy();
     // Status returned is in lowercase so have to convert to uppercase.
     expect(status.toUpperCase()).toBe<OEQ.Common.ItemStatus>(STATUS_LIVE);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This mainly adds support to `oeq-ts-rest-api` to support the new `highlight` array which comes back from the search2 endpoint. In doing this though I noticed the return type for `search` was the `Common.PagedResult<T>` which does not match the server - and even has the `resumptionToken` which search2 does not use.

So inline with the Server definition I also created a specialised interface (`SearchResult`), one that didn't have a `resumptionToken` and instead does have a `highlight[]`. I could have looked at changing `PagedResult` to have a base class without `resumptionToken` and build from there, however server side these are not related so it made no sense to build in that relationship this side of the fence.

Once that was also done I tweaked the front-end to use it. Interestingly, because the types structurally are very similar TS was happy and everything still worked. However if these diverge further in the future we want to make sure things line up. And to further support this I changed the mocked data to TS with types.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
