### PR TITLE
Feature/facet selector integration

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
@@ -89,13 +89,13 @@ describe("SearchModule", () => {
     it("should generate a where clause for one category", () => {
       const singleCategory = [selectedCategories[1]];
       expect(SearchModule.generateCategoryWhereQuery(singleCategory)).toBe(
-        "/xml/item/city='Hobart'"
+        "(/xml/item/city='Hobart')"
       );
     });
 
     it("should generate a where clause for multiple groups of categories", () => {
       expect(SearchModule.generateCategoryWhereQuery(selectedCategories)).toBe(
-        "/xml/item/language='Java' AND /xml/item/language='Scala' AND /xml/item/city='Hobart'"
+        "(/xml/item/language='Java' OR /xml/item/language='Scala') AND (/xml/item/city='Hobart')"
       );
     });
   });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
@@ -138,6 +138,9 @@ export const listCategories = async (
  * It is intended that this can be run alongside other search filters, and thereby provide
  * matching categories.
  *
+ * The where clause used for generating one Classification's category list should only include
+ * categories from other Classifications.
+ *
  * @param options The standard options used for searching, as these also filter the generated categories
  */
 export const listClassifications = async (
@@ -156,7 +159,6 @@ export const listClassifications = async (
         categories: await listCategories({
           ...convertSearchOptions(options),
           nodes: [settings.schemaNode],
-          // Only use categories of other Classifications to generate a where clause.
           where: generateCategoryWhereQuery(
             options.selectedCategories?.filter((c) => c.id !== settings.id)
           ),

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
@@ -93,7 +93,6 @@ const convertSearchOptions: (
       lastModifiedDateRange,
       owner,
       status,
-      selectedCategories,
       rawMode,
     } = options;
     let searchFacetsParams: OEQ.SearchFacets.SearchFacetsParams = {
@@ -106,7 +105,6 @@ const convertSearchOptions: (
         status?.sort(),
         OEQ.Common.ItemStatuses.alternatives.map((i) => i.value).sort()
       ),
-      where: generateCategoryWhereQuery(selectedCategories),
     };
     if (collections && collections.length > 0) {
       searchFacetsParams = {
@@ -158,6 +156,10 @@ export const listClassifications = async (
         categories: await listCategories({
           ...convertSearchOptions(options),
           nodes: [settings.schemaNode],
+          // Only use categories of other Classifications to generate a where clause.
+          where: generateCategoryWhereQuery(
+            options.selectedCategories?.filter((c) => c.id !== settings.id)
+          ),
         }),
         schemaNode: settings.schemaNode,
       })

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -123,7 +123,9 @@ export const formatQuery = (query: string, addWildcard: boolean): string => {
 };
 
 /**
- * Generates a Where clause for search. Each condition is linked by a AND.
+ * Generates a Where clause through Classifications.
+ * Each Classification that has categories selected is joined by AND.
+ * Each selected category of one Classification is joined by OR.
  *
  * @param selectedCategories A list of selected Categories grouped by Classification ID.
  */
@@ -136,13 +138,11 @@ export const generateCategoryWhereQuery = (
 
   const and = " AND ";
   const or = " OR ";
-  // Concatenate each selected category of one Classification by OR.
   const processNodeTerms = (
     categories: string[],
     schemaNode?: string
   ): string => categories.map((c) => `/xml${schemaNode}='${c}'`).join(or);
 
-  // Concatenate each Classification that has categories selected by AND.
   return selectedCategories
     .filter((c) => c.categories.length > 0)
     .map(

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -133,18 +133,21 @@ export const generateCategoryWhereQuery = (
   if (!selectedCategories || selectedCategories.length === 0) {
     return undefined;
   }
-  // Convert a list of categories into a list of where clause search conditions.
-  // The format is "node='category'".
+
+  const and = " AND ";
+  const or = " OR ";
+  // Concatenate each selected category of one Classification by OR.
   const processNodeTerms = (
     categories: string[],
     schemaNode?: string
-  ): string[] => categories.map((c) => `/xml${schemaNode}='${c}'`);
+  ): string => categories.map((c) => `/xml${schemaNode}='${c}'`).join(or);
 
-  const and = " AND ";
-  // Concatenate all search conditions with AND.
+  // Concatenate each Classification that has categories selected by AND.
   return selectedCategories
-    .flatMap(({ schemaNode, categories }: SelectedCategories) =>
-      processNodeTerms(categories, schemaNode)
+    .filter((c) => c.categories.length > 0)
+    .map(
+      ({ schemaNode, categories }: SelectedCategories) =>
+        `(${processNodeTerms(categories, schemaNode)})`
     )
     .join(and);
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -359,22 +359,25 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           <Grid item>
             <RefineSearchPanel controls={refinePanelControls} />
           </Grid>
-          {classifications.length > 0 && (
-            <Grid item>
-              <Card>
-                <CardContent>
-                  <Typography variant="h5">
-                    {languageStrings.searchpage.categorySelector.title}
-                  </Typography>
-                  <CategorySelector
-                    classifications={classifications}
-                    onSelectedCategoriesChange={handleSelectedCategoriesChange}
-                    selectedCategories={searchPageOptions.selectedCategories}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
-          )}
+          {classifications.length > 0 &&
+            classifications.some((c) => c.categories.length > 0) && (
+              <Grid item>
+                <Card>
+                  <CardContent>
+                    <Typography variant="h5">
+                      {languageStrings.searchpage.categorySelector.title}
+                    </Typography>
+                    <CategorySelector
+                      classifications={classifications}
+                      onSelectedCategoriesChange={
+                        handleSelectedCategoriesChange
+                      }
+                      selectedCategories={searchPageOptions.selectedCategories}
+                    />
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
         </Grid>
       </Grid>
     </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -359,20 +359,22 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           <Grid item>
             <RefineSearchPanel controls={refinePanelControls} />
           </Grid>
-          <Grid item>
-            <Card>
-              <CardContent>
-                <Typography variant="h5">
-                  {languageStrings.searchpage.categorySelector.title}
-                </Typography>
-                <CategorySelector
-                  classifications={classifications}
-                  onSelectedCategoriesChange={handleSelectedCategoriesChange}
-                  selectedCategories={searchPageOptions.selectedCategories}
-                />
-              </CardContent>
-            </Card>
-          </Grid>
+          {classifications.length > 0 && (
+            <Grid item>
+              <Card>
+                <CardContent>
+                  <Typography variant="h5">
+                    {languageStrings.searchpage.categorySelector.title}
+                  </Typography>
+                  <CategorySelector
+                    classifications={classifications}
+                    onSelectedCategoriesChange={handleSelectedCategoriesChange}
+                    selectedCategories={searchPageOptions.selectedCategories}
+                  />
+                </CardContent>
+              </Card>
+            </Grid>
+          )}
         </Grid>
       </Grid>
     </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CategorySelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CategorySelector.tsx
@@ -213,26 +213,29 @@ export const CategorySelector = ({
     const selectedTerms: string[] =
       selectedCategories?.find((c) => c.id === id)?.categories ?? [];
 
-    // Previously selected categories that still apply to current search criteria.
-    const selectedAndExist = categories.filter((c) =>
-      selectedTerms.includes(c.term)
+    // Generate two arrays for previously selected categories. One for those still
+    // applicable and the other one for those not applicable.
+    const [selectedApplicable, selectedNotApplicable] = selectedTerms.reduce<
+      [OEQ.SearchFacets.Facet[], OEQ.SearchFacets.Facet[]]
+    >(
+      ([applicable, notApplicable], term) => {
+        const applicableCategory = categories.find((c) => c.term === term);
+        return applicableCategory
+          ? [applicable.concat(applicableCategory), notApplicable]
+          : [applicable, notApplicable.concat({ term: term, count: 0 })];
+      },
+      [[], []]
     );
-
-    // Previously selected categories that do not apply to current search criteria.
-    // Their counts should be 0.
-    const selectedButDisappear = selectedTerms
-      .filter((t) => categories.every((c) => c.term !== t))
-      .map((t) => ({ term: t, count: 0 }));
 
     // Categories that apply to current search criteria but have not been selected.
-    const noSelected = categories.filter(
+    const notSelected = categories.filter(
       (c) => !selectedTerms.includes(c.term)
     );
-    // The concatenating order is selectedAndExist -> selectedButDisappear -> noSelected.
+    // The concatenating order is selectedApplicable -> selectedNotApplicable -> notSelected.
     const orderedFacets: OEQ.SearchFacets.Facet[] = [
-      ...selectedAndExist,
-      ...selectedButDisappear,
-      ...noSelected,
+      ...selectedApplicable,
+      ...selectedNotApplicable,
+      ...notSelected,
     ];
 
     return orderedFacets


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

According to the latest discussions, we want to refactor the Category Selector for below changes: 
1. Each Classification is joined by `AND`; 
2. Each category of a Classification is joined by `OR`; 
3. Selected categories that do not apply to current search criteria are still displayed and their counts are 0 so that users can deselect them;
4. To generate a where clause for updating one Classification, only categories selected from other Classifications are used.
4. The Classification panel do not show if all Classifications do not have categories for selecting.