### PR TITLE
bugfix/old-ui-option-do-not-persist

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
@@ -59,14 +59,9 @@ import "tinymce/plugins/toc";
 import "tinymce/plugins/visualblocks";
 import "tinymce/plugins/visualchars";
 import "tinymce/plugins/wordcount";
+import { RenderData } from "../mainui";
 
-declare const renderData:
-  | {
-      baseResources: string;
-      newUI: boolean;
-      autotestMode: boolean;
-    }
-  | undefined;
+declare const renderData: RenderData | undefined;
 
 // from https://github.com/tinymce/tinymce/blob/26b948ac85b75991ab9e50d0affdf4f5c0b34f65/modules/tinymce/src/core/main/ts/api/file/BlobCache.ts#L31-L39
 export interface BlobInfo {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
@@ -59,7 +59,7 @@ import "tinymce/plugins/toc";
 import "tinymce/plugins/visualblocks";
 import "tinymce/plugins/visualchars";
 import "tinymce/plugins/wordcount";
-import { RenderData } from "../mainui";
+import type { RenderData } from "../mainui";
 
 declare const renderData: RenderData | undefined;
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -31,6 +31,7 @@ import {
   LegacyContentProps,
 } from "../legacycontent/LegacyContent";
 import { LegacyContentRenderer } from "../legacycontent/LegacyContentRenderer";
+import type { RenderData } from "./index";
 
 interface LegacyPageProps extends TemplateUpdateProps {
   location: Location;
@@ -44,6 +45,7 @@ interface LegacyPageProps extends TemplateUpdateProps {
       cb: (p: LegacyContentProps) => LegacyContentProps
     ) => void;
   };
+  renderData?: RenderData;
 }
 
 export function templatePropsForLegacy({
@@ -78,9 +80,17 @@ export const LegacyPage = React.memo(
     updateTemplate,
     setPreventNavigation,
     redirect,
+    renderData,
   }: LegacyPageProps) => {
     const { content } = legacyContent;
     const shouldPreventNav = content ? content.preventUnload : false;
+
+    // If New UI is actually not enabled then reload the page to display Old UI.
+    React.useEffect(() => {
+      if (renderData && !renderData.newUI) {
+        window.location.reload();
+      }
+    }, []);
 
     React.useEffect(() => {
       if (content) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -53,12 +53,12 @@ const baseFullPath = new URL(document.head.getElementsByTagName("base")[0].href)
   .pathname;
 const basePath = baseFullPath.substr(0, baseFullPath.length - 1);
 
-declare const renderData:
-  | {
-      baseResources: string;
-      newUI: boolean;
-    }
-  | undefined;
+export interface RenderData {
+  baseResources: string;
+  newUI: boolean;
+  autotestMode: boolean;
+}
+declare const renderData: RenderData | undefined;
 
 const beforeunload = function (e: Event) {
   e.returnValue = ("Are you sure?" as unknown) as boolean;
@@ -180,6 +180,7 @@ function IndexPage() {
               {...mkRouteProps(p)}
               errorCallback={errorCallback}
               legacyContent={{ content, setLegacyContentProps }}
+              renderData={renderData}
             />
           )}
         />


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

When New UI is turned off, if users open any `tsx` page they will see New UI. We want to ensure they can still go back to Old UI if they open any legacy page.

The fix requires both back-end and front-end changes. The back-end change is made in `RenderNewTemplate`. This will ensure the value of `newui` included in `renderData` is correct.
The front-end change consisits of a new type for `renderData` and a new usage of `useEffect` in `LegacyPage.tsx` which may or may not reload the page, depending on `renderData`.
