### PR TITLE
Move Date Range to SearchModule.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -27,7 +27,7 @@ import {
   KeyboardDatePicker,
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
-import { DateRange } from "../modules/SearchModule";
+import type { DateRange } from "../modules/SearchModule";
 import SettingsToggleSwitch from "./SettingsToggleSwitch";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { languageStrings } from "../util/langstrings";

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -27,25 +27,12 @@ import {
   KeyboardDatePicker,
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
+import { DateRange } from "../modules/SearchModule";
 import SettingsToggleSwitch from "./SettingsToggleSwitch";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { languageStrings } from "../util/langstrings";
 import LuxonUtils from "@date-io/luxon";
 import { DateTime } from "luxon";
-
-/**
- * Type of date range.
- */
-export interface DateRange {
-  /**
-   * The start date of a date range.
-   */
-  start?: Date;
-  /**
-   * The end date of a date range.
-   */
-  end?: Date;
-}
 
 interface DatePickerProps {
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -20,7 +20,6 @@ import { API_BASE_URL } from "../config";
 import { SelectedCategories } from "./SearchFacetsModule";
 import { SortOrder } from "./SearchSettingsModule";
 import { Collection } from "./CollectionsModule";
-import { DateRange } from "../components/DateRangeSelector";
 import { getISODateString } from "../util/Date";
 
 /**
@@ -72,6 +71,20 @@ export interface SearchOptions {
    * Whether to search attachments or not.
    */
   searchAttachments?: boolean;
+}
+
+/**
+ * Represent a date range which has an optional start and end.
+ */
+export interface DateRange {
+  /**
+   * The start date of a date range.
+   */
+  start?: Date;
+  /**
+   * The end date of a date range.
+   */
+  end?: Date;
 }
 
 /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -35,6 +35,7 @@ import {
   defaultSearchOptions,
   searchItems,
   SearchOptions,
+  DateRange,
 } from "../modules/SearchModule";
 import SearchBar from "../search/components/SearchBar";
 import * as OEQ from "@openequella/rest-api-client";
@@ -54,7 +55,7 @@ import { SearchResultList } from "./components/SearchResultList";
 import { CollectionSelector } from "./components/CollectionSelector";
 import { Collection } from "../modules/CollectionsModule";
 import { useHistory } from "react-router";
-import { DateRange, DateRangeSelector } from "../components/DateRangeSelector";
+import { DateRangeSelector } from "../components/DateRangeSelector";
 import OwnerSelector from "./components/OwnerSelector";
 import StatusSelector from "./components/StatusSelector";
 


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Move the definition of type `Date Range` to `SearchModule` to reduce coupling between business layer and front-end.