### PR TITLE
ci(github-actions): use actions setup node with nvmrc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
       - stable-*
       - component/**
     tags:
-      - '**'
+      - "**"
   pull_request:
     branches:
       - master
@@ -50,17 +50,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ivy-
 
-      - name: Set up NVM
-        shell: bash -l {0}
-        run: |
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-          export NVM_DIR="$HOME/.nvm"
-          echo "source $NVM_DIR/nvm.sh" >> "$HOME/.bash_profile"
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
 
-      - name: Install NodeJS
-        shell: bash -l {0}
-        run: |
-          nvm install
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -68,41 +65,34 @@ jobs:
           java-version: 1.8
 
       - name: Install node dependencies (core)
-        shell: bash -l -eo pipefail {0}
-        working-directory: Source/Plugins/Core/com.equella.core/js 
+        working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
           npm ci
 
       - name: Install node dependencies (IntegTester)
-        shell: bash -l -eo pipefail {0}
         working-directory: autotest/IntegTester/ps
         run: |
           npm ci
 
       - name: Install node dependencies (root)
-        shell: bash -l -eo pipefail {0}
         run: |
           npm ci
 
       - name: Run checks
-        shell: bash -l -eo pipefail {0}
         run: |
           npm run check
           ./sbt headerCheck checkJavaCodeStyle
 
       - name: Run unit tests (java/scala)
-        shell: bash -l -eo pipefail {0}
         run: |
           ./sbt test
 
       - name: Run unit tests (javascript)
-        shell: bash -l -eo pipefail {0}
-        working-directory: Source/Plugins/Core/com.equella.core/js 
+        working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
           npm cit
 
       - name: Build primary artefacts
-        shell: bash -l -eo pipefail {0}
         run: |
           ./sbt installerZip writeLanguagePack writeScriptingJavadoc
 
@@ -197,7 +187,7 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: Artefacts
- 
+
       - name: Extract installer from build
         env:
           DOWNLOAD_DIR: Artefacts


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

leverages github actions setup-node to remove need for `shell: bash -l -eo pipefail {0}`

based off https://github.com/actions/setup-node/issues/32#issuecomment-539794249

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
