### PR TITLE
EBP: User Preferences Page styles

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -42,6 +42,7 @@
 @import "whereclause.css";
 @import "myresourcecontribute.css";
 @import "htmleditorwebcontrol.css";
+@import "userdetails.css";
 
 $small-breakpoint-max: "768px";
 $medium-breakpoint-max: "1200px";
@@ -5218,4 +5219,62 @@ button:focus {
   p {
     margin-left: 0;
   }
+}
+
+// User preferences page styling
+#editUser p {
+  @include typography-body-1;
+  margin-left: 0;
+}
+
+#editUser .edit h3 {
+  @include typography-headline-6;
+  color: $secondaryColor;
+}
+
+#editUser .edit:last-child,
+#editUser .edit:nth-last-child(2) {
+  h3 {
+    padding-top: $doubleMargin * 2;
+  }
+  p {
+    @include typography-body-1;
+  }
+}
+
+.profile-save-button,
+.change-pass-button {
+  @include buttonShadowBorder;
+  width: 250px;
+}
+
+.user-details #col2 {
+  width: 250px;
+  margin: 0 $doubleMargin;
+}
+#editUser.area .edit.double .input.text {
+  height: 100px;
+  width: 510px;
+}
+
+#ed_fan {
+  margin-left: $singleMargin;
+}
+
+#ed_em {
+  width: 495px;
+}
+
+.itemdefs_container {
+  padding: $singleMargin;
+
+  input {
+    padding: $singleMargin;
+  }
+  label {
+    margin: $singleMargin;
+  }
+}
+.newListSelected .newList {
+  padding-bottom: $doubleMargin;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5230,73 +5230,76 @@ button:focus {
 }
 
 // User preferences page styling
-#editUser p {
-  @include typography-body-1;
-  margin-left: 0;
-}
 
-#editUser .edit h3 {
-  @include typography-headline-6;
-  color: $secondaryColor;
-}
-
-#editUser .edit:last-child,
-#editUser .edit:nth-last-child(2) {
-  h3 {
-    padding-top: $doubleMargin * 2;
-  }
+#editUser {
   p {
     @include typography-body-1;
+    margin-left: 0;
   }
-}
 
-.profile-save-button,
-.change-pass-button {
-  @include buttonShadowBorder;
-  width: 250px;
+  .edit h3 {
+    @include typography-headline-6;
+    color: $secondaryColor;
+  }
+
+  .edit.double .input.text {
+    height: 100px;
+    width: 510px;
+  }
+
+  .edit:last-child,
+  .edit:nth-last-child(2) {
+    h3 {
+      padding-top: $doubleMargin * 2;
+    }
+  }
+
+  #ed_fan {
+    margin-left: $singleMargin;
+  }
+
+  #ed_em {
+    width: 495px;
+  }
+
+  .itemdefs_container {
+    padding: $singleMargin;
+    border-radius: 3px;
+
+    li {
+      display: flex;
+      padding-bottom: $singleMargin;
+    }
+
+    input {
+      padding: $singleMargin;
+    }
+
+    label {
+      height: auto;
+      padding-left: $doubleMargin;
+    }
+  }
+
+  hr {
+    @include muiBorder;
+  }
+
+  .input.checkbox {
+    display: flex;
+  }
 }
 
 .user-details #col2 {
   width: 250px;
   margin: 0 $doubleMargin;
-}
-#editUser.area .edit.double .input.text {
-  height: 100px;
-  width: 510px;
-}
-
-#ed_fan {
-  margin-left: $singleMargin;
-}
-
-#ed_em {
-  width: 495px;
-}
-
-.itemdefs_container {
-  padding: $singleMargin;
-  border-radius: 3px;
-
-  li {
-    display: flex;
-    padding-bottom: $singleMargin;
-  }
-  input {
-    padding: $singleMargin;
-  }
-  label {
-    height: auto;
-    padding-left: $doubleMargin;
+  .profile-save-button,
+  .change-pass-button {
+    @include buttonShadowBorder;
+    width: 250px;
   }
 }
 
 .newListSelected .newList {
   padding-bottom: $doubleMargin;
-}
-
-#editUser hr {
-  @include muiBorder;
-}
-#editUser .input.checkbox {
-  display: flex;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1592,7 +1592,7 @@ Alerts
 *****************************************************************************/
 
 .alert {
-  border-radius: 4px;
+  @include curvedCorners;
   padding: 14px 35px 8px 35px;
   background-color: #fcf8e3;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -65,6 +65,14 @@ $doubleMargin: 16px;
   border-radius: 4px;
   border: none;
 }
+
+@mixin muiBorder {
+  border: none;
+  height: 1px;
+  margin: 0;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
 @mixin hoverHighlight {
   &:hover {
     background-color: $hoverBackgroundColor;
@@ -5275,6 +5283,11 @@ button:focus {
     margin: $singleMargin;
   }
 }
+
 .newListSelected .newList {
   padding-bottom: $doubleMargin;
+}
+
+#editUser hr {
+  @include muiBorder;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5275,12 +5275,18 @@ button:focus {
 
 .itemdefs_container {
   padding: $singleMargin;
+  border-radius: 3px;
 
+  li {
+    display: flex;
+    padding-bottom: $singleMargin;
+  }
   input {
     padding: $singleMargin;
   }
   label {
-    margin: $singleMargin;
+    height: auto;
+    padding-left: $doubleMargin;
   }
 }
 
@@ -5290,4 +5296,7 @@ button:focus {
 
 #editUser hr {
   @include muiBorder;
+}
+#editUser .input.checkbox {
+  display: flex;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -60,9 +60,16 @@ $doubleMargin: 16px;
   -moz-box-shadow: $boxShadow;
   -webkit-box-shadow: $boxShadow;
 }
+
+@mixin curvedCorners {
+  border-radius: 4px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+}
+
 @mixin buttonShadowBorder {
   @include boxShadow;
-  border-radius: 4px;
+  @include curvedCorners;
   border: none;
 }
 
@@ -359,6 +366,7 @@ Buttons
 *****************************************************************************/
 
 .btn {
+  @include curvedCorners;
   padding: 0 8px 0 8px;
   display: inline-flex;
   position: relative;
@@ -367,7 +375,6 @@ Buttons
   box-sizing: border-box;
   min-width: 64px;
   border: none;
-  border-radius: 4px;
   outline: none;
   cursor: pointer;
   background-color: $primaryColor;
@@ -383,8 +390,8 @@ Buttons
 }
 
 .button-expandable {
+  @include curvedCorners;
   font-size: 0;
-  border-radius: 4px;
   &:hover {
     @include typography-button();
   }
@@ -484,15 +491,12 @@ select[multiple="multiple"] {
 }
 
 .modal-search-result.youtube img {
+  @include curvedCorners;
   margin: 0 20px 10px 0;
   padding: 4px;
   background: #fff;
   border: 1px solid #ddd;
   float: left;
-  -moz-border-radius: 3px;
-  -webkit-border-radius: 3px;
-  -o-border-radius: 3px;
-  border-radius: 3px;
 }
 
 .modal-search-result.youtube input {
@@ -1588,11 +1592,9 @@ Alerts
 *****************************************************************************/
 
 .alert {
+  border-radius: 4px;
   padding: 14px 35px 8px 35px;
   background-color: #fcf8e3;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   position: fixed;
   color: white;
@@ -4274,15 +4276,11 @@ img.warningimg {
 }
 
 .universalresources .progress-bar {
+  @include curvedCorners;
   width: 200px;
   height: 14px;
   border: 1px solid #aaa;
   margin: 0 10px 0 0;
-
-  -moz-border-radius: 3px;
-  -o-border-radius: 3px;
-  -webkit-border-radius: 3px;
-  border-radius: 3px;
   float: right;
 }
 
@@ -5249,6 +5247,7 @@ button:focus {
 
   .edit:last-child,
   .edit:nth-last-child(2) {
+    //the last two edit sections on the page - needs an extra margin because of the drop downs
     h3 {
       padding-top: $doubleMargin * 2;
     }
@@ -5263,8 +5262,8 @@ button:focus {
   }
 
   .itemdefs_container {
+    @include curvedCorners;
     padding: $singleMargin;
-    border-radius: 3px;
 
     li {
       display: flex;
@@ -5290,13 +5289,15 @@ button:focus {
   }
 }
 
+$col2Width: 250px;
+
 .user-details #col2 {
-  width: 250px;
+  width: $col2Width;
   margin: 0 $doubleMargin;
   .profile-save-button,
   .change-pass-button {
     @include buttonShadowBorder;
-    width: 250px;
+    width: $col2Width;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#1983 
- Save and Change password buttons padding and shadow fix
- First and last name alignment
- Timezone/Language section alignment
- Checkbox padding and alignment
- Header size and font aligns with other new stuff (I.E contribution page)
- Uses MUI theme colours
- Added padding to expanded dropdowns when they are at the bottom of a page
- Change dividers to use MuiDivider styles
- border radius for the watched collections box
![Peek 2020-09-16 17-24](https://user-images.githubusercontent.com/24543345/93305217-8bc92780-f841-11ea-8121-ccbaafde0489.gif)
![image](https://user-images.githubusercontent.com/24543345/93305322-ae5b4080-f841-11ea-9854-ac9f670d3d8b.png)
![image](https://user-images.githubusercontent.com/24543345/93305377-c4690100-f841-11ea-8ad8-04f3b8135d56.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
