### PR TITLE
Make Old UI persist for settings page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -44,7 +44,7 @@ interface LegacyPageProps extends TemplateUpdateProps {
       cb: (p: LegacyContentProps) => LegacyContentProps
     ) => void;
   };
-  reloadNeeded: boolean;
+  isReloadNeeded: boolean;
 }
 
 export function templatePropsForLegacy({
@@ -79,14 +79,14 @@ export const LegacyPage = React.memo(
     updateTemplate,
     setPreventNavigation,
     redirect,
-    reloadNeeded,
+    isReloadNeeded,
   }: LegacyPageProps) => {
     const { content } = legacyContent;
     const shouldPreventNav = content ? content.preventUnload : false;
 
     // If New UI is actually not enabled then reload the page to display Old UI.
     React.useEffect(() => {
-      if (reloadNeeded) {
+      if (isReloadNeeded) {
         window.location.reload();
       }
     }, []);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -31,7 +31,6 @@ import {
   LegacyContentProps,
 } from "../legacycontent/LegacyContent";
 import { LegacyContentRenderer } from "../legacycontent/LegacyContentRenderer";
-import type { RenderData } from "./index";
 
 interface LegacyPageProps extends TemplateUpdateProps {
   location: Location;
@@ -45,7 +44,7 @@ interface LegacyPageProps extends TemplateUpdateProps {
       cb: (p: LegacyContentProps) => LegacyContentProps
     ) => void;
   };
-  renderData?: RenderData;
+  reloadNeeded: boolean;
 }
 
 export function templatePropsForLegacy({
@@ -80,14 +79,14 @@ export const LegacyPage = React.memo(
     updateTemplate,
     setPreventNavigation,
     redirect,
-    renderData,
+    reloadNeeded,
   }: LegacyPageProps) => {
     const { content } = legacyContent;
     const shouldPreventNav = content ? content.preventUnload : false;
 
     // If New UI is actually not enabled then reload the page to display Old UI.
     React.useEffect(() => {
-      if (renderData && !renderData.newUI) {
+      if (reloadNeeded) {
         window.location.reload();
       }
     }, []);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -131,6 +131,7 @@ function IndexPage() {
       refreshUser,
       redirect: p.history.push,
       setPreventNavigation,
+      reloadNeeded: !renderData?.newUI, // Indicate that new UI is displayed but not enabled.
     };
   }
 
@@ -180,7 +181,6 @@ function IndexPage() {
               {...mkRouteProps(p)}
               errorCallback={errorCallback}
               legacyContent={{ content, setLegacyContentProps }}
-              renderData={renderData}
             />
           )}
         />
@@ -269,7 +269,12 @@ export default function () {
     ReactDOM.render(
       <BrowserRouter basename={basePath} forceRefresh>
         <ThemeProvider theme={oeqTheme}>
-          <SettingsPage refreshUser={() => {}} updateTemplate={() => {}} />
+          {/* Opening Settings page in Old UI does not required reloading the page.*/}
+          <SettingsPage
+            refreshUser={() => {}}
+            updateTemplate={() => {}}
+            reloadNeeded={false}
+          />
         </ThemeProvider>
       </BrowserRouter>,
       document.getElementById("settingsPage")

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -131,7 +131,7 @@ function IndexPage() {
       refreshUser,
       redirect: p.history.push,
       setPreventNavigation,
-      reloadNeeded: !renderData?.newUI, // Indicate that new UI is displayed but not enabled.
+      isReloadNeeded: !renderData?.newUI, // Indicate that new UI is displayed but not enabled.
     };
   }
 
@@ -273,7 +273,7 @@ export default function () {
           <SettingsPage
             refreshUser={() => {}}
             updateTemplate={() => {}}
-            reloadNeeded={false}
+            isReloadNeeded={false}
           />
         </ThemeProvider>
       </BrowserRouter>,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -37,6 +37,7 @@ export interface OEQRouteComponentProps<T = any>
   redirect(to: LocationDescriptor): void;
   setPreventNavigation(b: boolean): void;
   refreshUser(): void;
+  reloadNeeded: boolean;
 }
 
 export interface OEQRoute {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -37,7 +37,7 @@ export interface OEQRouteComponentProps<T = any>
   redirect(to: LocationDescriptor): void;
   setPreventNavigation(b: boolean): void;
   refreshUser(): void;
-  reloadNeeded: boolean;
+  isReloadNeeded: boolean;
 }
 
 export interface OEQRoute {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -65,14 +65,25 @@ const useStyles = makeStyles((theme: Theme) => {
 
 interface SettingsPageProps extends TemplateUpdateProps {
   refreshUser: () => void;
+  reloadNeeded: boolean;
 }
 
-const SettingsPage = ({ refreshUser, updateTemplate }: SettingsPageProps) => {
+const SettingsPage = ({
+  refreshUser,
+  updateTemplate,
+  reloadNeeded,
+}: SettingsPageProps) => {
   const classes = useStyles();
 
   const [adminDialogOpen, setAdminDialogOpen] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [settingGroups, setSettingGroups] = useState<SettingGroup[]>([]);
+
+  React.useEffect(() => {
+    if (reloadNeeded) {
+      window.location.reload();
+    }
+  }, []);
 
   useEffect(() => {
     updateTemplate(templateDefaults(languageStrings["com.equella.core"].title));

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -65,13 +65,13 @@ const useStyles = makeStyles((theme: Theme) => {
 
 interface SettingsPageProps extends TemplateUpdateProps {
   refreshUser: () => void;
-  reloadNeeded: boolean;
+  isReloadNeeded: boolean;
 }
 
 const SettingsPage = ({
   refreshUser,
   updateTemplate,
-  reloadNeeded,
+  isReloadNeeded,
 }: SettingsPageProps) => {
   const classes = useStyles();
 
@@ -80,7 +80,7 @@ const SettingsPage = ({
   const [settingGroups, setSettingGroups] = useState<SettingGroup[]>([]);
 
   React.useEffect(() => {
-    if (reloadNeeded) {
+    if (isReloadNeeded) {
       window.location.reload();
     }
   }, []);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/settings/menu/SettingsMenuContributor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/settings/menu/SettingsMenuContributor.java
@@ -25,6 +25,7 @@ import com.tle.web.sections.render.Label;
 import com.tle.web.sections.result.util.KeyLabel;
 import com.tle.web.sections.standard.model.HtmlLinkState;
 import com.tle.web.settings.SettingsList;
+import com.tle.web.template.RenderNewTemplate;
 import com.tle.web.template.section.AbstractUpdatableMenuContributor;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +56,15 @@ public class SettingsMenuContributor extends AbstractUpdatableMenuContributor {
       hls.setLabel(LABEL_KEY);
 
       MenuContribution mc =
-          new MenuContribution(hls, ICON_PATH, 30, 30, "settings", "/page/settings");
+          new MenuContribution(
+              hls,
+              ICON_PATH,
+              30,
+              30,
+              "settings",
+              // If New UI is off the route can be null here because LegacyContentApi
+              // will update the route to be '/access/settings.do'.
+              RenderNewTemplate.isNewUIEnabled() ? "/page/settings" : null);
       mcs.add(mc);
     }
 


### PR DESCRIPTION

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Previous fix does not work for the Settings page because this page isn't a Legacy page. The new fix in this PR can ensure Old UI  persists for both Settings page and Legacy pages.