### PR TITLE
Highlight search terms in the results

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/SearchResult.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/SearchResult.mock.ts
@@ -329,4 +329,5 @@ export const getSearchResultsCustom = (
         "http://localhost:8080/rest/api/item/266bb0ff-a730-4658-aec0-c68bbefc227c/1/",
     },
   })),
+  highlight: [],
 });

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
@@ -15,131 +15,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as OEQ from "@openequella/rest-api-client";
+import type { Story } from "@storybook/react";
 import * as React from "react";
 import * as mockData from "../../__mocks__/searchresult_mock_data";
 import SearchResult from "../../tsrc/search/components/SearchResult";
-import { boolean, number, object, text } from "@storybook/addon-knobs";
 
 export default {
   title: "Search/SearchResult",
   component: SearchResult,
 };
-const defaultItemName = "Item Name";
-const defaultItemDescription = "Item Description";
 
-export const BasicSearchResultComponent = () => (
-  <SearchResult
-    name={text("name", mockData.basicSearchObj.name || defaultItemName)}
-    version={number("version", mockData.basicSearchObj.version)}
-    uuid={text("uuid", mockData.basicSearchObj.uuid)}
-    description={text(
-      "description",
-      mockData.basicSearchObj.description || defaultItemDescription
-    )}
-    displayFields={object("display fields", [
-      ...mockData.basicSearchObj.displayFields,
-    ])}
-    modifiedDate={object("modified date", mockData.basicSearchObj.modifiedDate)}
-    createdDate={object("created date", mockData.basicSearchObj.createdDate)}
-    status={text("item status", mockData.basicSearchObj.status)}
-    displayOptions={object(
-      "display options",
-      mockData.basicSearchObj.displayOptions
-    )}
-    attachments={object("attachments", [
-      ...mockData.basicSearchObj.attachments,
-    ])}
-    links={object("links", mockData.basicSearchObj.links)}
-    collectionId={text("collection ID", mockData.basicSearchObj.collectionId)}
-    commentCount={number("comment count", mockData.basicSearchObj.commentCount)}
-    thumbnail={text("thumbnail", mockData.basicSearchObj.thumbnail)}
-    keywordFoundInAttachment={boolean(
-      "keywordFoundInAttachment",
-      mockData.basicSearchObj.keywordFoundInAttachment
-    )}
-  />
+export const BasicSearchResult: Story<OEQ.Search.SearchResultItem> = (args) => (
+  <SearchResult {...args} />
 );
+BasicSearchResult.args = {
+  ...mockData.basicSearchObj,
+};
 
-export const AttachmentSearchResultComponent = () => (
-  <SearchResult
-    name={text("name", mockData.attachSearchObj.name || defaultItemName)}
-    version={number("version", mockData.attachSearchObj.version)}
-    uuid={text("uuid", mockData.attachSearchObj.uuid)}
-    description={text(
-      "description",
-      mockData.attachSearchObj.description || defaultItemDescription
-    )}
-    displayFields={object("display fields", [
-      ...mockData.attachSearchObj.displayFields,
-    ])}
-    modifiedDate={object(
-      "modified date",
-      mockData.attachSearchObj.modifiedDate
-    )}
-    createdDate={object("created date", mockData.attachSearchObj.createdDate)}
-    status={text("item status", mockData.attachSearchObj.status)}
-    displayOptions={object(
-      "display options",
-      mockData.attachSearchObj.displayOptions
-    )}
-    attachments={object("attachments", [
-      ...mockData.attachSearchObj.attachments,
-    ])}
-    links={object("links", mockData.attachSearchObj.links)}
-    collectionId={text("collection ID", mockData.attachSearchObj.collectionId)}
-    commentCount={number(
-      "comment count",
-      mockData.attachSearchObj.commentCount
-    )}
-    thumbnail={text("thumbnail", mockData.attachSearchObj.thumbnail)}
-    keywordFoundInAttachment={boolean(
-      "keywordFoundInAttachment",
-      mockData.basicSearchObj.keywordFoundInAttachment
-    )}
-  />
-);
+export const AttachmentSearchResult: Story<OEQ.Search.SearchResultItem> = (
+  args
+) => <SearchResult {...args} />;
+AttachmentSearchResult.args = {
+  ...mockData.attachSearchObj,
+};
 
-export const CustomMetadataSearchResultComponent = () => (
-  <SearchResult
-    name={text("name", mockData.customMetaSearchObj.name || defaultItemName)}
-    version={number("version", mockData.customMetaSearchObj.version)}
-    uuid={text("uuid", mockData.customMetaSearchObj.uuid)}
-    description={text(
-      "description",
-      mockData.customMetaSearchObj.description || defaultItemDescription
-    )}
-    displayFields={object("display fields", [
-      ...mockData.customMetaSearchObj.displayFields,
-    ])}
-    modifiedDate={object(
-      "modified date",
-      mockData.customMetaSearchObj.modifiedDate
-    )}
-    createdDate={object(
-      "created date",
-      mockData.customMetaSearchObj.createdDate
-    )}
-    status={text("item status", mockData.customMetaSearchObj.status)}
-    displayOptions={object(
-      "display options",
-      mockData.customMetaSearchObj.displayOptions
-    )}
-    attachments={object("attachments", [
-      ...mockData.customMetaSearchObj.attachments,
-    ])}
-    links={object("links", mockData.customMetaSearchObj.links)}
-    collectionId={text(
-      "collection ID",
-      mockData.customMetaSearchObj.collectionId
-    )}
-    commentCount={number(
-      "comment count",
-      mockData.customMetaSearchObj.commentCount
-    )}
-    thumbnail={text("thumbnail", mockData.customMetaSearchObj.thumbnail)}
-    keywordFoundInAttachment={boolean(
-      "keywordFoundInAttachment",
-      mockData.basicSearchObj.keywordFoundInAttachment
-    )}
-  />
-);
+export const KeywordFoundInAttachmentSearchResult: Story<OEQ.Search.SearchResultItem> = (
+  args
+) => <SearchResult {...args} />;
+KeywordFoundInAttachmentSearchResult.args = {
+  ...mockData.attachSearchObj,
+  keywordFoundInAttachment: true,
+};
+
+export const CustomMetadataSearchResult: Story<OEQ.Search.SearchResultItem> = (
+  args
+) => <SearchResult {...args} />;
+CustomMetadataSearchResult.args = {
+  ...mockData.customMetaSearchObj,
+  keywordFoundInAttachment: false,
+};

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
@@ -31,9 +31,7 @@ export const BasicSearchResult: Story<SearchResultProps> = (args) => (
   <SearchResult {...args} />
 );
 BasicSearchResult.args = {
-  item: {
-    ...mockData.basicSearchObj,
-  },
+  item: mockData.basicSearchObj,
   highlights: [],
 };
 
@@ -42,7 +40,7 @@ export const AttachmentSearchResult: Story<SearchResultProps> = (args) => (
 );
 AttachmentSearchResult.args = {
   ...BasicSearchResult.args,
-  item: { ...mockData.attachSearchObj },
+  item: mockData.attachSearchObj,
 };
 
 export const KeywordFoundInAttachmentSearchResult: Story<SearchResultProps> = (

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
@@ -15,43 +15,64 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as OEQ from "@openequella/rest-api-client";
 import type { Story } from "@storybook/react";
 import * as React from "react";
 import * as mockData from "../../__mocks__/searchresult_mock_data";
-import SearchResult from "../../tsrc/search/components/SearchResult";
+import SearchResult, {
+  SearchResultProps,
+} from "../../tsrc/search/components/SearchResult";
 
 export default {
   title: "Search/SearchResult",
   component: SearchResult,
 };
 
-export const BasicSearchResult: Story<OEQ.Search.SearchResultItem> = (args) => (
+export const BasicSearchResult: Story<SearchResultProps> = (args) => (
   <SearchResult {...args} />
 );
 BasicSearchResult.args = {
-  ...mockData.basicSearchObj,
+  item: {
+    ...mockData.basicSearchObj,
+  },
+  highlights: [],
 };
 
-export const AttachmentSearchResult: Story<OEQ.Search.SearchResultItem> = (
-  args
-) => <SearchResult {...args} />;
+export const AttachmentSearchResult: Story<SearchResultProps> = (args) => (
+  <SearchResult {...args} />
+);
 AttachmentSearchResult.args = {
-  ...mockData.attachSearchObj,
+  ...BasicSearchResult.args,
+  item: { ...mockData.attachSearchObj },
 };
 
-export const KeywordFoundInAttachmentSearchResult: Story<OEQ.Search.SearchResultItem> = (
+export const KeywordFoundInAttachmentSearchResult: Story<SearchResultProps> = (
   args
 ) => <SearchResult {...args} />;
 KeywordFoundInAttachmentSearchResult.args = {
-  ...mockData.attachSearchObj,
-  keywordFoundInAttachment: true,
+  ...BasicSearchResult.args,
+  item: { ...mockData.attachSearchObj, keywordFoundInAttachment: true },
 };
 
-export const CustomMetadataSearchResult: Story<OEQ.Search.SearchResultItem> = (
-  args
-) => <SearchResult {...args} />;
+export const CustomMetadataSearchResult: Story<SearchResultProps> = (args) => (
+  <SearchResult {...args} />
+);
 CustomMetadataSearchResult.args = {
-  ...mockData.customMetaSearchObj,
-  keywordFoundInAttachment: false,
+  ...BasicSearchResult.args,
+  item: {
+    ...mockData.customMetaSearchObj,
+    keywordFoundInAttachment: false,
+  },
+};
+
+export const HighlightedSearchResult: Story<SearchResultProps> = (args) => (
+  <SearchResult {...args} />
+);
+HighlightedSearchResult.args = {
+  item: {
+    ...mockData.basicSearchObj,
+    name: "The life of cats and dogs in the big city",
+    description:
+      "This is the story of a dog and a cat in the city, exploring what cats and dogs do when there are no people. (Using highlights [cat, dog*].)",
+  },
+  highlights: ["cat", "dog*"],
 };

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResultList.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResultList.stories.tsx
@@ -46,7 +46,7 @@ const sharedPaginationArgs = {
 
 export const EmptyResultListComponent: Story<SearchResultListProps> = (
   args
-) => <SearchResultList {...args}></SearchResultList>;
+) => <SearchResultList {...args} />;
 
 EmptyResultListComponent.args = {
   searchResultItems: emptySearch.results,
@@ -63,7 +63,7 @@ EmptyResultListComponent.args = {
 
 export const BasicSearchResultListComponent: Story<SearchResultListProps> = (
   args
-) => <SearchResultList {...args}></SearchResultList>;
+) => <SearchResultList {...args} />;
 
 BasicSearchResultListComponent.args = {
   ...EmptyResultListComponent.args,
@@ -72,11 +72,12 @@ BasicSearchResultListComponent.args = {
     ...sharedPaginationArgs,
     count: singlePageSearch.available,
   },
+  highlights: [],
 };
 
 export const LoadingSearchResultListComponent: Story<SearchResultListProps> = (
   args
-) => <SearchResultList {...args}></SearchResultList>;
+) => <SearchResultList {...args} />;
 
 LoadingSearchResultListComponent.args = {
   ...BasicSearchResultListComponent.args,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -29,7 +29,11 @@ describe("<SearchResult/>", () => {
     return render(
       //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error  because of the <Link/> tag within SearchResult
       <BrowserRouter>
-        <SearchResult {...itemResult} key={itemResult.uuid} />
+        <SearchResult
+          key={itemResult.uuid}
+          item={{ ...itemResult }}
+          highlights={[]}
+        />
       </BrowserRouter>
     );
   };

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -29,11 +29,7 @@ describe("<SearchResult/>", () => {
     return render(
       //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error  because of the <Link/> tag within SearchResult
       <BrowserRouter>
-        <SearchResult
-          key={itemResult.uuid}
-          item={{ ...itemResult }}
-          highlights={[]}
-        />
+        <SearchResult key={itemResult.uuid} item={itemResult} highlights={[]} />
       </BrowserRouter>
     );
   };

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/util/TextUtils.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/util/TextUtils.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { highlight } from "../../../tsrc/util/TextUtils";
+
+describe("Highlighting of Text", () => {
+  const className = "highlighted";
+  it.each([
+    [
+      "The quick brown fox jumps over the lazy dog",
+      ["The", "fox", "dog"],
+      `<span class="${className}">The</span> quick brown <span class="${className}">fox</span> jumps over <span class="${className}">the</span> lazy <span class="${className}">dog</span>`,
+    ],
+    [
+      "The life of kelpies explained",
+      ["kelp*"],
+      `The life of <span class="${className}">kelpies</span> explained`,
+    ],
+  ])(
+    "Produces a string containing the text highlighted with <span>s - %s",
+    (text, highlights, expected) => {
+      expect(highlight(text, highlights, className)).toEqual(expected);
+    }
+  );
+});

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -404,6 +404,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
                 onChange: handleSortOrderChanged,
               }}
               onClearSearchOptions={handleClearSearchOptions}
+              highlights={pagedSearchResult.highlight}
             />
           </Grid>
         </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -15,27 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import { SyntheticEvent } from "react";
-import Tooltip from "@material-ui/core/Tooltip";
-import { makeStyles } from "@material-ui/core/styles";
-import { languageStrings } from "../../util/langstrings";
-import ReactHtmlParser from "react-html-parser";
 import {
-  Divider,
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Badge,
+  Divider,
+  Grid,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
   Theme,
   Typography,
-  Grid,
-  Badge,
 } from "@material-ui/core";
-import { Date as DateDisplay } from "../../components/Date";
+import { makeStyles } from "@material-ui/core/styles";
+import Tooltip from "@material-ui/core/Tooltip";
 import {
   AttachFile,
   ExpandMore,
@@ -43,9 +38,15 @@ import {
   Search,
 } from "@material-ui/icons";
 import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { SyntheticEvent } from "react";
+import ReactHtmlParser from "react-html-parser";
 import { Link } from "react-router-dom";
-import { routes } from "../../mainui/routes";
+import { Date as DateDisplay } from "../../components/Date";
 import OEQThumb from "../../components/OEQThumb";
+import { routes } from "../../mainui/routes";
+import { languageStrings } from "../../util/langstrings";
+import { highlight } from "../../util/TextUtils";
 
 const useStyles = makeStyles((theme: Theme) => {
   return {
@@ -79,34 +80,51 @@ const useStyles = makeStyles((theme: Theme) => {
       color: theme.palette.secondary.main,
       borderRadius: "50%",
     },
+    highlight: {
+      color: theme.palette.secondary.main,
+    },
   };
 });
 
+export interface SearchResultProps {
+  /**
+   * The details of the items to display.
+   */
+  item: OEQ.Search.SearchResultItem;
+
+  /**
+   * The list of words which should be highlighted.
+   */
+  highlights: string[];
+}
+
 export default function SearchResult({
-  name,
-  version,
-  uuid,
-  description,
-  displayFields,
-  modifiedDate,
-  status,
-  displayOptions,
-  attachments,
-  keywordFoundInAttachment,
-  links,
-}: OEQ.Search.SearchResultItem) {
+  item: {
+    name,
+    version,
+    uuid,
+    description,
+    displayFields,
+    modifiedDate,
+    status,
+    displayOptions,
+    attachments,
+    keywordFoundInAttachment,
+  },
+  highlights,
+}: SearchResultProps) {
   const classes = useStyles();
 
   const searchResultStrings = languageStrings.searchpage.searchresult;
 
-  const [attachExapanded, setAttachExpanded] = React.useState(
+  const [attachExpanded, setAttachExpanded] = React.useState(
     displayOptions?.standardOpen ?? false
   );
 
   const handleAttachmentPanelClick = (event: SyntheticEvent) => {
     /** prevents the SearchResult onClick from firing when attachment panel is clicked */
     event.stopPropagation();
-    setAttachExpanded(!attachExapanded);
+    setAttachExpanded(!attachExpanded);
   };
 
   const itemMetadata = (
@@ -196,7 +214,7 @@ export default function SearchResult({
       return (
         <Accordion
           className={classes.attachmentExpander}
-          expanded={attachExapanded}
+          expanded={attachExpanded}
           onClick={(event) => handleAttachmentPanelClick(event)}
         >
           <AccordionSummary expandIcon={<ExpandMore />}>
@@ -217,8 +235,13 @@ export default function SearchResult({
     return null;
   };
 
+  const highlightField = (fieldValue: string) =>
+    ReactHtmlParser(highlight(fieldValue, highlights, classes.highlight));
+
   const itemLink = (
-    <Link to={routes.ViewItem.to(uuid, version)}>{name ?? uuid}</Link>
+    <Link to={routes.ViewItem.to(uuid, version)}>
+      {name ? highlightField(name) : uuid}
+    </Link>
   );
 
   return (
@@ -232,7 +255,7 @@ export default function SearchResult({
         secondary={
           <>
             <Typography className={classes.itemDescription}>
-              {description}
+              {highlightField(description ?? "")}
             </Typography>
             <List disablePadding>{customDisplayMetadata}</List>
             {generateAttachmentList()}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -15,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import * as OEQ from "@openequella/rest-api-client";
 import {
   Button,
   Card,
@@ -30,11 +28,13 @@ import {
   Tooltip,
   Typography,
 } from "@material-ui/core";
-import SearchOrderSelect, { SearchOrderSelectProps } from "./SearchOrderSelect";
-import { languageStrings } from "../../util/langstrings";
-import SearchResult from "./SearchResult";
 import { makeStyles } from "@material-ui/core/styles";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { languageStrings } from "../../util/langstrings";
+import SearchOrderSelect, { SearchOrderSelectProps } from "./SearchOrderSelect";
 import { SearchPagination, SearchPaginationProps } from "./SearchPagination";
+import SearchResult from "./SearchResult";
 
 const useStyles = makeStyles({
   transparentList: {
@@ -70,6 +70,10 @@ export interface SearchResultListProps {
    * Fired when the New search button is clicked.
    */
   onClearSearchOptions: () => void;
+  /**
+   * List of words which should be highlighted in the titles and descriptions of items.
+   */
+  highlights: string[];
 }
 
 /**
@@ -84,6 +88,7 @@ export const SearchResultList = ({
   orderSelectProps,
   paginationProps,
   onClearSearchOptions,
+  highlights,
 }: SearchResultListProps) => {
   const searchPageStrings = languageStrings.searchpage;
   const classes = useStyles();
@@ -92,7 +97,11 @@ export const SearchResultList = ({
    */
   const searchResults = searchResultItems.map(
     (item: OEQ.Search.SearchResultItem) => (
-      <SearchResult {...item} key={item.uuid} />
+      <SearchResult
+        key={item.uuid}
+        item={{ ...item }}
+        highlights={highlights}
+      />
     )
   );
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/TextUtils.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/TextUtils.ts
@@ -60,7 +60,29 @@ export const highlight = (
     return text;
   }
 
-  const re = new RegExp("^(.*?)\\b(" + highlightsRegex + ")\\b(.*)$", "is");
+  // The follow Regex attempts to break a block of string into:
+  // * Group 1 (optional) - text before that which is to be highlighted
+  //   /^(.*?)/ : Non-greedily match anything from the start of the line upto the next group
+  // * Group 2 - The text which should be highlighted
+  //   /(<highlightsRegex>)\b/ : Using the generated highlightsRegex (typically in the form
+  //                             of /word|word|word/) match up to the next word boundary (/\b/)
+  // * Group 3 (optional) - The remaining text (after that which should be highlighted)
+  //   /(.*)$/ : Match zero or more characters up to the end of the line of text.
+  //
+  // Basic example use cases:
+  // 1. Input: "This and that other thing"; highlightsRegex: "and"
+  //  Group 1: "This "
+  //  Group 2: "and"
+  //  Group 3: " that other thing"
+  // 2. Input: "This and that other thing"; highlightsRegex: "this"
+  //  Group 1: ""
+  //  Group 2: "This"
+  //  Group 3: " and that other thing"
+  // 3. Input: "This and that other thing"; highlightsRegex: "thing"
+  //  Group 1: "This and that other "
+  //  Group 2: "thing"
+  //  Group 3: ""
+  const re = new RegExp("^(.*?)(" + highlightsRegex + ")\\b(.*)$", "is");
   const highlightWords = (_text: string): string => {
     const matches = _text.match(re);
     if (!matches) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/TextUtils.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/TextUtils.ts
@@ -1,0 +1,78 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Based on work from com.tle.web.sections.render.TextUtils
+ */
+
+const removeNonWordCharacters = (highlight: string): string =>
+  highlight
+    .replace(/\\/g, "")
+    .replace(/\./g, "")
+    .replace(/\(/g, "")
+    .replace(/\)/g, "")
+    .replace(/\[/g, "")
+    .replace(/]/g, "")
+    .replace(/\+/g, "")
+    .replace(/\?/g, ".?")
+    .replace(/\*/g, "\\w*")
+    .replace(/\|/g, "");
+
+const highlightsAsRegex = (highlights: string[]) =>
+  highlights
+    .map((h) => h.trim())
+    .filter((h) => h.length > 0)
+    .map((h) => removeNonWordCharacters(h))
+    .filter((h) => h.length > 0)
+    .join("|");
+
+/**
+ * Takes a line of text and a list of words which should be highlighted within that line. It returns
+ * a `string` which contains the text, and the listed words encapsulated within `span`s
+ * having the specified `class`.
+ *
+ * @param text Plain text to be highlighted
+ * @param highlights A list of words to highlight
+ * @param cssClass The CSS class to apply to the highlighting spans
+ */
+export const highlight = (
+  text: string,
+  highlights: string[],
+  cssClass: string
+): string => {
+  const highlightsRegex = highlightsAsRegex(highlights);
+  if (highlights.length < 1) {
+    // Nothing to highlight
+    return text;
+  }
+
+  const re = new RegExp("^(.*?)\\b(" + highlightsRegex + ")\\b(.*)$", "is");
+  const highlightWords = (_text: string): string => {
+    const matches = _text.match(re);
+    if (!matches) {
+      return _text;
+    }
+    const [, before, highlight, after] = matches;
+    return (
+      before +
+      `<span class="${cssClass}">${highlight}</span>` +
+      highlightWords(after)
+    );
+  };
+
+  return highlightWords(text);
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This change highlights search terms in the title and description of search result items in the same way (algorithmically) as the Legacy Search UI. The algorithm around this was mainly in java class `com.tle.web.sections.render.TextUtils`. As a result, a key part of this PR was to convert that to TS (`utils/TextUtils.ts`).

Once that was in place, it was just a matter of weaving it in, integrating with the 'highlight' list returned as part of #2225. 

To assist testing, I also refactored the `SearchResult.stories.tsx` to Storybook 6 before adding an additional story.

#1306 

![image](https://user-images.githubusercontent.com/43919233/93425408-40744f00-f8fd-11ea-8a4c-7e09a3213cc7.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
