### PR TITLE
front-end: Highlight only matches from the start of words

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/util/TextUtils.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/util/TextUtils.test.ts
@@ -30,6 +30,13 @@ describe("Highlighting of Text", () => {
       ["kelp*"],
       `The life of <span class="${className}">kelpies</span> explained`,
     ],
+    [
+      // Test we're only matching from the start of words - i.e. `an` at the end
+      // of Australian should not be highlighted.
+      "There was an Australian",
+      ["an*"],
+      `There was <span class="${className}">an</span> Australian`,
+    ],
   ])(
     "Produces a string containing the text highlighted with <span>s - %s",
     (text, highlights, expected) => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/TextUtils.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/TextUtils.ts
@@ -64,8 +64,9 @@ export const highlight = (
   // * Group 1 (optional) - text before that which is to be highlighted
   //   /^(.*?)/ : Non-greedily match anything from the start of the line upto the next group
   // * Group 2 - The text which should be highlighted
-  //   /(<highlightsRegex>)\b/ : Using the generated highlightsRegex (typically in the form
-  //                             of /word|word|word/) match up to the next word boundary (/\b/)
+  //   /\b(<highlightsRegex>)\b/ : Using the generated highlightsRegex (typically in the form
+  //                               of /word|word|word/) match whole words. (Using word boundary
+  //                               specifiers on either side - /\b/.)
   // * Group 3 (optional) - The remaining text (after that which should be highlighted)
   //   /(.*)$/ : Match zero or more characters up to the end of the line of text.
   //
@@ -82,7 +83,7 @@ export const highlight = (
   //  Group 1: "This and that other "
   //  Group 2: "thing"
   //  Group 3: ""
-  const re = new RegExp("^(.*?)(" + highlightsRegex + ")\\b(.*)$", "is");
+  const re = new RegExp("^(.*?)\\b(" + highlightsRegex + ")\\b(.*)$", "is");
   const highlightWords = (_text: string): string => {
     const matches = _text.match(re);
     if (!matches) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

The legacy highlighting code had an additional word boundary in the regex. Further testing revealed the importance of this, so adding it back in here to the conversion.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
