### PR TITLE
EBP: Improve text field styles

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5356,3 +5356,32 @@ $col2Width: 250px;
 .newListSelected .newList {
   padding-bottom: $doubleMargin;
 }
+.save-scrapbook-page.action-button {
+  @include buttonShadowBorder;
+  width: $col2Width;
+  margin-left: $doubleMargin;
+}
+.controldialog .area {
+  box-shadow: none;
+}
+
+// select user/select group dialogs need a specified width. Annoyingly they only have a unique ID
+// wherever they are used.
+// #1wrap and #2wrap don't work directly as selectors because they start with numbers
+#dul_userGroupsDialog,
+#dul_selectGroupDialog,
+#fbo_sowrap,
+#lce_selectInstructorwrap,
+#lce_selectOtherwrap,
+#lce_selectCustomwrap,
+#fpbo_sowrap,
+#_selectUserDialogwrap,
+#_audwrap,
+[id="1wrap"],
+[id="2wrap"] {
+  width: 550px;
+}
+
+.schedulersettings .dayprefix {
+  margin-left: $doubleMargin;
+}

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5386,10 +5386,6 @@ $col2Width: 250px;
   width: 550px;
 }
 
-.schedulersettings .dayprefix {
-  margin-left: $doubleMargin;
-}
-
 #ed_fin,
 #ed_fan {
   width: 200px;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5348,6 +5348,11 @@ $col2Width: 250px;
   }
 }
 
+#bss_moderateSelectedButton,
+#bss_clearSelectedButton {
+  @include buttonShadowBorder;
+}
+
 .newListSelected .newList {
   padding-bottom: $doubleMargin;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5382,6 +5382,7 @@ $col2Width: 250px;
 #_audwrap,
 [id="1wrap"],
 [id="2wrap"] {
+  @include buttonShadowBorder;
   width: 550px;
 }
 

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5221,33 +5221,33 @@ ul.treeview li.collapsable a.hitarea::before {
   content: none;
 }
 
-$loginLabelWidth: 100;
-$whitespaceWidth: 4;
-$loginTextBoxWidth: 200;
+$loginLabelWidth: 100px;
+$whitespaceWidth: 4px;
+$loginTextBoxWidth: 200px;
 #_logonButton {
   display: block;
-  margin-left: $loginLabelWidth + $whitespaceWidth + unquote("px");
+  margin-left: $loginLabelWidth + $whitespaceWidth;
   margin-top: $doubleMargin;
-  width: $loginTextBoxWidth + unquote("px");
+  width: $loginTextBoxWidth;
   @include boxShadow;
 }
 
 #username {
-  width: $loginTextBoxWidth + unquote("px");
+  width: $loginTextBoxWidth - ($doubleMargin * 2);
 }
 
 #password {
-  width: $loginTextBoxWidth + unquote("px");
+  width: $loginTextBoxWidth - ($doubleMargin * 2);
 }
 
 label[for="username"] {
   display: inline-block;
-  width: $loginLabelWidth + unquote("px");
+  width: $loginLabelWidth;
 }
 
 label[for="password"] {
   display: inline-block;
-  width: $loginLabelWidth + unquote("px");
+  width: $loginLabelWidth;
 }
 
 button:focus {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5356,6 +5356,7 @@ $col2Width: 250px;
 .newListSelected .newList {
   padding-bottom: $doubleMargin;
 }
+
 .save-scrapbook-page.action-button {
   @include buttonShadowBorder;
   width: $col2Width;
@@ -5375,6 +5376,8 @@ $col2Width: 250px;
 #lce_selectOtherwrap,
 #lce_selectCustomwrap,
 #fpbo_sowrap,
+#fbm_sowrap,
+#fba_sowrap,
 #_selectUserDialogwrap,
 #_audwrap,
 [id="1wrap"],
@@ -5384,4 +5387,9 @@ $col2Width: 250px;
 
 .schedulersettings .dayprefix {
   margin-left: $doubleMargin;
+}
+
+#ed_fin,
+#ed_fan {
+  width: 200px;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -418,8 +418,11 @@ select[multiple="multiple"] {
   border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   border-radius: 4px 4px 0 0;
   background-color: #f5f5f5;
-  height: 56px;
-
+  &:not(#q):not(.prompt) {
+    //so as to avoid affecting searchbars
+    padding: $doubleMargin;
+    font-size: 16px;
+  }
   &:hover {
     border-bottom: 2px solid rgba(0, 0, 0, 0.42);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#1983 
- Add MUI padding to textfields
- Fix some broken select user dialog widths and add shadow borders (after the fix is screenshot 2, before the fix is in screenshot 3)
![image](https://user-images.githubusercontent.com/24543345/93729769-3b6b1480-fc09-11ea-8b5c-c1fe159e7d34.png)
![image](https://user-images.githubusercontent.com/24543345/93729904-b6342f80-fc09-11ea-9d87-1bffe644632c.png)
![image](https://user-images.githubusercontent.com/24543345/93729978-fabfcb00-fc09-11ea-9a92-6aab795c1127.png)
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
