### PR TITLE
Adjusted wording for unsupported browser message

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -4492,5 +4492,5 @@ course.edit.validation.codeinuse=Course with code ''{0}'' already exists.
 impexp.entities=Additional Entities
 api.taxonomy.validation.datasource.unknown=Unknown data source identifier
 api.taxonomy.validation.datasource.notimplemented=Data source identifier not currently implemented
-unsupportedbrowser.heading=Sorry, you are using an unsupported browser.
-unsupportedbrowser.message=For the openEQUELLA New UI you must be using a current version of Firefox, Chrome or Microsoft Edge.
+unsupportedbrowser.heading=openEQUELLA is not compatible with this browser.
+unsupportedbrowser.message=Please try again in a modern browser. openEQUELLA runs in modern browsers such as Chrome, Firefox and Safari.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
#1306 

This is just a simple language string change, to make the unsupported browser message a little more generic. In particular moving the word 'supported', and removing the message about new ui. Since an end user would likely not understand what the 'new ui' even means

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
