### PR TITLE
Bugfix/search page view attachment acl issue

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -108,7 +108,7 @@ export default function SearchResult({
     modifiedDate,
     status,
     displayOptions,
-    attachments,
+    attachments = [],
     keywordFoundInAttachment,
   },
   highlights,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -52,6 +52,7 @@ import scala.collection.mutable.ListBuffer
   * SearchResultItem and SearchResultAttachment, respectively.
   */
 object SearchHelper {
+  val privileges = Array("VIEW_ITEM")
 
   /**
     * Create a new search with search criteria.
@@ -175,7 +176,7 @@ object SearchHelper {
   def createSerializer(itemIds: List[ItemIdKey]): ItemSerializerItemBean = {
     val ids      = itemIds.map(_.getKey.asInstanceOf[java.lang.Long]).asJavaCollection
     val category = List(ItemSerializerService.CATEGORY_ALL).asJavaCollection
-    LegacyGuice.itemSerializerService.createItemBeanSerializer(ids, category, false)
+    LegacyGuice.itemSerializerService.createItemBeanSerializer(ids, category, false, privileges: _*)
   }
 
   /**
@@ -211,20 +212,21 @@ object SearchHelper {
     * Convert a list of AttachmentBean to a list of SearchResultAttachment
     */
   def convertToAttachment(attachmentBeans: java.util.List[AttachmentBean],
-                          itemKey: ItemIdKey): List[SearchResultAttachment] = {
-    attachmentBeans.asScala
-      .map(
-        att =>
-          SearchResultAttachment(
-            attachmentType = att.getRawAttachmentType,
-            id = att.getUuid,
-            description = Option(att.getDescription),
-            preview = att.isPreview,
-            mimeType = getMimetypeForAttachment(att),
-            hasGeneratedThumb = thumbExists(itemKey, att),
-            links = getLinksFromBean(att)
-        ))
-      .toList
+                          itemKey: ItemIdKey): Option[List[SearchResultAttachment]] = {
+    Option(attachmentBeans).map(
+      beans =>
+        beans.asScala
+          .map(att =>
+            SearchResultAttachment(
+              attachmentType = att.getRawAttachmentType,
+              id = att.getUuid,
+              description = Option(att.getDescription),
+              preview = att.isPreview,
+              mimeType = getMimetypeForAttachment(att),
+              hasGeneratedThumb = thumbExists(itemKey, att),
+              links = getLinksFromBean(att)
+          ))
+          .toList)
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -31,6 +31,7 @@ import com.tle.common.beans.exception.NotFoundException
 import com.tle.common.search.DefaultSearch
 import com.tle.common.search.whereparser.WhereParser
 import com.tle.core.freetext.queries.FreeTextBooleanQuery
+import com.tle.core.item.security.ItemSecurityConstants
 import com.tle.core.item.serializer.{ItemSerializerItemBean, ItemSerializerService}
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.interfaces.beans.AbstractExtendableBean
@@ -52,7 +53,7 @@ import scala.collection.mutable.ListBuffer
   * SearchResultItem and SearchResultAttachment, respectively.
   */
 object SearchHelper {
-  val privileges = Array("VIEW_ITEM")
+  val privileges = Array(ItemSecurityConstants.VIEW_ITEM)
 
   /**
     * Create a new search with search criteria.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -50,7 +50,7 @@ case class SearchResultItem(
     modifiedDate: Date,
     collectionId: String,
     commentCount: Int,
-    attachments: List[SearchResultAttachment],
+    attachments: Option[List[SearchResultAttachment]],
     thumbnail: String,
     displayFields: List[DisplayField],
     displayOptions: Option[DisplayOptions],

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -208,7 +208,7 @@ export interface SearchResultItem {
   /**
    * Item's attachments.
    */
-  attachments: Attachment[];
+  attachments?: Attachment[];
   /**
    * Item's thumbnail.
    */


### PR DESCRIPTION
#1306 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Currently, new search page throws an error if users have no permissions to view attachments.
At the begining I thought the required permission would be `VIEW_ATTACHMENTS`, but after some digging I realised the required permission is `VIEW_ITEM`. 

So here are a list of changes to review:

1. We need to tell the ItemBean serialiser what permissions to check. Without doing this, the error still occurs even though the permission is given. And then, the serialiser will generate a list of attachment beans or null, depending on permission checks.

2. Change the type of attachments to optional in both back-end and front-end.

3. In component `SearchResult`, give a default value to attachments if it's undefined.

In the below example,  `VIEW_ITEM` of the first item is revoked whereas that of the second item is granted.
 
![image](https://user-images.githubusercontent.com/47203811/94256227-d139d300-ff6c-11ea-9dca-af601c47dd8e.png)



