### PR TITLE
chore(eslint): Disable jest/nomocks rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     },
     "rules": {
       "jest/consistent-test-it": "error",
-      "jest/no-mocks-import": "warn",
+      "jest/no-mocks-import": "off",
       "jest/require-top-level-describe": "error",
       "notice/notice": [
         "error",


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

This rule conflicts with how we are doing our mocks. In that we're not
mocking a whole module, we simply mocking the return data of some
functions within a module.

However this rule is now heavily polluting our GHA builds.

More info on rule at: https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-mocks-import.md

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
