### PR TITLE
Add lookup functionality to UserQuery rest module, with a few basic tests

### DIFF
--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -68,4 +68,10 @@ export const PUT = <T, R>(path: string, data?: T): Promise<R> =>
     .then((response: AxiosResponse<R>) => response.data)
     .catch(catchHandler);
 
+export const POST = <T, R>(path: string, data?: T): Promise<R> =>
+  axios
+    .post(path, data)
+    .then((response: AxiosResponse<R>) => response.data)
+    .catch(catchHandler);
+
 export default axios;

--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -82,7 +82,7 @@ export const POST = <T, R>(
 ): Promise<R> =>
   axios
     .post(path, data)
-    .then((response: AxiosResponse<R>) => {
+    .then((response: AxiosResponse<unknown>) => {
       const data = response.data;
       if (!validator(data)) {
         throw new TypeError(

--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -68,10 +68,29 @@ export const PUT = <T, R>(path: string, data?: T): Promise<R> =>
     .then((response: AxiosResponse<R>) => response.data)
     .catch(catchHandler);
 
-export const POST = <T, R>(path: string, data?: T): Promise<R> =>
+/**
+ * Executes a HTTP POST for a given path.
+ *
+ * @param path The URL path for the target POST
+ * @param validator A function to perform runtime type checking against the result - typically with typescript-is
+ * @param data The data to be sent in POST request
+ */
+export const POST = <T, R>(
+  path: string,
+  validator: (data: unknown) => data is R,
+  data?: T
+): Promise<R> =>
   axios
     .post(path, data)
-    .then((response: AxiosResponse<R>) => response.data)
+    .then((response: AxiosResponse<R>) => {
+      const data = response.data;
+      if (!validator(data)) {
+        throw new TypeError(
+          `Data format mismatch with data received from server, on request to: "${path}"`
+        );
+      }
+      return data;
+    })
     .catch(catchHandler);
 
 export default axios;

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GET } from './AxiosInstance';
+import { GET, POST } from './AxiosInstance';
 import { is } from 'typescript-is';
 import { UuidString } from './Common';
 
@@ -61,6 +61,15 @@ export interface SearchParams {
   users: boolean;
 }
 
+export interface LookupParams {
+  /** String array of User IDs to lookup. */
+  users: string[];
+  /** String array of Group IDs to lookup. */
+  groups: string[];
+  /** String array of Role IDs to lookup. */
+  roles: string[];
+}
+
 const isSearchResult = (instance: unknown): instance is SearchResult =>
   is<SearchResult>(instance);
 
@@ -79,5 +88,20 @@ export const search = (
   GET<SearchResult>(
     apiBasePath + USERQUERY_ROOT_PATH + '/search',
     isSearchResult,
+    params
+  );
+
+/**
+ * Lookup for users and related entities (i.e. groups and roles).
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param params Query parameters to customize result
+ */
+export const lookup = (
+  apiBasePath: string,
+  params: LookupParams
+): Promise<SearchResult> =>
+  POST<LookupParams, SearchResult>(
+    apiBasePath + USERQUERY_ROOT_PATH + '/lookup',
     params
   );

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -103,5 +103,6 @@ export const lookup = (
 ): Promise<SearchResult> =>
   POST<LookupParams, SearchResult>(
     apiBasePath + USERQUERY_ROOT_PATH + '/lookup',
+    isSearchResult,
     params
   );

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -62,11 +62,11 @@ export interface SearchParams {
 }
 
 export interface LookupParams {
-  /** String array of User IDs to lookup. */
+  /** List of User IDs to lookup. */
   users: string[];
-  /** String array of Group IDs to lookup. */
+  /** List of Group IDs to lookup. */
   groups: string[];
-  /** String array of Role IDs to lookup. */
+  /** List of Role IDs to lookup. */
   roles: string[];
 }
 
@@ -92,7 +92,7 @@ export const search = (
   );
 
 /**
- * Lookup for users and related entities (i.e. groups and roles).
+ * Lookup users and related entities (i.e. groups and roles) by id.
  *
  * @param apiBasePath Base URI to the oEQ institution and API
  * @param params Query parameters to customize result


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Adds oEQ userquery/lookup REST endpoint support to the oeq-ts-rest-api module. 

This will enable us to lookup oEQ users, groups and roles by id. 

The primary driver for implementing this is to allow for the new Search page to read in a user id from a query string, and display the correct user details in the OwnerSelector control. 


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
