### PR TITLE
Add support for retrieving MIME type viewer configuration to oeq-ts-rest-api

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/MimeTypeList.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/MimeTypeList.stories.tsx
@@ -20,7 +20,7 @@ import type { Meta, Story } from "@storybook/react";
 import MimeTypeList, {
   MimeTypeFilterListProps,
 } from "../../tsrc/settings/Search/searchfilter/MimeTypeList";
-import type { MimeTypeEntry } from "../../tsrc/modules/SearchFilterSettingsModule";
+import * as OEQ from "@openequella/rest-api-client";
 
 export default {
   title: "MimeTypeList",
@@ -30,7 +30,7 @@ export default {
   },
 } as Meta<MimeTypeFilterListProps>;
 
-const defaultMimeTypes: MimeTypeEntry[] = [
+const defaultMimeTypes: OEQ.MimeType.MimeTypeEntry[] = [
   { mimeType: "image/png", desc: "This is a Image filter" },
   { mimeType: "image/jpeg", desc: "This is a Image filter" },
 ];

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFilterSettingsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFilterSettingsModule.ts
@@ -15,12 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as OEQ from "@openequella/rest-api-client";
 import Axios from "axios";
-import { encodeQuery } from "../util/encodequery";
 import {
   BatchOperationResponse,
   groupErrorMessages,
 } from "../api/BatchOperationResponse";
+import { API_BASE_URL } from "../config";
+import { encodeQuery } from "../util/encodequery";
 
 export interface MimeTypeFilter {
   /**
@@ -38,25 +40,14 @@ export interface MimeTypeFilter {
   mimeTypes: string[];
 }
 
-export interface MimeTypeEntry {
-  /**
-   * The name of a Mime type.
-   */
-  mimeType: string;
-  /**
-   * The description of a Mime type.
-   */
-  desc: string;
-}
-
 const MIME_TYPE_FILTERS_URL = "api/settings/search/filter";
-const MIME_TYPE_URL = "api/mimetype";
 
 export const getMimeTypeFiltersFromServer = (): Promise<MimeTypeFilter[]> =>
   Axios.get(MIME_TYPE_FILTERS_URL).then((res) => res.data);
 
-export const getMIMETypesFromServer = (): Promise<MimeTypeEntry[]> =>
-  Axios.get(MIME_TYPE_URL).then((res) => res.data);
+export const getMIMETypesFromServer = (): Promise<
+  OEQ.MimeType.MimeTypeEntry[]
+> => OEQ.MimeType.listMimeTypes(API_BASE_URL);
 
 export const batchUpdateOrAdd = (filters: MimeTypeFilter[]) =>
   Axios.put<BatchOperationResponse[]>(
@@ -69,7 +60,7 @@ export const batchDelete = (ids: string[]) =>
     `${MIME_TYPE_FILTERS_URL}/${encodeQuery({ ids: ids })}`
   ).then((res) => groupErrorMessages(res.data));
 
-export const getMimeTypeDetail = (entry: MimeTypeEntry) => {
+export const getMimeTypeDetail = (entry: OEQ.MimeType.MimeTypeEntry) => {
   const { mimeType, desc } = entry;
   if (desc) {
     return `${desc} (${mimeType})`;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
 import {
   Button,
   Dialog,
@@ -24,17 +23,18 @@ import {
   DialogTitle,
   TextField,
 } from "@material-ui/core";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { useEffect, useState } from "react";
 import {
   getMIMETypesFromServer,
   MimeTypeFilter,
-  MimeTypeEntry,
   vaidateMimeTypeName,
 } from "../../../modules/SearchFilterSettingsModule";
-import { useEffect, useState } from "react";
 import { commonString } from "../../../util/commonstrings";
-import MimeTypeList from "./MimeTypeList";
-import { languageStrings } from "../../../util/langstrings";
 import { addElement, deleteElement } from "../../../util/ImmutableArrayUtil";
+import { languageStrings } from "../../../util/langstrings";
+import MimeTypeList from "./MimeTypeList";
 
 export interface MimeTypeFilterEditingDialogProps {
   /**
@@ -73,7 +73,9 @@ const MimeTypeFilterEditingDialog = ({
   const searchFilterStrings =
     languageStrings.settings.searching.searchfiltersettings;
 
-  const [mimeTypeEntries, setMimeTypeEntries] = useState<MimeTypeEntry[]>([]);
+  const [mimeTypeEntries, setMimeTypeEntries] = useState<
+    OEQ.MimeType.MimeTypeEntry[]
+  >([]);
   // Used to store the name of a MIME type filter.
   const [filterName, setFilterName] = useState<string>("");
   // Used to store the MIME types of a MIME type filter.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeList.tsx
@@ -15,19 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
 import {
+  Checkbox,
   List,
   ListItem,
   ListItemText,
-  Checkbox,
   Typography,
 } from "@material-ui/core";
-import {
-  getMimeTypeDetail,
-  MimeTypeEntry,
-} from "../../../modules/SearchFilterSettingsModule";
 import { makeStyles } from "@material-ui/core/styles";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { getMimeTypeDetail } from "../../../modules/SearchFilterSettingsModule";
 import { languageStrings } from "../../../util/langstrings";
 
 const useStyles = makeStyles({
@@ -47,7 +45,7 @@ export interface MimeTypeFilterListProps {
   /**
    * A list of MIME types to be displayed.
    */
-  entries: MimeTypeEntry[];
+  entries: OEQ.MimeType.MimeTypeEntry[];
   /**
    * Fired when the value of each Checkbox is changed.
    */

--- a/oeq-ts-rest-api/src/MimeType.ts
+++ b/oeq-ts-rest-api/src/MimeType.ts
@@ -29,8 +29,93 @@ export interface MimeTypeEntry {
   desc?: string;
 }
 
+/**
+ * Configuration for a MIME type viewer.
+ *
+ * Based on: com.tle.web.viewurl.ResourceViewerConfig
+ */
+export interface ViewerConfig {
+  /**
+   * Whether the viewer should open in a new window.
+   */
+  openInNewWindow: boolean;
+  /**
+   * CSS style width specification.
+   */
+  width: string;
+  /**
+   * CSS style height specification.
+   */
+  height: string;
+  /**
+   * Whether a light-table type viewer should be used - i.e. originally the old
+   * [Thickbox](http://codylindley.com/thickbox/) and more recently
+   * [Fancybox](http://fancybox.net/).
+   */
+  thickbox: boolean;
+  /**
+   * Various freeform configuration for the specific viewer.
+   */
+  attr: Record<string, unknown>;
+}
+
+/**
+ * Current list of known oEQ ViewerIds.
+ */
+export type ViewerId =
+  | 'downloadIms'
+  | 'echoCenterViewer'
+  | 'echoPlayerViewer'
+  | 'echoPodcastViewer'
+  | 'echoVodcastViewer'
+  | 'externalToolViewer'
+  | 'fancy'
+  | 'file'
+  | 'googledocviewer'
+  | 'htmlFiveViewer'
+  | 'kalturaViewer'
+  | 'livNavTreeViewer'
+  | 'qtiTestViewer'
+  | 'tohtml'
+  | 'toimg';
+
+/**
+ * Basic details for each viewer, including optional configuration. If `config` is not present, then
+ * the consumer should use it's own defaults.
+ */
+export interface MimeTypeViewerDetail {
+  /**
+   * One of the standard oEQ viewer types.
+   */
+  viewerId: ViewerId;
+  /**
+   * Standard config (optionally defined) around how this should be displayed.
+   */
+  config?: ViewerConfig;
+}
+
+/**
+ * The complete viewer configuration for a MIME type.
+ */
+export interface MimeTypeViewerConfiguration {
+  /**
+   * Which viewer should be used by default - .e.g. on search result pages.
+   */
+  defaultViewer: string;
+  /**
+   * Full list of viewers which are enabled for a MIME type, including any additional custom
+   * configuration.
+   */
+  viewers: MimeTypeViewerDetail[];
+}
+
 const isMimeTypeEntryList = (instance: unknown): instance is MimeTypeEntry[] =>
   is<MimeTypeEntry[]>(instance);
+
+const isMimeTypeViewerConfiguration = (
+  instance: unknown
+): instance is MimeTypeViewerConfiguration =>
+  is<MimeTypeViewerConfiguration>(instance);
 
 const MIMETYPE_ROOT_PATH = '/mimetype';
 
@@ -41,3 +126,20 @@ const MIMETYPE_ROOT_PATH = '/mimetype';
  */
 export const listMimeTypes = (apiBasePath: string): Promise<MimeTypeEntry[]> =>
   GET(apiBasePath + MIMETYPE_ROOT_PATH, isMimeTypeEntryList);
+
+/**
+ * Given a MIME type (e.g. "application/pdf") retrieve the oEQ viewer configuration for it. Note
+ * that configuration details will be brief if there are no additional (non-default) settings defined.
+ * It is then up to the consumer to determine their own defaults.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param mimeType A simple string in the normal format of <type>/<subtype>
+ */
+export const getViewersForMimeType = (
+  apiBasePath: string,
+  mimeType: string
+): Promise<MimeTypeViewerConfiguration> =>
+  GET(
+    apiBasePath + MIMETYPE_ROOT_PATH + '/viewerconfig/' + mimeType,
+    isMimeTypeViewerConfiguration
+  );

--- a/oeq-ts-rest-api/src/MimeType.ts
+++ b/oeq-ts-rest-api/src/MimeType.ts
@@ -20,11 +20,11 @@ import { GET } from './AxiosInstance';
 
 export interface MimeTypeEntry {
   /**
-   * The name of a Mime type.
+   * The name of a MIME type.
    */
   mimeType: string;
   /**
-   * The description of a Mime type.
+   * The description of a MIME type.
    */
   desc?: string;
 }
@@ -99,7 +99,7 @@ export interface MimeTypeViewerDetail {
  */
 export interface MimeTypeViewerConfiguration {
   /**
-   * Which viewer should be used by default - .e.g. on search result pages.
+   * Which viewer should be used by default - e.g. on search result pages.
    */
   defaultViewer: string;
   /**

--- a/oeq-ts-rest-api/src/MimeType.ts
+++ b/oeq-ts-rest-api/src/MimeType.ts
@@ -15,16 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * as Auth from './Auth';
-export * as Collection from './Collection';
-export * as Common from './Common';
-export * as LegacyContent from './LegacyContent';
-export * as MimeType from './MimeType';
-export * as Errors from './Errors';
-export * as Schema from './Schema';
-export * as Security from './Security';
-export * as Settings from './Settings';
-export * as Search from './Search';
-export * as SearchFacets from './SearchFacets';
-export * as UserQuery from './UserQuery';
-export * as Utils from './Utils';
+import { is } from 'typescript-is';
+import { GET } from './AxiosInstance';
+
+export interface MimeTypeEntry {
+  /**
+   * The name of a Mime type.
+   */
+  mimeType: string;
+  /**
+   * The description of a Mime type.
+   */
+  desc?: string;
+}
+
+const isMimeTypeEntryList = (instance: unknown): instance is MimeTypeEntry[] =>
+  is<MimeTypeEntry[]>(instance);
+
+const MIMETYPE_ROOT_PATH = '/mimetype';
+
+/**
+ * List all available MIME types for the institution.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ */
+export const listMimeTypes = (apiBasePath: string): Promise<MimeTypeEntry[]> =>
+  GET(apiBasePath + MIMETYPE_ROOT_PATH, isMimeTypeEntryList);

--- a/oeq-ts-rest-api/test/MimeType.test.ts
+++ b/oeq-ts-rest-api/test/MimeType.test.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 import * as OEQ from '../src';
-import { listMimeTypes } from '../src/MimeType';
+import { getViewersForMimeType, listMimeTypes } from '../src/MimeType';
 import * as TC from './TestConfig';
 
 beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
@@ -27,5 +27,18 @@ describe('listMimeTypes', () => {
   it('lists MIME types for the collection', async () => {
     const mimeTypes = await listMimeTypes(TC.API_PATH);
     expect(mimeTypes.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getViewersForMimeType', () => {
+  it('can retrieve the viewer configuration for each MIME type on the server', async () => {
+    const allMimeTypes = await listMimeTypes(TC.API_PATH);
+    for (const mt of allMimeTypes) {
+      const viewerConfig = await getViewersForMimeType(
+        TC.API_PATH,
+        mt.mimeType
+      );
+      expect(viewerConfig.defaultViewer).toBeTruthy();
+    }
   });
 });

--- a/oeq-ts-rest-api/test/MimeType.test.ts
+++ b/oeq-ts-rest-api/test/MimeType.test.ts
@@ -15,16 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * as Auth from './Auth';
-export * as Collection from './Collection';
-export * as Common from './Common';
-export * as LegacyContent from './LegacyContent';
-export * as MimeType from './MimeType';
-export * as Errors from './Errors';
-export * as Schema from './Schema';
-export * as Security from './Security';
-export * as Settings from './Settings';
-export * as Search from './Search';
-export * as SearchFacets from './SearchFacets';
-export * as UserQuery from './UserQuery';
-export * as Utils from './Utils';
+import * as OEQ from '../src';
+import { listMimeTypes } from '../src/MimeType';
+import * as TC from './TestConfig';
+
+beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
+
+afterAll(() => OEQ.Auth.logout(TC.API_PATH, true));
+
+describe('listMimeTypes', () => {
+  it('lists MIME types for the collection', async () => {
+    const mimeTypes = await listMimeTypes(TC.API_PATH);
+    expect(mimeTypes.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This PR Adds support the TS REST Module for the new endpoint added in #2339 to retrieve viewer configuration for a specified MIME type. This work is seen in `MimeType.ts` and `MimeType.test.ts`.

However when doing this I saw that the existing `/mimetype` query (to list MIME types) was still sitting in one of the front-end modules (`SearchFilterSettingsModule.ts`) so I refactored that out into the new `MimeType.ts` and then refactored the consumers as needed.

#1306

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
