### PR TITLE
bugfix(rest-api): Should return a 404 if MIME type not found

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
@@ -38,6 +38,14 @@ public class MimeTypeApiTest extends AbstractRestApiTest {
     }
   }
 
+  @Test
+  public void testMimeTypeConfigurationNotFoundHandling() throws IOException {
+    final String noSuchMimeType = "blah/blah";
+    final HttpMethod method =
+        new GetMethod(MIMETYPE_API_ENDPOINT + "/viewerconfig/" + noSuchMimeType);
+    assertEquals(HttpStatus.SC_NOT_FOUND, makeClientRequest(method));
+  }
+
   private List<MimeTypeDetail> getMimeTypes() throws IOException {
     final HttpMethod method = new GetMethod(MIMETYPE_API_ENDPOINT);
     assertEquals(HttpStatus.SC_OK, makeClientRequest(method));

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
@@ -30,8 +30,7 @@ public class MimeTypeApiTest extends AbstractRestApiTest {
   public void testRetrieveMimeTypeConfiguration() throws Exception {
     // Let's process all the known mimetypes to ensure we can
     for (MimeTypeDetail detail : getMimeTypes()) {
-      final HttpMethod method =
-          new GetMethod(MIMETYPE_API_ENDPOINT + "/viewerconfig/" + detail.getMimeType());
+      final HttpMethod method = new GetMethod(buildViewerConfigPath(detail.getMimeType()));
       assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
       JsonNode viewConfig = mapper.readTree(method.getResponseBodyAsString());
       assertNotNull(viewConfig.findValue("defaultViewer"));
@@ -41,8 +40,7 @@ public class MimeTypeApiTest extends AbstractRestApiTest {
   @Test
   public void testMimeTypeConfigurationNotFoundHandling() throws IOException {
     final String noSuchMimeType = "blah/blah";
-    final HttpMethod method =
-        new GetMethod(MIMETYPE_API_ENDPOINT + "/viewerconfig/" + noSuchMimeType);
+    final HttpMethod method = new GetMethod(buildViewerConfigPath(noSuchMimeType));
     assertEquals(HttpStatus.SC_NOT_FOUND, makeClientRequest(method));
   }
 
@@ -51,6 +49,10 @@ public class MimeTypeApiTest extends AbstractRestApiTest {
     assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
     return mapper.readValue(
         method.getResponseBodyAsString(), new TypeReference<List<MimeTypeDetail>>() {});
+  }
+
+  private String buildViewerConfigPath(String mimeType) {
+    return MIMETYPE_API_ENDPOINT + "/viewerconfig/" + mimeType;
   }
 
   // Mirror of com.tle.web.api.settings.MimeTypeDetail


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Missed this in the initial implementation. So not really a bugfix, but kinda. Anyway, simply wraps the request to get the provided MIME type in an `Option` and then goes from there. `Some(entry)` => Do as it did before (copy and paste); `None` => Return a response of `HttpStatus.SC_NOT_FOUND`.

#1306

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
