### PR TITLE
EBP: Add missing auth.css

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -43,6 +43,7 @@
 @import "myresourcecontribute.css";
 @import "htmleditorwebcontrol.css";
 @import "userdetails.css";
+@import "auth.css";
 
 $small-breakpoint-max: "768px";
 $medium-breakpoint-max: "1200px";


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes


##### Description of change
#1983 
This css file was missing from legacy.scss, causing the external system connector's window to be unusably small. The screenshot shows an error window as I'm working upon another bug at the moment, but these styles are definitely necessary.
Before style fix: 
![image](https://user-images.githubusercontent.com/24543345/94639758-49fbaf00-0320-11eb-9c71-861157852a6e.png)
After style fix:
![image](https://user-images.githubusercontent.com/24543345/94639918-afe83680-0320-11eb-8735-90243eb475d4.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
