### PR TITLE
Improve ItemSummaryTest - testAttachmentViewCount

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/viewing/ItemSummaryTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/viewing/ItemSummaryTest.java
@@ -132,9 +132,9 @@ public class ItemSummaryTest extends AbstractCleanupTest {
 
   @Test
   public void testAttachmentViewCount() {
-    final String linkAttachment = "https://www.google.com/";
+    final String linkAttachment = "https://archive.org/";
 
-    final String imgAlt = "input[value=\"Google Search\"]";
+    final String archiveOrgPreambleString = "div.preamble-whoweare";
     logon(AUTOTEST_LOGON, AUTOTEST_PASSWD);
 
     final WizardPageTab wizard = new ContributePage(context).load().openWizard(COLLECTION3);
@@ -145,7 +145,9 @@ public class ItemSummaryTest extends AbstractCleanupTest {
     checkViews(summary, 1, linkAttachment, 0);
 
     // view the attachment and go back
-    summary.attachments().viewLinkAttachment(linkAttachment, By.cssSelector(imgAlt));
+    summary
+        .attachments()
+        .viewLinkAttachment(linkAttachment, By.cssSelector(archiveOrgPreambleString));
     final WebDriver.Navigation navigate = context.getDriver().navigate();
     navigate.back();
     // navigate.refresh();
@@ -155,7 +157,9 @@ public class ItemSummaryTest extends AbstractCleanupTest {
     checkViews(summary, 2, linkAttachment, 1);
 
     // view the attachment again and go back
-    summary.attachments().viewLinkAttachment(linkAttachment, By.cssSelector(imgAlt));
+    summary
+        .attachments()
+        .viewLinkAttachment(linkAttachment, By.cssSelector(archiveOrgPreambleString));
     navigate.back();
     // navigate.refresh();
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change
This test has been causing problems in the old and new UI in GHA as of late. It seems the runner is often in non-english speaking countries and so Google redirects to a different version of itself so that the xpath check doesn't work.
As discussed with @edalex-ian, I've changed the link to be archive.org and the xpath to be the preamble string at the start of the page (see screenshot).
![image](https://user-images.githubusercontent.com/24543345/94757311-40844c80-03dd-11eb-872c-bfa4e097a4e7.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
