### PR TITLE
EBP: Improve URL attachment dialog styles

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -71,7 +71,7 @@ $doubleMargin: 16px;
   -moz-border-radius: 4px;
 }
 
-@mixin editDialogCommonStyles {
+@mixin editAttachmentDialogStyles {
   height: 100%;
   box-shadow: none;
   padding: 0;
@@ -4160,7 +4160,7 @@ a.modal-control.modal-save {
 .fileHandler {
   .modal-content .modal-content-background .modal-content-inner .float-left {
     width: 100%;
-    @include editDialogCommonStyles;
+    @include editAttachmentDialogStyles;
   }
 
   .modal-content-inner {
@@ -4171,7 +4171,7 @@ a.modal-control.modal-save {
 
 .urlHandler {
   .modal-content .modal-content-background .modal-content-inner .float-left {
-    @include editDialogCommonStyles;
+    @include editAttachmentDialogStyles;
   }
 
   .modal-content-inner {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -3164,13 +3164,6 @@ button + .repeater-groups {
   padding-bottom: $singleMargin;
 }
 
-.fileHandler {
-  .modal-content-inner {
-    display: flex;
-    flex-direction: row-reverse;
-  }
-}
-
 .attachment-content {
   min-height: 340px;
   padding: 20px 25px;
@@ -4159,40 +4152,56 @@ a.modal-control.modal-save {
 }
 
 .fileHandler {
+  .modal-content .modal-content-background .modal-content-inner .float-left {
+    width: 100%;
+    height: 100%;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .modal-content-inner {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+}
+
+.urlHandler {
+  .modal-content .modal-content-background .modal-content-inner .float-left {
+    height: 100%;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .modal-content-inner {
+    flex-direction: row;
+  }
+}
+
+.fileHandler,
+.urlHandler {
   @include buttonShadowBorder;
   @include centreAlignFancyBox;
   width: $iframeDialogWidth;
   height: $iframeDialogHeight + $doubleMargin;
   position: sticky;
-}
 
-.fileHandler
-  .modal-content
-  .modal-content-background
-  .modal-content-inner
-  .float-left {
-  width: 100%;
-  height: 100%;
-  box-shadow: none;
-  padding: 0;
-}
+  .modal-content-inner {
+    border: none;
+  }
 
-.fileHandler .modal-content-inner {
-  border: none;
-}
+  .attachment-details ~ .attachment-content {
+    padding-left: 0;
+    margin-left: 0;
+  }
 
-.fileHandler .attachment-details ~ .attachment-content {
-  padding-left: 0;
-  margin-left: 0;
-}
+  .fileadd h3 {
+    //redundant string for handlers.file.title already in the dialog header
+    display: none;
+  }
 
-.fileHandler .fileadd h3 {
-  //redundant string for handlers.file.title already in the dialog header
-  display: none;
-}
-
-.fileHandler .modal-content-inner {
-  padding-left: 0;
+  .modal-content-inner {
+    padding-left: 0;
+  }
 }
 
 .universalresourcedialog .modal-content {
@@ -5371,6 +5380,7 @@ $col2Width: 250px;
 .user-details #col2 {
   width: $col2Width;
   margin: 0 $doubleMargin;
+
   .profile-save-button,
   .change-pass-button {
     @include buttonShadowBorder;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -71,6 +71,12 @@ $doubleMargin: 16px;
   -moz-border-radius: 4px;
 }
 
+@mixin editDialogCommonStyles {
+  height: 100%;
+  box-shadow: none;
+  padding: 0;
+}
+
 @mixin buttonShadowBorder {
   @include boxShadow;
   @include curvedCorners;
@@ -4154,9 +4160,7 @@ a.modal-control.modal-save {
 .fileHandler {
   .modal-content .modal-content-background .modal-content-inner .float-left {
     width: 100%;
-    height: 100%;
-    box-shadow: none;
-    padding: 0;
+    @include editDialogCommonStyles;
   }
 
   .modal-content-inner {
@@ -4167,9 +4171,7 @@ a.modal-control.modal-save {
 
 .urlHandler {
   .modal-content .modal-content-background .modal-content-inner .float-left {
-    height: 100%;
-    box-shadow: none;
-    padding: 0;
+    @include editDialogCommonStyles;
   }
 
   .modal-content-inner {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#1983 
Turns out the styles applied to the file attachment dialog in #2255 didn't apply in the URL attachment dialog, and so this PR applies the same styling to the URL dialog.
Before change:
![image](https://user-images.githubusercontent.com/24543345/94880422-38441400-04a6-11eb-981a-7a03126faafc.png)

After change:
![image](https://user-images.githubusercontent.com/24543345/94880393-22365380-04a6-11eb-8453-8e80f766797a.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
