### PR TITLE
Remove -f from the check:md call

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check:scala": "find . -name '*.scala' -o -name '*.sbt' | xargs scalafmt --test",
     "check:java": "find . -name '*.java' | xargs google-java-format -n --set-exit-if-changed",
     "check:license": "cd Source/Plugins/Core/com.equella.core/js && licensee --production --errors-only && cd -",
-    "check:md": "remark -qf --ignore-pattern NOTICE.md .",
+    "check:md": "remark -q --ignore-pattern NOTICE.md .",
     "check:scss": "prettier --check ${npm_package_config_stylesheet_glob}",
     "check:ts": "eslint ${npm_package_config_typescript_glob}",
     "check:ts-types-source": "tsc --noEmit --project \"Source/Plugins/Core/com.equella.core/js/tsconfig.json\"",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
The -f option for remark means "frail", which means any problems (including warnings) cause a non-zero exit. 
Because of #2360, this PR removes the option from the task so that false positives for the no-dead-urls rule don't break builds.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
