### PR TITLE
Allow skipping tests in TestNG at runtime

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/bugs/VisibilityScriptingBugTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/bugs/VisibilityScriptingBugTest.java
@@ -10,7 +10,7 @@ import com.tle.webtests.pageobject.wizard.ContributePage;
 import com.tle.webtests.pageobject.wizard.WizardPageTab;
 import com.tle.webtests.test.AbstractCleanupTest;
 import org.testng.annotations.Test;
-import retry.RetryTest;
+import testng.annotation.RetryTest;
 
 /**
  * This is a test to ensure that GH issue #1678 has not regressed.

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/PackageAndNavigationTest.java
@@ -24,7 +24,7 @@ import java.net.URL;
 import java.text.MessageFormat;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import retry.RetryTest;
+import testng.annotation.RetryTest;
 
 @TestInstitution("fiveo")
 public class PackageAndNavigationTest extends AbstractCleanupAutoTest {

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -69,10 +69,6 @@ public class NewSearchPageTest extends AbstractSessionTest {
   @SkipTest(skipOldUI = true)
   public void backToSearchPage() {
     context.getDriver().navigate().back();
-    // todo: remove this when we can skip this test suite in Old UI mode.
-    if (!searchPage.usingNewUI()) {
-      context.getDriver().navigate().refresh();
-    }
     searchPage.get();
     // Expect when going 'back' to the search page, the previous search
     // settings have been remembered.

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -19,7 +19,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "open the new Search page and wait for initial search completed")
-  @NewUIOnly(true)
+  @NewUIOnly
   public void initialSearch() {
     searchPage = new NewSearchPage(context).load();
     // The initial search should return 16 items.
@@ -27,7 +27,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(dependsOnMethods = "initialSearch", description = "Search with a query and refine controls")
-  @NewUIOnly(true)
+  @NewUIOnly
   public void searchByFilters() {
     searchPage.newSearch();
     // Search by Collections.
@@ -56,7 +56,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "open an item's summary page", dependsOnMethods = "searchByFilters")
-  @NewUIOnly(true)
+  @NewUIOnly
   public void openItemSummaryPage() {
     final String ITEM_TITLE = "Java (cloned)";
     SummaryPage summaryPage = searchPage.selectItem(ITEM_TITLE);
@@ -66,7 +66,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   @Test(
       description = "Go back to the Search page from another page",
       dependsOnMethods = "openItemSummaryPage")
-  @NewUIOnly(true)
+  @NewUIOnly
   public void backToSearchPage() {
     context.getDriver().navigate().back();
     searchPage.get();
@@ -77,7 +77,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "Search with a low privileged user", dependsOnMethods = "backToSearchPage")
-  @NewUIOnly(true)
+  @NewUIOnly
   public void searchWithLessACLS() {
     // This account can only access the Collection 'Hardware platforms' and items of this
     // Collection. But it has no access to attachments and comments.

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -7,7 +7,7 @@ import com.tle.webtests.pageobject.viewitem.SummaryPage;
 import com.tle.webtests.test.AbstractSessionTest;
 import io.github.openequella.pages.search.NewSearchPage;
 import org.testng.annotations.Test;
-import testng.annotation.SkipTest;
+import testng.annotation.NewUIOnly;
 
 @TestInstitution("facet")
 public class NewSearchPageTest extends AbstractSessionTest {
@@ -19,7 +19,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "open the new Search page and wait for initial search completed")
-  @SkipTest(skipOldUI = true)
+  @NewUIOnly(true)
   public void initialSearch() {
     searchPage = new NewSearchPage(context).load();
     // The initial search should return 16 items.
@@ -27,7 +27,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(dependsOnMethods = "initialSearch", description = "Search with a query and refine controls")
-  @SkipTest(skipOldUI = true)
+  @NewUIOnly(true)
   public void searchByFilters() {
     searchPage.newSearch();
     // Search by Collections.
@@ -56,7 +56,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "open an item's summary page", dependsOnMethods = "searchByFilters")
-  @SkipTest(skipOldUI = true)
+  @NewUIOnly(true)
   public void openItemSummaryPage() {
     final String ITEM_TITLE = "Java (cloned)";
     SummaryPage summaryPage = searchPage.selectItem(ITEM_TITLE);
@@ -66,7 +66,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   @Test(
       description = "Go back to the Search page from another page",
       dependsOnMethods = "openItemSummaryPage")
-  @SkipTest(skipOldUI = true)
+  @NewUIOnly(true)
   public void backToSearchPage() {
     context.getDriver().navigate().back();
     searchPage.get();
@@ -77,7 +77,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "Search with a low privileged user", dependsOnMethods = "backToSearchPage")
-  @SkipTest(skipOldUI = true)
+  @NewUIOnly(true)
   public void searchWithLessACLS() {
     // This account can only access the Collection 'Hardware platforms' and items of this
     // Collection. But it has no access to attachments and comments.

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -7,6 +7,7 @@ import com.tle.webtests.pageobject.viewitem.SummaryPage;
 import com.tle.webtests.test.AbstractSessionTest;
 import io.github.openequella.pages.search.NewSearchPage;
 import org.testng.annotations.Test;
+import testng.annotation.SkipTest;
 
 @TestInstitution("facet")
 public class NewSearchPageTest extends AbstractSessionTest {
@@ -18,6 +19,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "open the new Search page and wait for initial search completed")
+  @SkipTest(skipOldUI = true)
   public void initialSearch() {
     searchPage = new NewSearchPage(context).load();
     // The initial search should return 16 items.
@@ -25,6 +27,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(dependsOnMethods = "initialSearch", description = "Search with a query and refine controls")
+  @SkipTest(skipOldUI = true)
   public void searchByFilters() {
     searchPage.newSearch();
     // Search by Collections.
@@ -53,6 +56,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "open an item's summary page", dependsOnMethods = "searchByFilters")
+  @SkipTest(skipOldUI = true)
   public void openItemSummaryPage() {
     final String ITEM_TITLE = "Java (cloned)";
     SummaryPage summaryPage = searchPage.selectItem(ITEM_TITLE);
@@ -62,6 +66,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   @Test(
       description = "Go back to the Search page from another page",
       dependsOnMethods = "openItemSummaryPage")
+  @SkipTest(skipOldUI = true)
   public void backToSearchPage() {
     context.getDriver().navigate().back();
     // todo: remove this when we can skip this test suite in Old UI mode.
@@ -76,6 +81,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(description = "Search with a low privileged user", dependsOnMethods = "backToSearchPage")
+  @SkipTest(skipOldUI = true)
   public void searchWithLessACLS() {
     // This account can only access the Collection 'Hardware platforms' and items of this
     // Collection. But it has no access to attachments and comments.

--- a/autotest/OldTests/src/test/java/testng/FailureRetryAnalyzer.java
+++ b/autotest/OldTests/src/test/java/testng/FailureRetryAnalyzer.java
@@ -1,9 +1,10 @@
-package retry;
+package testng;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
+import testng.annotation.RetryTest;
 
 public class FailureRetryAnalyzer implements IRetryAnalyzer {
   int currentRetry = 0;

--- a/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
+++ b/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
@@ -31,10 +31,10 @@ public class TestAnnotationTransformer implements IAnnotationTransformer {
   private void checkSkipTestAnnotation(ITestAnnotation annotation, Method testMethod) {
     NewUIOnly newUIOnly = testMethod.getAnnotation(NewUIOnly.class);
     // Read the configuration of using new UI or not from environment variable.
-    boolean isNewUIEnabled = Boolean.parseBoolean(System.getProperty(OLD_TEST_NEWUI));
+    boolean isNewUIEnabled = Boolean.parseBoolean(System.getenv(OLD_TEST_NEWUI));
     if (newUIOnly != null && newUIOnly.value()) {
       System.out.println("method name :" + testMethod);
-      System.out.println(System.getProperty(OLD_TEST_NEWUI));
+      System.out.println(System.getenv(OLD_TEST_NEWUI));
       System.out.println(isNewUIEnabled);
     }
 

--- a/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
+++ b/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
@@ -1,9 +1,10 @@
-package retry;
+package testng;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.ITestAnnotation;
+import testng.annotation.RetryTest;
 
 public class TestAnnotationTransformer implements IAnnotationTransformer {
 
@@ -12,7 +13,9 @@ public class TestAnnotationTransformer implements IAnnotationTransformer {
       ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
     if (testMethod == null) return;
     RetryTest maxRetryCount = testMethod.getAnnotation(RetryTest.class);
-    if (maxRetryCount == null || maxRetryCount.value() < 1) return;
-    annotation.setRetryAnalyzer(FailureRetryAnalyzer.class);
+
+    if (maxRetryCount != null && maxRetryCount.value() > 1) {
+      annotation.setRetryAnalyzer(FailureRetryAnalyzer.class);
+    }
   }
 }

--- a/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
+++ b/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
@@ -32,12 +32,6 @@ public class TestAnnotationTransformer implements IAnnotationTransformer {
     NewUIOnly newUIOnly = testMethod.getAnnotation(NewUIOnly.class);
     // Read the configuration of using new UI or not from environment variable.
     boolean isNewUIEnabled = Boolean.parseBoolean(System.getenv(OLD_TEST_NEWUI));
-    if (newUIOnly != null && newUIOnly.value()) {
-      System.out.println("method name :" + testMethod);
-      System.out.println(System.getenv(OLD_TEST_NEWUI));
-      System.out.println(isNewUIEnabled);
-    }
-
     // Skip tests that should not run against Old UI when CI is running in Old UI.
     if (newUIOnly != null && newUIOnly.value() && !isNewUIEnabled) {
       annotation.setEnabled(false);

--- a/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
+++ b/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
@@ -23,6 +23,12 @@ public class TestAnnotationTransformer implements IAnnotationTransformer {
     SkipTest skipTest = testMethod.getAnnotation(SkipTest.class);
     // Read the configuration of using new UI or not from environment variable.
     boolean isNewUIEnabled = Boolean.parseBoolean(System.getProperty(OLD_TEST_NEWUI));
+    if (skipTest != null && skipTest.skipOldUI()) {
+      System.out.println("method name :" + testMethod);
+      System.out.println(System.getProperty(OLD_TEST_NEWUI));
+      System.out.println(isNewUIEnabled);
+    }
+
     // Skip tests that should not run against Old UI when CI is running in Old UI.
     if (skipTest != null && skipTest.skipOldUI() && !isNewUIEnabled) {
       annotation.setEnabled(false);

--- a/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
+++ b/autotest/OldTests/src/test/java/testng/TestAnnotationTransformer.java
@@ -5,17 +5,27 @@ import java.lang.reflect.Method;
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.ITestAnnotation;
 import testng.annotation.RetryTest;
+import testng.annotation.SkipTest;
 
 public class TestAnnotationTransformer implements IAnnotationTransformer {
+  private static final String OLD_TEST_NEWUI = "OLD_TEST_NEWUI";
 
   @Override
   public void transform(
       ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
     if (testMethod == null) return;
-    RetryTest maxRetryCount = testMethod.getAnnotation(RetryTest.class);
 
+    RetryTest maxRetryCount = testMethod.getAnnotation(RetryTest.class);
     if (maxRetryCount != null && maxRetryCount.value() > 1) {
       annotation.setRetryAnalyzer(FailureRetryAnalyzer.class);
+    }
+
+    SkipTest skipTest = testMethod.getAnnotation(SkipTest.class);
+    // Read the configuration of using new UI or not from environment variable.
+    boolean isNewUIEnabled = Boolean.parseBoolean(System.getProperty(OLD_TEST_NEWUI));
+    // Skip tests that should not run against Old UI when CI is running in Old UI.
+    if (skipTest != null && skipTest.skipOldUI() && !isNewUIEnabled) {
+      annotation.setEnabled(false);
     }
   }
 }

--- a/autotest/OldTests/src/test/java/testng/annotation/NewUIOnly.java
+++ b/autotest/OldTests/src/test/java/testng/annotation/NewUIOnly.java
@@ -4,6 +4,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SkipTest {
-  boolean skipOldUI();
+public @interface NewUIOnly {
+  boolean value();
 }

--- a/autotest/OldTests/src/test/java/testng/annotation/NewUIOnly.java
+++ b/autotest/OldTests/src/test/java/testng/annotation/NewUIOnly.java
@@ -5,5 +5,5 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface NewUIOnly {
-  boolean value();
+  boolean value() default true;
 }

--- a/autotest/OldTests/src/test/java/testng/annotation/RetryTest.java
+++ b/autotest/OldTests/src/test/java/testng/annotation/RetryTest.java
@@ -1,4 +1,4 @@
-package retry;
+package testng.annotation;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/autotest/OldTests/src/test/java/testng/annotation/SkipTest.java
+++ b/autotest/OldTests/src/test/java/testng/annotation/SkipTest.java
@@ -1,0 +1,9 @@
+package testng.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SkipTest {
+  boolean skipOldUI();
+}

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -1,6 +1,8 @@
 name: SingleSuite
 threadCount: 1
-
+listeners:
+  - testng.TestAnnotationTransformer
+  -
 tests:
   - name: OneAfterAnother
     classes:

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -2,7 +2,6 @@ name: SingleSuite
 threadCount: 1
 listeners:
   - testng.TestAnnotationTransformer
-  -
 tests:
   - name: OneAfterAnother
     classes:

--- a/autotest/OldTests/testng.xml
+++ b/autotest/OldTests/testng.xml
@@ -2,7 +2,7 @@
 
 <suite name="EQUELLA testing" parallel="instances" data-provider-thread-count="4" thread-count="4" configfailurepolicy="continue">
   <listeners>
-    <listener class-name="retry.TestAnnotationTransformer"/>
+    <listener class-name="testng.TestAnnotationTransformer"/>
   </listeners>
   <suite-files>
 		<suite-file path="./testng-local-searching.xml"/>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,7 @@ env:
     KALTURA_BRANCH: master
     AUTOTEST_CONFIG: "autotest/codebuild.conf"
     EQ_EXIFTOOL_PATH: "/usr/bin/exiftool"
+    OLD_TEST_NEWUI: true
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
#### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Add the ability of skipping tests in TestNG at runtime based on the environment.

There are three steps done to support this.
1. Add a new annotation which is used to specify whether to skip a test or not.
2. In 'TestAnnotationTransformer', dynamically disable a test based on the annotation and environment.
3. Include the Transformer in `tesnng-codebuild.yaml `.

This PR also refactored the directory structure where `TestAnnotationTransformer` is sitting.  