### PR TITLE
feat(server): Maintain logo aspect ratio

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -267,7 +267,7 @@ export const languageStrings = {
       title: "Logo Settings",
       siteLogo: "Site Logo",
       siteLogoDescription:
-        "The main logo for the site, primarily displayed in the top left of pages. (Use a PNG file of 230x36 pixels for best results.)",
+        "The main logo for the site, primarily displayed in the top left of pages. (Use a PNG file with a maximum width of 230 pixels for best results.)",
     },
     errors: {
       invalidimagetitle: "Image Processing Error",

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/service/impl/ThemeSettingsServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/service/impl/ThemeSettingsServiceImpl.java
@@ -37,10 +37,15 @@ import io.bit3.jsass.Compiler;
 import io.bit3.jsass.Options;
 import io.bit3.jsass.Output;
 import io.bit3.jsass.context.StringContext;
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.net.URLConnection;
 import java.util.Collections;
 import javax.imageio.ImageIO;
@@ -54,6 +59,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("nls")
 @Bind(ThemeSettingsService.class)
 public class ThemeSettingsServiceImpl implements ThemeSettingsService {
+
   @Inject TLEAclManager tleAclManager;
   @Inject ConfigurationService configurationService;
   @Inject FileSystemService fileSystemService;
@@ -110,36 +116,19 @@ public class ThemeSettingsServiceImpl implements ThemeSettingsService {
   @Override
   public void setLogo(File logoFile) throws IOException {
     checkPermissions();
-    CustomisationFile customisationFile = new CustomisationFile();
-    // read in image file
-    BufferedImage bImage = null;
-    bImage = ImageIO.read(logoFile);
-    if (bImage == null) {
+
+    // Resize logo
+    BufferedImage logo = ImageIO.read(logoFile);
+    if (logo == null) {
       throw new IllegalArgumentException("Invalid image file");
     }
+    RenderedImage resizedLogo = resizeLogo(logo);
 
-    // resize image to logo size (230px x 36px)
-    BufferedImage resizedImage = new BufferedImage(230, 36, BufferedImage.TYPE_INT_ARGB);
-    Graphics2D g2d = (Graphics2D) resizedImage.getGraphics();
-    g2d.drawImage(
-        bImage,
-        0,
-        0,
-        resizedImage.getWidth() - 1,
-        resizedImage.getHeight() - 1,
-        0,
-        0,
-        bImage.getWidth() - 1,
-        bImage.getHeight() - 1,
-        null);
-    g2d.dispose();
-    RenderedImage rImage = resizedImage;
-
-    // write resized image to image file in the institution's filestore
+    // write resized logo to image file in the institution's filestore
     ByteArrayOutputStream os = new ByteArrayOutputStream();
-    ImageIO.write(rImage, "png", os);
+    ImageIO.write(resizedLogo, "png", os);
     InputStream fis = new ByteArrayInputStream(os.toByteArray());
-    fileSystemService.write(customisationFile, LOGO_FILENAME, fis, false);
+    fileSystemService.write(new CustomisationFile(), LOGO_FILENAME, fis, false);
     os.close();
     fis.close();
   }
@@ -217,5 +206,33 @@ public class ThemeSettingsServiceImpl implements ThemeSettingsService {
       LOGGER.debug("Failed to compile Sass to css ", e);
     }
     return legacyScss;
+  }
+
+  private BufferedImage resizeLogo(BufferedImage logo) {
+    if (logo == null) {
+      throw new IllegalArgumentException("resizeLogo() should not be called with a null logo.");
+    }
+
+    final int maxWidth = 230; // based on New UI layout
+    final int width = Math.min(maxWidth, logo.getWidth());
+    final float scale = (float) width / logo.getWidth();
+    final int height = (int) (logo.getHeight() * scale);
+
+    BufferedImage resizedLogo = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g2d = (Graphics2D) resizedLogo.getGraphics();
+    g2d.drawImage(
+        logo,
+        0,
+        0,
+        resizedLogo.getWidth() - 1,
+        resizedLogo.getHeight() - 1,
+        0,
+        0,
+        logo.getWidth() - 1,
+        logo.getHeight() - 1,
+        null);
+    g2d.dispose();
+
+    return resizedLogo;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Just a quick one when I was exploring what we can now do with setting up a custom theme. This increases what images we can use for a logo.

Biggest issue was before if you image was not 36px high, it'd get squashed and stretched making most images unrecognisable. As you can see in the screenshot, now we can use nice square ones for example - as somewhat common logo format.

#2478

![image](https://user-images.githubusercontent.com/43919233/97823693-d594a100-1d0d-11eb-8fdb-47330a545a83.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
