### PR TITLE
Use TestNG packages to run new REST endpoint tests

### DIFF
--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -137,6 +137,7 @@ tests:
       - io.github.openequella.rest.Search2ApiTest
       - io.github.openequella.rest.BaseEntityAPITest
       - io.github.openequella.search.NewSearchPageTest
+      - io.github.openequella.rest.MimeTypeApiTest
       - com.tle.webtests.test.webservices.soap.Soap51Test
       - com.tle.webtests.test.webservices.soap.SoapServicesTest
       - com.tle.webtests.test.webservices.OAIEndpointTest

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -4,6 +4,8 @@ listeners:
   - testng.TestAnnotationTransformer
 tests:
   - name: OneAfterAnother
+    packages:
+      - io.github.openequella.rest
     classes:
       - com.tle.webtests.test.searching.BrowsebyTest
       - com.tle.webtests.test.searching.CloudSearchingTest
@@ -133,11 +135,6 @@ tests:
       - com.tle.webtests.test.webservices.rest.TasksApiTest
       - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
       - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
-      - io.github.openequella.rest.AuthApiTest
-      - io.github.openequella.rest.Search2ApiTest
-      - io.github.openequella.rest.BaseEntityAPITest
-      - io.github.openequella.search.NewSearchPageTest
-      - io.github.openequella.rest.MimeTypeApiTest
       - com.tle.webtests.test.webservices.soap.Soap51Test
       - com.tle.webtests.test.webservices.soap.SoapServicesTest
       - com.tle.webtests.test.webservices.OAIEndpointTest

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -6,6 +6,7 @@ tests:
   - name: OneAfterAnother
     packages:
       - io.github.openequella.rest
+      - io.github.openequella.search
     classes:
       - com.tle.webtests.test.searching.BrowsebyTest
       - com.tle.webtests.test.searching.CloudSearchingTest


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

We can use `TestNG packages` to run all the functional tests  from package `io.github.openequella.rest` .