### PR TITLE
add storybook artifact to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,23 @@ jobs:
         run: |
           npm ci
 
+      - name: Generate Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+        npm run build-storybook
+
+      - name: Package Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+          tar cvf storybook.tar storybook-static
+
+      - name: Save Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          name: Storybook
+          path: storybook.tar
+
       - name: Run checks
         run: |
           npm run check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,12 +84,10 @@ jobs:
         npm run build-storybook
 
       - name: Package Static Storybook instance
-        working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
-          tar cvf storybook.tar storybook-static
+          tar cvf storybook.tar Source/Plugins/Core/com.equella.core/js/storybook-static
 
       - name: Save Static Storybook instance
-        working-directory: Source/Plugins/Core/com.equella.core/js
         uses: actions/upload-artifact@v2.2.0
         with:
           name: Storybook

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ generated.keystore
 Source/Plugins/Kaltura
 server.xml
 node_modules/
-
+storybook-static/


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
This PR is an attempt to bring in a static instance of our Storybook.io into the artifacts of GHA. 
Drafted until I see it working on CI. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
