### PR TITLE
Add steps to ci.yaml to build and artefact storybook

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/target
 **/output
 **/.psc-package
+**/storybook-static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,12 @@ jobs:
         run: |
           tar cvf storybook.tar Source/Plugins/Core/com.equella.core/js/storybook-static
 
+      - name: Remove Storybook Folder After Packaging
+        # We need this step so that storybook isn't included in the checks
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+          rm -R /storybook-static
+
       - name: Save Static Storybook instance
         uses: actions/upload-artifact@v2.2.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,13 +85,14 @@ jobs:
 
       - name: Package Static Storybook instance
         run: |
-          tar cvf storybook.tar Source/Plugins/Core/com.equella.core/js/storybook-static
+          tar cvf storybook.tar --transform='s/.\+\///' \
+          Source/Plugins/Core/com.equella.core/js/storybook-static
 
       - name: Remove Storybook Folder After Packaging
         # We need this step so that storybook isn't included in the checks
         working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
-          rm -R /storybook-static
+          rm -R storybook-static
 
       - name: Save Static Storybook instance
         uses: actions/upload-artifact@v2.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,9 +121,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm.storybook-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
+            ${{ runner.os }}-npm.storybook-
 
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -133,11 +133,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
-
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
 
       - name: Install node dependencies (core)
         working-directory: Source/Plugins/Core/com.equella.core/js

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,22 +125,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
-      - name: SBT Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-
-
-      - name: Ivy Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.ivy2/cache
-          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-          restore-keys: |
-            ${{ runner.os }}-ivy-
-
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
         id: nvm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,20 @@ jobs:
         run: |
           npm ci
 
+      - name: Generate Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+        npm run build-storybook
+
+      - name: Package Static Storybook instance
+        run: |
+          tar cvf storybook.tar Source/Plugins/Core/com.equella.core/js/storybook-static
+      - name: Save Static Storybook instance
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          name: Storybook
+          path: storybook.tar
+
       - name: Run checks
         run: |
           npm run check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,11 +94,10 @@ jobs:
           rm -R storybook-static
 
       - name: Save Static Storybook instance
-        working-directory: Source/Plugins/Core/com.equella.core/js
         uses: actions/upload-artifact@v2.2.0
         with:
           name: Storybook
-          path: storybook.tar
+          path: Source/Plugins/Core/com.equella.core/js/storybook.tar
 
       - name: Run checks
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,6 @@ jobs:
           tar cvf storybook.tar storybook-static
 
       - name: Remove Storybook Folder After Packaging
-        # We need this step so that storybook isn't included in the checks
         working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
           rm -R storybook-static

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,11 +81,12 @@ jobs:
       - name: Generate Static Storybook instance
         working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
-        npm run build-storybook
+          npm run build-storybook
 
       - name: Package Static Storybook instance
         run: |
           tar cvf storybook.tar Source/Plugins/Core/com.equella.core/js/storybook-static
+
       - name: Save Static Storybook instance
         uses: actions/upload-artifact@v2.2.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,9 +84,9 @@ jobs:
           npm run build-storybook
 
       - name: Package Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
         run: |
-          tar cvf storybook.tar --transform='s/.\+\///' \
-          Source/Plugins/Core/com.equella.core/js/storybook-static
+          tar cvf storybook.tar storybook-static
 
       - name: Remove Storybook Folder After Packaging
         # We need this step so that storybook isn't included in the checks
@@ -95,6 +95,7 @@ jobs:
           rm -R storybook-static
 
       - name: Save Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
         uses: actions/upload-artifact@v2.2.0
         with:
           name: Storybook

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,27 +78,6 @@ jobs:
         run: |
           npm ci
 
-      - name: Generate Static Storybook instance
-        working-directory: Source/Plugins/Core/com.equella.core/js
-        run: |
-          npm run build-storybook
-
-      - name: Package Static Storybook instance
-        working-directory: Source/Plugins/Core/com.equella.core/js
-        run: |
-          tar cvf storybook.tar storybook-static
-
-      - name: Remove Storybook Folder After Packaging
-        working-directory: Source/Plugins/Core/com.equella.core/js
-        run: |
-          rm -R storybook-static
-
-      - name: Save Static Storybook instance
-        uses: actions/upload-artifact@v2.2.0
-        with:
-          name: Storybook
-          path: Source/Plugins/Core/com.equella.core/js/storybook.tar
-
       - name: Run checks
         run: |
           npm run check
@@ -130,6 +109,72 @@ jobs:
         with:
           name: Artefacts
           path: artefacts.tar
+
+  build_storybook:
+    runs-on: ubuntu-latest
+    steps:
+      # Using v1 (rather than v2) through-out this workflow due to issue:
+      # https://github.com/actions/checkout/issues/237
+      - uses: actions/checkout@v1
+
+      - name: NPM Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: SBT Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+
+      - name: Ivy Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ivy2/cache
+          key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-ivy-
+
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Install node dependencies (core)
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+          npm ci
+
+      - name: Generate Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+          npm run build-storybook
+
+      - name: Package Static Storybook instance
+        working-directory: Source/Plugins/Core/com.equella.core/js
+        run: |
+          tar cvf storybook.tar storybook-static
+
+      - name: Save Static Storybook instance
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          name: Storybook
+          path: Source/Plugins/Core/com.equella.core/js/storybook.tar
 
   build_import_export_tool:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ generated.keystore
 Source/Plugins/Kaltura
 server.xml
 node_modules/
-
+storybook-static/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ generated.keystore
 Source/Plugins/Kaltura
 server.xml
 node_modules/
-storybook-static/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules/
+storybook-static/

--- a/Source/Plugins/Core/com.equella.core/js/.gitignore
+++ b/Source/Plugins/Core/com.equella.core/js/.gitignore
@@ -11,3 +11,4 @@
 /public/
 yarn-error.log
 .vscode
+storybook-static/

--- a/Source/Plugins/Core/com.equella.core/js/tsconfig.json
+++ b/Source/Plugins/Core/com.equella.core/js/tsconfig.json
@@ -35,6 +35,7 @@
     "acceptance-tests",
     "webpack",
     "jest",
-    "src/setupTests.ts"
+    "src/setupTests.ts",
+    "storybook-static"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
This PR adds steps to GitHub Actions workflow to build the static instance of Storybook and upload it as an artefact. 
Drafted until I see it working on CI.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
