### PR TITLE
chore(sbt): Add rebuild task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -245,16 +245,26 @@ sources in (Compile, doc) := {
 }
 javacOptions in (Compile, doc) := Seq()
 
-lazy val cleanrun = taskKey[Unit]("clean, build and run a dev server")
-
 lazy val allEquella = ScopeFilter(inAggregates(equella))
 
-cleanrun := {
+lazy val devrebuild = taskKey[Unit]("clean and build all code - targeting a local dev run")
+
+devrebuild := {
   Def
     .sequential(
       clean.all(allEquella),
       jpfWriteDevJars.all(allPluginsScope),
       (fullClasspath in Compile).all(allEquella),
+    )
+    .value
+}
+
+lazy val cleanrun = taskKey[Unit]("clean, build and run a dev server")
+
+cleanrun := {
+  Def
+    .sequential(
+      devrebuild,
       (run in equellaserver).toTask("")
     )
     .value


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

We currently only have a 'rebuild' task that also starts the server.
Often though after pulling latest code, all I want is a rebuild to
ensure my working copy is all clean before starting in the IDE.
Typically, projects have a 'rebuild' task to help with this workflow.

With this new task you can now simply:

```
sbt devrebuild
```

or, if you do want the server to start as well

```
sbt cleanrun
```

or, if after doing the above `sbt devrebuild` you later just want to start the server you can follow with:

```
sbt equellaserver/run
```

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
