### PR TITLE
Fix view video attachments from New Search UI search results

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/ViewerModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/ViewerModule.test.ts
@@ -16,7 +16,10 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
-import { determineViewer } from "../../../tsrc/modules/ViewerModule";
+import {
+  determineAttachmentViewUrl,
+  determineViewer,
+} from "../../../tsrc/modules/ViewerModule";
 
 describe("determineViewer()", () => {
   const fileAttachmentType = "file";
@@ -57,4 +60,26 @@ describe("determineViewer()", () => {
         )
       ).toEqual(["lightbox", fileViewUrl])
   );
+});
+
+describe("determineAttachmentViewUrl()", () => {
+  const viewUrl = "http://blah/blah";
+  const uuid = "uuid";
+  const version = 1;
+
+  it("returns the viewUrl for non 'file' attachmentType", () =>
+    expect(
+      determineAttachmentViewUrl(uuid, version, "link", viewUrl, undefined)
+    ).toEqual(viewUrl));
+
+  it("returns an oEQ 'file' URL for attachmentType 'file'", () =>
+    expect(
+      determineAttachmentViewUrl(
+        uuid,
+        version,
+        "file",
+        viewUrl,
+        "directory/file.txt"
+      )
+    ).toEqual("file/uuid/1/directory/file.txt"));
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/ViewerModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/ViewerModule.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
+import { AppConfig } from "../AppConfig";
 import { isLightboxSupportedMimeType } from "../components/Lightbox";
 
 export type Viewer = "lightbox" | "link";
@@ -65,3 +66,24 @@ export const determineViewer = (
 
   return simpleLinkView;
 };
+
+/**
+ * Based on attachment type, builds either a direct link to a file attachment URL or uses the
+ * provided `viewUrl`.
+ *
+ * @param itemUuid The attachment item's UUID
+ * @param itemVersion The attachment item's version
+ * @param attachmentType The type of the attachment - as provided by the server
+ * @param viewUrl The default 'view' link provided by the server for the attachment
+ * @param fileAttachmentPath If attachment type of 'file' then the `filePath` provided by the server
+ */
+export const determineAttachmentViewUrl = (
+  itemUuid: string,
+  itemVersion: number,
+  attachmentType: string,
+  viewUrl: string,
+  fileAttachmentPath?: string
+): string =>
+  attachmentType === "file"
+    ? `${AppConfig.baseUrl}file/${itemUuid}/${itemVersion}/${fileAttachmentPath}`
+    : viewUrl;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -40,6 +40,7 @@ import * as React from "react";
 import { SyntheticEvent, useEffect, useState } from "react";
 import ReactHtmlParser from "react-html-parser";
 import { Link } from "react-router-dom";
+import { HashLink } from "react-router-hash-link";
 import { sprintf } from "sprintf-js";
 import { Date as DateDisplay } from "../../components/Date";
 import ItemAttachmentLink from "../../components/ItemAttachmentLink";
@@ -47,10 +48,12 @@ import OEQThumb from "../../components/OEQThumb";
 import { StarRating } from "../../components/StarRating";
 import { routes } from "../../mainui/routes";
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
-import { determineViewer } from "../../modules/ViewerModule";
+import {
+  determineAttachmentViewUrl,
+  determineViewer,
+} from "../../modules/ViewerModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
-import { HashLink } from "react-router-hash-link";
 
 const useStyles = makeStyles((theme: Theme) => {
   return {
@@ -289,11 +292,19 @@ export default function SearchResult({
           attachmentType,
           description,
           id,
-          links: { view: url },
+          links: { view: defaultViewUrl },
           mimeType,
+          filePath,
         },
         viewerDetails,
       }: AttachmentAndViewerDetails) => {
+        const viewUrl = determineAttachmentViewUrl(
+          uuid,
+          version,
+          attachmentType,
+          defaultViewUrl,
+          filePath
+        );
         return (
           <ListItem key={id} button className={classes.nested}>
             <ListItemIcon>
@@ -304,7 +315,7 @@ export default function SearchResult({
               mimeType={mimeType}
               viewerDetails={determineViewer(
                 attachmentType,
-                url,
+                viewUrl,
                 mimeType,
                 viewerDetails?.viewerId
               )}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -24,9 +24,8 @@ import java.util.Date
 
 import com.dytech.edge.exceptions.BadRequestException
 import com.tle.beans.entity.DynaCollection
-import com.tle.beans.item.{Comment, ItemIdKey, ItemStatus}
+import com.tle.beans.item.{Comment, ItemIdKey}
 import com.tle.common.Check
-import com.tle.common.Utils.parseDate
 import com.tle.common.beans.exception.NotFoundException
 import com.tle.common.search.DefaultSearch
 import com.tle.common.search.whereparser.WhereParser
@@ -41,6 +40,7 @@ import com.tle.web.api.item.equella.interfaces.beans.{
 }
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
 import com.tle.web.api.search.model.{SearchParam, SearchResultAttachment, SearchResultItem}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -225,7 +225,8 @@ object SearchHelper {
               preview = att.isPreview,
               mimeType = getMimetypeForAttachment(att),
               hasGeneratedThumb = thumbExists(itemKey, att),
-              links = getLinksFromBean(att)
+              links = getLinksFromBean(att),
+              filePath = getFilePathForAttachment(att)
           ))
           .toList)
   }
@@ -240,7 +241,6 @@ object SearchHelper {
     * Determines if attachment contains a generated thumbnail in filestore
     */
   def thumbExists(itemKey: ItemIdKey, attachBean: AttachmentBean): Option[Boolean] = {
-
     attachBean match {
       case fileBean: FileAttachmentBean =>
         val item = LegacyGuice.viewableItemFactory.createNewViewableItem(itemKey)
@@ -261,6 +261,18 @@ object SearchHelper {
       case _ => None
     }
   }
+
+  /**
+    * If the attachment is a file, then return the path for that attachment.
+    *
+    * @param attachment a potential file attachment
+    * @return the path of the provided file attachment
+    */
+  def getFilePathForAttachment(attachment: AttachmentBean): Option[String] =
+    attachment match {
+      case fileAttachment: FileAttachmentBean => Option(fileAttachment.getFilename)
+      case _                                  => None
+    }
 
   /**
     * Extract the value of 'links' from the 'extras' of AbstractExtendableBean.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -69,6 +69,7 @@ case class SearchResultItem(
   * @param mimeType Mime Type of file based attachments
   * @param hasGeneratedThumb Indicates if file based attachments have a generated thumbnail store in filestore
   * @param links Attachment's links.
+  * @param filePath If a file attachment, the path for the represented file
   */
 case class SearchResultAttachment(
     attachmentType: String,
@@ -77,5 +78,6 @@ case class SearchResultAttachment(
     preview: Boolean,
     mimeType: Option[String],
     hasGeneratedThumb: Option[Boolean],
-    links: java.util.Map[String, String]
+    links: java.util.Map[String, String],
+    filePath: Option[String]
 )

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -163,6 +163,10 @@ export interface Attachment {
      */
     thumbnail: string;
   };
+  /**
+   * If a file attachment, the path for the represented file
+   */
+  filePath?: string;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Unfortunately, unless the viewer for the video MIME types was configured as 'file' then the viewer would fail. By default, the viewer is the HTML 5 Viewer of oEQ, so it was attempting to use the resultant HTML from that page in a `<video>` tag.

To fix this, the path of the file for file attachments is also returned in the attachment data for search results. This can then be used by the front end to build a direct `file` URL when wanted. In the case of the viewer, this is pretty well always unless the viewer configuration is for download.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
