### PR TITLE
Include Selection Session information in RenderData.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -20,9 +20,22 @@ import * as ReactDOM from "react-dom";
 import { initStrings } from "../util/langstrings";
 import "../util/polyfill";
 
+/**
+ * Structure of Selection Session information which is used to help build
+ * components(e.g. SearchResult) in the context of Selection Session.
+ */
 interface SelectionSessionInfo {
+  /**
+   * The ID of a Selection Session
+   */
   stateId: string;
+  /**
+   * The ID of an LMS Integration
+   */
   integId?: string;
+  /**
+   * The UI layout used in Selection Session
+   */
   layout: string;
 }
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -20,11 +20,18 @@ import * as ReactDOM from "react-dom";
 import { initStrings } from "../util/langstrings";
 import "../util/polyfill";
 
+interface SelectionSessionInfo {
+  stateId: string;
+  integId?: string;
+  layout: string;
+}
+
 export interface RenderData {
   baseResources: string;
   newUI: boolean;
   autotestMode: boolean;
   newSearch: boolean;
+  selectionSessionInfo: SelectionSessionInfo | null;
 }
 export type EntryPage = "mainDiv" | "searchPage" | "settingsPage";
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -159,7 +159,7 @@ object RenderNewTemplate {
 
       val integrationSection: IntegrationSection =
         context.lookupSection(classOf[IntegrationSection])
-      val integId = integrationSection.getStateId(context)
+      val integId = Option(integrationSection).map(_.getStateId(context)).orNull
 
       val selectionSessionInfo = new ObjectExpression
       selectionSessionInfo.put("stateId", stateId)


### PR DESCRIPTION
#688 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds Selection Session data to `renderData` for the new search UI.  The data includes: the ID of a Selection Session, the ID of an Integration and the layout which is used.

![image](https://user-images.githubusercontent.com/47203811/98628940-d8c20980-236b-11eb-8d91-ff89460a3069.png)


![image](https://user-images.githubusercontent.com/47203811/98628966-e8d9e900-236b-11eb-81d5-4bb52c7eb3e5.png)
