### PR TITLE
Feature - REST API to retrieve advanced searches

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
@@ -1,0 +1,30 @@
+package com.tle.web.api.settings
+
+import com.tle.beans.entity.BaseEntityLabel
+import com.tle.legacy.LegacyGuice
+import io.swagger.annotations.{Api, ApiOperation}
+import javax.ws.rs.core.Response
+import javax.ws.rs.{GET, Path, Produces}
+import org.jboss.resteasy.annotations.cache.NoCache
+
+/**
+  * API for managing Advanced Searches (internally - and historically - known as Power Searches).
+  */
+@NoCache
+@Path("settings/advancedsearch/")
+@Produces(value = Array("application/json"))
+@Api(value = "Settings")
+class AdvancedSearchResource {
+  private val powerSearchService = LegacyGuice.powerSearchService
+
+  @GET
+  @ApiOperation(
+    value = "List available Advanced Searches",
+    notes =
+      "This endpoint is used to retrieve available Advanced Searches and is secured by SEARCH_POWER_SEARCH",
+    response = classOf[BaseEntityLabel],
+    responseContainer = "List"
+  )
+  def getAll: Response =
+    Response.ok().entity(powerSearchService.listSearchable()).build()
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.settings
 
 import com.tle.beans.entity.BaseEntityLabel

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchService.java
@@ -29,6 +29,12 @@ import java.util.List;
 /** @author Nicholas Read */
 public interface PowerSearchService
     extends AbstractEntityService<EntityEditingBean, PowerSearch>, RemotePowerSearchService {
+
+  /**
+   * List all available Power Searches (Advanced Searches) assuming 'SEARCH_POWER_SEARCH' ACL.
+   *
+   * @return available power searches
+   */
   List<BaseEntityLabel> listSearchable();
 
   List<BaseEntityLabel> listAllForSchema(long schemaId);

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AbstractRestApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AbstractRestApiTest.java
@@ -17,13 +17,24 @@ import org.testng.annotations.BeforeClass;
 @TestInstitution("rest")
 public class AbstractRestApiTest {
 
-  protected static final TestConfig TEST_CONFIG = new TestConfig(AbstractRestApiTest.class);
   protected static final String USERNAME = "AutoTest";
   protected static final String PASSWORD = "automated";
-  private static final String AUTH_API_ENDPOINT = TEST_CONFIG.getInstitutionUrl() + "api/auth";
+
+  protected TestConfig testConfig = null;
 
   protected final HttpClient httpClient = new HttpClient();
   protected final ObjectMapper mapper = new ObjectMapper();
+
+  public String getAuthApiEndpoint() {
+    return getTestConfig().getInstitutionUrl() + "api/auth";
+  }
+
+  protected TestConfig getTestConfig() {
+    if (testConfig == null) {
+      testConfig = new TestConfig(AbstractRestApiTest.class);
+    }
+    return testConfig;
+  }
 
   @BeforeClass
   public void login() throws IOException {
@@ -40,7 +51,7 @@ public class AbstractRestApiTest {
   }
 
   protected HttpMethod buildLoginMethod(String username, String password) {
-    final String loginEndpoint = AUTH_API_ENDPOINT + "/login";
+    final String loginEndpoint = getAuthApiEndpoint() + "/login";
     final NameValuePair[] queryVals = {
       new NameValuePair("username", username), new NameValuePair("password", password)
     };
@@ -50,13 +61,13 @@ public class AbstractRestApiTest {
   }
 
   protected HttpMethod buildLogoutMethod() {
-    final String logoutEndpoint = AUTH_API_ENDPOINT + "/logout";
-    final HttpMethod method = new PutMethod(logoutEndpoint);
-    return method;
+    final String logoutEndpoint = getAuthApiEndpoint() + "/logout";
+    return new PutMethod(logoutEndpoint);
   }
 
   protected boolean hasAuthenticatedSession() throws IOException {
-    final String userDetailsEndpoint = TEST_CONFIG.getInstitutionUrl() + "api/content/currentuser";
+    final String userDetailsEndpoint =
+        getTestConfig().getInstitutionUrl() + "api/content/currentuser";
     final HttpMethod method = new GetMethod(userDetailsEndpoint);
     if (makeClientRequest(method) != HttpStatus.SC_OK) {
       throw new RuntimeException(

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
@@ -1,0 +1,118 @@
+package io.github.openequella.rest;
+
+import static org.junit.Assert.assertEquals;
+
+import com.tle.webtests.framework.TestConfig;
+import com.tle.webtests.framework.TestInstitution;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.codehaus.jackson.type.TypeReference;
+import org.testng.annotations.Test;
+
+@TestInstitution("fiveo")
+public class AdvancedSearchApiTest extends AbstractRestApiTest {
+  private final String ADVANCEDSEARCH_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/settings/advancedsearch";
+
+  @Override
+  protected TestConfig getTestConfig() {
+    if (testConfig == null) {
+      testConfig = new TestConfig(AdvancedSearchApiTest.class);
+    }
+    return testConfig;
+  }
+
+  @Test
+  public void testRetrieveAdvancedSearches() throws Exception {
+    final List<BaseEntityLabel> searches = getAdvancedSearches();
+    assertEquals(
+        "The number of returned advanced searches should match the institution total.",
+        3,
+        searches.size());
+  }
+
+  private List<BaseEntityLabel> getAdvancedSearches() throws IOException {
+    final HttpMethod method = new GetMethod(ADVANCEDSEARCH_API_ENDPOINT);
+    assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
+    return mapper.readValue(
+        method.getResponseBodyAsString(), new TypeReference<List<BaseEntityLabel>>() {});
+  }
+
+  private static class BaseEntityLabel {
+    private String owner;
+    private String privType;
+    private String uuid;
+    private String value;
+    private boolean systemType;
+    private long bundleId;
+    private long id;
+    private long idValue;
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public void setOwner(String owner) {
+      this.owner = owner;
+    }
+
+    public String getPrivType() {
+      return privType;
+    }
+
+    public void setPrivType(String privType) {
+      this.privType = privType;
+    }
+
+    public String getUuid() {
+      return uuid;
+    }
+
+    public void setUuid(String uuid) {
+      this.uuid = uuid;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public boolean isSystemType() {
+      return systemType;
+    }
+
+    public void setSystemType(boolean systemType) {
+      this.systemType = systemType;
+    }
+
+    public long getBundleId() {
+      return bundleId;
+    }
+
+    public void setBundleId(long bundleId) {
+      this.bundleId = bundleId;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public long getIdValue() {
+      return idValue;
+    }
+
+    public void setIdValue(long idValue) {
+      this.idValue = idValue;
+    }
+  }
+}

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/BaseEntityAPITest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/BaseEntityAPITest.java
@@ -14,8 +14,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class BaseEntityAPITest extends AbstractRestApiTest {
-  private static final String COLLECTION_API_ENDPOINT =
-      TEST_CONFIG.getInstitutionUrl() + "api/collection";
+  private final String COLLECTION_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/collection";
   private final String PERMISSION = "SEARCH_COLLECTION";
 
   @DataProvider(name = "initialResumptionTokens")

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
@@ -14,8 +14,7 @@ import org.testng.annotations.Test;
 
 public class MimeTypeApiTest extends AbstractRestApiTest {
 
-  private static final String MIMETYPE_API_ENDPOINT =
-      TEST_CONFIG.getInstitutionUrl() + "api/mimetype";
+  private final String MIMETYPE_API_ENDPOINT = getTestConfig().getInstitutionUrl() + "api/mimetype";
 
   @Test
   public void testRetrieveMimeTypes() throws Exception {

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class Search2ApiTest extends AbstractRestApiTest {
-  private static final String SEARCH_API_ENDPOINT = TEST_CONFIG.getInstitutionUrl() + "api/search2";
+  private final String SEARCH_API_ENDPOINT = getTestConfig().getInstitutionUrl() + "api/search2";
 
   @Test(description = "Search without parameters")
   public void noParamSearchTest() throws IOException {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Added a new simple `api/settings/advancedsearches/` for retrieval of Advanced Searches (aka Power Searches).

While doing this, also needed to refactor a couple of supporting classes.

![image](https://user-images.githubusercontent.com/43919233/98898643-2ec8b580-2502-11eb-8a63-666b22869420.png)

#1306

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
