### PR TITLE
Feature/new search query params

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/searchOptions.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/searchOptions.mock.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SearchOptions } from "../tsrc/modules/SearchModule";
+import { SortOrder } from "../tsrc/modules/SearchSettingsModule";
+import { getCollectionMap } from "../__mocks__/getCollectionsResp";
+import { users } from "./UserSearch.mock";
+
+export const allSearchOptions: SearchOptions = {
+  rowsPerPage: 10,
+  currentPage: 0,
+  sortOrder: SortOrder.NAME,
+  rawMode: true,
+  status: ["LIVE", "REVIEW"],
+  searchAttachments: true,
+  query: "test machine",
+  collections: getCollectionMap,
+  selectedCategories: [
+    { id: 766943, categories: ["Hobart"] },
+    { id: 766944, categories: ["Some cool things"] },
+  ],
+  lastModifiedDateRange: {
+    start: new Date("2020-05-26T13:24:00.889+10:00"),
+    end: new Date("2020-05-27T13:24:00.889+10:00"),
+  },
+  owner: users[0],
+};

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/searchOptions.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/searchOptions.mock.ts
@@ -15,15 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SearchOptions } from "../tsrc/modules/SearchModule";
-import { SortOrder } from "../tsrc/modules/SearchSettingsModule";
 import { getCollectionMap } from "../__mocks__/getCollectionsResp";
+import { SearchOptions } from "../tsrc/modules/SearchModule";
 import { users } from "./UserSearch.mock";
 
 export const allSearchOptions: SearchOptions = {
   rowsPerPage: 10,
   currentPage: 0,
-  sortOrder: SortOrder.NAME,
+  sortOrder: "NAME",
   rawMode: true,
   status: ["LIVE", "REVIEW"],
   searchAttachments: true,

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
@@ -17,15 +17,19 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
+import { allSearchOptions } from "../../../__mocks__/searchOptions.mock";
 import { getSearchResult } from "../../../__mocks__/SearchResult.mock";
 import { users } from "../../../__mocks__/UserSearch.mock";
-import * as CollectionModule from "../../../tsrc/modules/CollectionsModule";
+import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
 import {
-  convertParamsToSearchOptions,
+  queryStringParamsToSearchOptions,
   DateRange,
   defaultSearchOptions,
+  generateQueryStringFromSearchOptions,
+  legacyQueryStringToSearchOptions,
+  newSearchQueryToSearchOptions,
   SearchOptions,
 } from "../../../tsrc/modules/SearchModule";
 import { SortOrder } from "../../../tsrc/modules/SearchSettingsModule";
@@ -116,10 +120,10 @@ describe("SearchModule", () => {
     expect(SearchModule.generateCategoryWhereQuery([])).toBeUndefined();
   });
 
-  describe("convertParamsToSearchOptions", () => {
+  describe("newSearchQueryToSearchOptions", () => {
     const mockedResolvedUser = jest.spyOn(UserModule, "resolveUsers");
     const mockedCollectionListSummary = jest.spyOn(
-      CollectionModule,
+      CollectionsModule,
       "collectionListSummary"
     );
 
@@ -127,15 +131,46 @@ describe("SearchModule", () => {
       jest.clearAllMocks();
     });
 
+    it("should convert query string to searchOptions", async () => {
+      mockedResolvedUser.mockResolvedValue(users);
+      mockedCollectionListSummary.mockResolvedValueOnce(getCollectionMap);
+      const longSearch =
+        '{"rowsPerPage":10,"currentPage":0,"sortOrder":"NAME","query":"test machine","rawMode":true,"status":["LIVE","REVIEW"],"searchAttachments":true,"selectedCategories":[{"id":766943,"categories":["Hobart"]},{"id":766944,"categories":["Some cool things"]}],"collections":[{"uuid":"8e3caf16-f3cb-b3dd-d403-e5eb8d545fff"},{"uuid":"8e3caf16-f3cb-b3dd-d403-e5eb8d545ffe"},{"uuid":"8e3caf16-f3cb-b3dd-d403-e5eb8d545ffg"},{"uuid":"8e3caf16-f3cb-b3dd-d403-e5eb8d545ffa"},{"uuid":"8e3caf16-f3cb-b3dd-d403-e5eb8d545ffb"}],"lastModifiedDateRange":{"start":"2020-05-26T03:24:00.889Z","end":"2020-05-27T03:24:00.889Z"},"owner":{"id":"680f5eb7-22e2-4ab6-bcea-25205165e36e"}}';
+      const convertedParamsPromise = await newSearchQueryToSearchOptions(
+        longSearch
+      );
+      expect(convertedParamsPromise).toEqual(allSearchOptions);
+    });
+  });
+
+  describe("convertParamsToSearchOptions", () => {
+    const mockLocation = {
+      pathname: "/search",
+      hash: "",
+      search: "",
+      state: "",
+    };
     it("should return undefined if no query string parameters are defined", async () => {
-      const convertedParamsPromise = await convertParamsToSearchOptions("");
+      const convertedParamsPromise = await queryStringParamsToSearchOptions(
+        mockLocation
+      );
       expect(convertedParamsPromise).toBeUndefined();
     });
+  });
+
+  describe("legacyQueryStringToSearchOptions", () => {
+    const mockedResolvedUser = jest.spyOn(UserModule, "resolveUsers");
+    const mockedCollectionListSummary = jest.spyOn(
+      CollectionsModule,
+      "collectionListSummary"
+    );
 
     it("should return default search for any parameters that aren't supported", async () => {
       const unsupportedQueryString = "?test=nothing&cool=beans";
       expect(
-        await convertParamsToSearchOptions(unsupportedQueryString)
+        await legacyQueryStringToSearchOptions(
+          new URLSearchParams(unsupportedQueryString)
+        )
       ).toEqual(defaultSearchOptions);
     });
 
@@ -147,8 +182,8 @@ describe("SearchModule", () => {
       const fullQueryString =
         "?in=C8e3caf16-f3cb-b3dd-d403-e5eb8d545fff&q=test&sort=datecreated&owner=680f5eb7-22e2-4ab6-bcea-25205165e36e&dp=1601510400000&dr=AFTER";
 
-      const convertedParamsPromise = await convertParamsToSearchOptions(
-        fullQueryString
+      const convertedParamsPromise = await legacyQueryStringToSearchOptions(
+        new URLSearchParams(fullQueryString)
       );
 
       const expectedSearchOptions: SearchOptions = {
@@ -209,8 +244,8 @@ describe("SearchModule", () => {
     ])(
       "converts legacy date range query params: %s to search options containing lastModifiedDateRange of %s",
       async (queryString, expectedRange) => {
-        const convertedSearchOptions = await convertParamsToSearchOptions(
-          queryString
+        const convertedSearchOptions = await legacyQueryStringToSearchOptions(
+          new URLSearchParams(queryString)
         );
         expect(convertedSearchOptions).toEqual({
           ...defaultSearchOptions,
@@ -223,10 +258,25 @@ describe("SearchModule", () => {
       mockedResolvedUser.mockResolvedValue([]);
       mockedCollectionListSummary.mockResolvedValue(getCollectionMap);
       const collectionQueryString = "?in=Cunknowncollection&owner=unknown";
-      const convertedSearchOptions = await convertParamsToSearchOptions(
-        collectionQueryString
+      const convertedSearchOptions = await legacyQueryStringToSearchOptions(
+        new URLSearchParams(collectionQueryString)
       );
       expect(convertedSearchOptions).toEqual(defaultSearchOptions);
+    });
+  });
+
+  describe("generateQueryStringFromSearchOptions", () => {
+    it("converts all searchOptions to a url encoded json string", () => {
+      expect(generateQueryStringFromSearchOptions(allSearchOptions)).toEqual(
+        "searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22NAME%22%2C%22rawMode%22%3Atrue%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22test+machine%22%2C%22collections%22%3A%5B%7B%22uuid%22%3A%228e3caf16-f3cb-b3dd-d403-e5eb8d545fff%22%7D%2C%7B%22uuid%22%3A%228e3caf16-f3cb-b3dd-d403-e5eb8d545ffe%22%7D%2C%7B%22uuid%22%3A%228e3caf16-f3cb-b3dd-d403-e5eb8d545ffg%22%7D%2C%7B%22uuid%22%3A%228e3caf16-f3cb-b3dd-d403-e5eb8d545ffa%22%7D%2C%7B%22uuid%22%3A%228e3caf16-f3cb-b3dd-d403-e5eb8d545ffb%22%7D%5D%2C%22selectedCategories%22%3A%5B%7B%22id%22%3A766943%2C%22categories%22%3A%5B%22Hobart%22%5D%7D%2C%7B%22id%22%3A766944%2C%22categories%22%3A%5B%22Some+cool+things%22%5D%7D%5D%2C%22lastModifiedDateRange%22%3A%7B%22start%22%3A%222020-05-26T03%3A24%3A00.889Z%22%2C%22end%22%3A%222020-05-27T03%3A24%3A00.889Z%22%7D%2C%22owner%22%3A%7B%22id%22%3A%22680f5eb7-22e2-4ab6-bcea-25205165e36e%22%7D%7D"
+      );
+    });
+
+    it("excludes any undefined properties", () => {
+      //defaultSearchOptions contains an an undefined sortOrder property
+      expect(
+        generateQueryStringFromSearchOptions(defaultSearchOptions)
+      ).not.toContain("sortOrder");
     });
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
@@ -288,7 +288,7 @@ describe("SearchModule", () => {
     });
 
     it("excludes any undefined properties", () => {
-      //defaultSearchOptions contains an an undefined sortOrder property
+      //defaultSearchOptions contains an undefined sortOrder property
       expect(
         generateQueryStringFromSearchOptions(defaultSearchOptions)
       ).not.toContain("sortOrder");

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -30,7 +30,6 @@ import { createMemoryHistory } from "history";
 import * as React from "react";
 import { act } from "react-dom/test-utils";
 import { Router } from "react-router-dom";
-import * as MimeTypesModule from "../../../tsrc/modules/MimeTypesModule";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
 import {
@@ -41,6 +40,7 @@ import {
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { Collection } from "../../../tsrc/modules/CollectionsModule";
+import * as MimeTypesModule from "../../../tsrc/modules/MimeTypesModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
@@ -100,7 +100,7 @@ jest
 
 const defaultSearchPageOptions: SearchPageOptions = {
   ...SearchModule.defaultSearchOptions,
-  sortOrder: SearchSettingsModule.SortOrder.RANK,
+  sortOrder: "RANK",
   dateRangeQuickModeEnabled: true,
 };
 const defaultCollectionPrivileges = [OEQ.Acl.ACL_SEARCH_COLLECTION];
@@ -473,9 +473,7 @@ describe("<SearchPage/>", () => {
   it("should clear search options and perform a new search", async () => {
     const { container } = page;
     const query = "clear query";
-    const sortingDropdown = screen.getByDisplayValue(
-      SearchSettingsModule.SortOrder.RANK
-    );
+    const sortingDropdown = screen.getByDisplayValue("RANK");
     const newSearchButton = screen.getByText(
       languageStrings.searchpage.newSearch
     );
@@ -493,7 +491,7 @@ describe("<SearchPage/>", () => {
     // Perform a new search and check.
     fireEvent.click(newSearchButton);
     await waitFor(() => {
-      expect(sortingDropdown).toHaveValue(SearchSettingsModule.SortOrder.RANK);
+      expect(sortingDropdown).toHaveValue("RANK");
       expect(getQueryBar(container)).toHaveValue("");
     });
     // Four searches have been performed: initial search, one for query change and
@@ -615,7 +613,7 @@ describe("<SearchPage/>", () => {
     // sort order is included in the search params
     expect(SearchModule.searchItems).toHaveBeenCalledWith({
       ...defaultSearchPageOptions,
-      sortOrder: SearchSettingsModule.SortOrder.DATEMODIFIED,
+      sortOrder: "DATEMODIFIED",
     });
   });
 

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -80,7 +80,7 @@ const mockSearchSettings = jest.spyOn(
 );
 const mockConvertParamsToSearchOptions = jest.spyOn(
   SearchModule,
-  "convertParamsToSearchOptions"
+  "queryStringParamsToSearchOptions"
 );
 window.scrollTo = jest.fn();
 const searchSettingPromise = mockSearchSettings.mockResolvedValue(
@@ -128,6 +128,7 @@ const renderSearchPage = async (
   window.history.replaceState({}, "Clean history state");
   const history = createMemoryHistory();
   if (queryString) history.push(queryString);
+  history.push({});
 
   const page = render(
     <Router history={history}>
@@ -683,7 +684,7 @@ describe("<SearchPage/>", () => {
   });
 });
 
-describe("conversion of legacy query parameters to SearchPageOptions", () => {
+describe("conversion of parameters to SearchPageOptions", () => {
   const searchPageOptions: SearchPageOptions = {
     ...defaultSearchPageOptions,
     dateRangeQuickModeEnabled: false,
@@ -697,11 +698,10 @@ describe("conversion of legacy query parameters to SearchPageOptions", () => {
     jest.clearAllMocks();
   });
 
-  it("should call convertParamsToSearchOptions using query paramaters in url", async () => {
+  it("should call queryStringParamsToSearchOptions using query paramaters in url", async () => {
     await renderSearchPage("?q=test");
-    expect(SearchModule.convertParamsToSearchOptions).toHaveBeenCalledTimes(1);
-    expect(SearchModule.convertParamsToSearchOptions).toHaveBeenCalledWith(
-      "?q=test"
+    expect(SearchModule.queryStringParamsToSearchOptions).toHaveBeenCalledTimes(
+      1
     );
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchSettingsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchSettingsModule.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import Axios from "axios";
+import { Literal, Static, Union } from "runtypes";
 import { fromAxiosError } from "../api/errors";
 import { templateError, TemplateUpdate } from "../mainui/Template";
 
@@ -26,7 +27,7 @@ export interface SearchSettings {
   searchingDisableOwnerFilter: boolean;
   searchingDisableDateModifiedFilter: boolean;
   fileCountDisabled: boolean;
-  defaultSearchSort: SortOrder;
+  defaultSearchSort: Static<typeof SortOrder>;
   authenticateFeedsByDefault: boolean;
 
   urlLevel: ContentIndex;
@@ -39,13 +40,13 @@ export interface CloudSettings {
   disabled: boolean;
 }
 
-export enum SortOrder {
-  RANK = "RANK",
-  DATEMODIFIED = "DATEMODIFIED",
-  DATECREATED = "DATECREATED",
-  NAME = "NAME",
-  RATING = "RATING",
-}
+export const SortOrder = Union(
+  Literal("RANK"),
+  Literal("DATEMODIFIED"),
+  Literal("DATECREATED"),
+  Literal("NAME"),
+  Literal("RATING")
+);
 
 export enum ContentIndex {
   OPTION_NONE = 0,
@@ -108,7 +109,7 @@ export const defaultSearchSettings: SearchSettings = {
   searchingDisableOwnerFilter: false,
   searchingDisableDateModifiedFilter: false,
   fileCountDisabled: false,
-  defaultSearchSort: SortOrder.RANK,
+  defaultSearchSort: "RANK",
   authenticateFeedsByDefault: false,
 
   urlLevel: 0,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -17,6 +17,7 @@
  */
 import { Card, CardContent, Grid, Typography } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
+import { History } from "history";
 import { isEqual, pick } from "lodash";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
@@ -35,7 +36,7 @@ import {
   SelectedCategories,
 } from "../modules/SearchFacetsModule";
 import {
-  convertParamsToSearchOptions,
+  queryStringParamsToSearchOptions,
   DateRange,
   defaultPagedSearchResult,
   defaultSearchOptions,
@@ -62,6 +63,7 @@ import {
   SearchResultList,
 } from "./components/SearchResultList";
 import StatusSelector from "./components/StatusSelector";
+import LocationState = History.LocationState;
 
 /**
  * Type of search options that are specific to Search page presentation layer.
@@ -123,7 +125,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const [searchSettings, setSearchSettings] = useState<SearchSettings>();
   const [classifications, setClassifications] = useState<Classification[]>([]);
 
-  const location = useLocation();
+  const location = useLocation<LocationState>();
 
   /**
    * Update the page title and retrieve Search settings.
@@ -137,11 +139,10 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
     Promise.all([
       getSearchSettingsFromServer(),
-      convertParamsToSearchOptions(location.search),
+      queryStringParamsToSearchOptions(location),
     ]).then((results) => {
       const [searchSettings, queryStringSearchOptions] = results;
       setSearchSettings(searchSettings);
-
       if (queryStringSearchOptions)
         setSearchPageOptions({
           ...queryStringSearchOptions,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -65,8 +65,6 @@ import {
 } from "./components/SearchResultList";
 import StatusSelector from "./components/StatusSelector";
 
-// import LocationState = History.LocationState;
-
 /**
  * Type of search options that are specific to Search page presentation layer.
  */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -17,11 +17,12 @@
  */
 import { Card, CardContent, Grid, Typography } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
-import { History } from "history";
+
 import { isEqual, pick } from "lodash";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { useHistory, useLocation } from "react-router";
+import { Static } from "runtypes";
 import { generateFromError } from "../api/errors";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import {
@@ -36,10 +37,10 @@ import {
   SelectedCategories,
 } from "../modules/SearchFacetsModule";
 import {
-  queryStringParamsToSearchOptions,
   DateRange,
   defaultPagedSearchResult,
   defaultSearchOptions,
+  queryStringParamsToSearchOptions,
   searchItems,
   SearchOptions,
 } from "../modules/SearchModule";
@@ -63,7 +64,8 @@ import {
   SearchResultList,
 } from "./components/SearchResultList";
 import StatusSelector from "./components/StatusSelector";
-import LocationState = History.LocationState;
+
+// import LocationState = History.LocationState;
 
 /**
  * Type of search options that are specific to Search page presentation layer.
@@ -125,7 +127,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const [searchSettings, setSearchSettings] = useState<SearchSettings>();
   const [classifications, setClassifications] = useState<Classification[]>([]);
 
-  const location = useLocation<LocationState>();
+  const location = useLocation();
 
   /**
    * Update the page title and retrieve Search settings.
@@ -205,7 +207,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       .finally(() => setShowSpinner(false));
   };
 
-  const handleSortOrderChanged = (order: SortOrder) =>
+  const handleSortOrderChanged = (order: Static<typeof SortOrder>) =>
     setSearchPageOptions({ ...searchPageOptions, sortOrder: order });
 
   const handleQueryChanged = (query: string) =>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchOrderSelect.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchOrderSelect.tsx
@@ -17,6 +17,7 @@
  */
 import { InputLabel, MenuItem, Select } from "@material-ui/core";
 import * as React from "react";
+import { Static } from "runtypes";
 import { SortOrder } from "../../modules/SearchSettingsModule";
 import { languageStrings } from "../../util/langstrings";
 
@@ -27,12 +28,12 @@ export interface SearchOrderSelectProps {
   /**
    * The selected order. Being undefined means no option is selected.
    */
-  value?: SortOrder;
+  value?: Static<typeof SortOrder>;
   /**
    * Fired when a different sort order is selected.
    * @param sortOrder The new order.
    */
-  onChange: (sortOrder: SortOrder) => void;
+  onChange: (sortOrder: Static<typeof SortOrder>) => void;
 }
 
 export const SearchOrderSelect = ({
@@ -50,12 +51,12 @@ export const SearchOrderSelect = ({
   /**
    * Provide a data source for search sorting control.
    */
-  const sortingOptionStrings = new Map<SortOrder, string>([
-    [SortOrder.RANK, relevance],
-    [SortOrder.DATEMODIFIED, lastModified],
-    [SortOrder.DATECREATED, dateCreated],
-    [SortOrder.NAME, title],
-    [SortOrder.RATING, userRating],
+  const sortingOptionStrings = new Map<Static<typeof SortOrder>, string>([
+    ["RANK", relevance],
+    ["DATEMODIFIED", lastModified],
+    ["DATECREATED", dateCreated],
+    ["NAME", title],
+    ["RATING", userRating],
   ]);
 
   const baseId = "sort-order-select";
@@ -71,7 +72,7 @@ export const SearchOrderSelect = ({
         labelId={labelId}
         // If sortOrder is undefined, pass an empty string to select nothing.
         value={value ?? ""}
-        onChange={(event) => onChange(event.target.value as SortOrder)}
+        onChange={(event) => onChange(SortOrder.check(event.target.value))}
       >
         {Array.from(sortingOptionStrings).map(([value, text]) => (
           <MenuItem key={value} value={value}>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/components/DefaultSortOrderSetting.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/components/DefaultSortOrderSetting.tsx
@@ -21,6 +21,7 @@ import {
   OutlinedInput,
   Select,
 } from "@material-ui/core";
+import { Static } from "runtypes";
 import { SortOrder } from "../../../modules/SearchSettingsModule";
 import * as React from "react";
 import { languageStrings } from "../../../util/langstrings";
@@ -28,8 +29,8 @@ import { makeStyles } from "@material-ui/core/styles";
 
 export interface DefaultSortOrderSettingProps {
   disabled: boolean;
-  value: SortOrder;
-  setValue: (order: SortOrder) => void;
+  value: Static<typeof SortOrder>;
+  setValue: (order: Static<typeof SortOrder>) => void;
 }
 const useStyles = makeStyles({
   select: {
@@ -49,25 +50,23 @@ export default function DefaultSortOrderSetting({
       <Select
         SelectDisplayProps={{ id: "_sortOrder" }}
         disabled={disabled}
-        onChange={(event) => setValue(event.target.value as SortOrder)}
+        onChange={(event) => setValue(SortOrder.check(event.target.value))}
         variant="outlined"
         value={value}
         className={classes.select}
         input={<OutlinedInput labelWidth={0} id="_sortOrder" />}
       >
-        <MenuItem value={SortOrder.RANK}>
-          {searchPageSettingsStrings.relevance}
-        </MenuItem>
-        <MenuItem value={SortOrder.DATEMODIFIED}>
+        <MenuItem value="RANK">{searchPageSettingsStrings.relevance}</MenuItem>
+        <MenuItem value={SortOrder.check("DATEMODIFIED")}>
           {searchPageSettingsStrings.lastModified}
         </MenuItem>
-        <MenuItem value={SortOrder.DATECREATED}>
+        <MenuItem value={SortOrder.check("DATECREATED")}>
           {searchPageSettingsStrings.dateCreated}
         </MenuItem>
-        <MenuItem value={SortOrder.NAME}>
+        <MenuItem value={SortOrder.check("NAME")}>
           {searchPageSettingsStrings.title}
         </MenuItem>
-        <MenuItem value={SortOrder.RATING}>
+        <MenuItem value={SortOrder.check("RATING")}>
           {searchPageSettingsStrings.userRating}
         </MenuItem>
       </Select>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
#1306

This builds further upon the PR i did to support legacy search parameters (#2414)

Summary of work performed:
- Adding SearchModule function to serialize a searchOptions object to a JSON string, to be used in a query string. This is intended to be used to allow for a new Search Page user to get a link to copy their current search.
  - in order to cut down on characters, only the bare minimum collection and owner identifiers are serialized. Undefined properties are also excluded.
- Deserialisation of the query string back into a searchOptions object
- Updating the SearchPage to accomodate the fact that we now can support two types of linkable searches.

- A PR will be submitted in the near future to add a button on the SearchPage to obtain the linkable url

All feedback welcomed, I have been staring at this for too long 😑

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
