### PR TITLE
Feature/buttons for selecting resources

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/ResourceSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/ResourceSelector.stories.tsx
@@ -1,0 +1,41 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import {
+  ResourceSelector,
+  ResourceSelectorProps,
+} from "../../tsrc/search/components/ResourceSelector";
+import { languageStrings } from "../../tsrc/util/langstrings";
+
+export default {
+  title: "Search/ResourceSelector",
+  component: ResourceSelector,
+  argTypes: {
+    onClick: { action: "on select resources" },
+  },
+} as Meta<ResourceSelectorProps>;
+
+export const StandardSelector: Story<ResourceSelectorProps> = (args) => (
+  <ResourceSelector {...args} />
+);
+
+StandardSelector.args = {
+  labelText: languageStrings.searchpage.selectResource.summaryPage,
+  isStopPropagation: true,
+};

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SelectionSessionModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SelectionSessionModule.test.ts
@@ -17,32 +17,41 @@
  */
 import { getSearchResult } from "../../../__mocks__/SearchResult.mock";
 import type { SelectionSessionInfo } from "../../../tsrc/AppConfig";
+import * as AppConfig from "../../../tsrc/AppConfig";
 import { buildSelectionSessionItemSummaryLink } from "../../../tsrc/modules/SelectionSessionModule";
 
+const basicSelectionSessionInfo: SelectionSessionInfo = {
+  stateId: "1",
+  layout: "coursesearch",
+};
+const mockGetRenderData = jest.spyOn(AppConfig, "getRenderData");
+const updateMockGetRenderData = (
+  selectionSessionInfo: SelectionSessionInfo
+) => {
+  mockGetRenderData.mockReturnValue({
+    baseResources: "p/r/2020.2.0/com.equella.core/",
+    newUI: true,
+    autotestMode: false,
+    newSearch: true,
+    selectionSessionInfo: selectionSessionInfo,
+  });
+};
+
 describe("buildSelectionSessionItemSummaryLink", () => {
-  const selectionSessionInfo: SelectionSessionInfo = {
-    stateId: "1",
-    layout: "coursesearch",
-  };
   const { uuid, version } = getSearchResult.results[0];
 
   it("builds basic URLs for accessing ItemSummary pages in Selection Session mode", () => {
-    const link = buildSelectionSessionItemSummaryLink(
-      selectionSessionInfo,
-      uuid,
-      version
-    );
+    updateMockGetRenderData(basicSelectionSessionInfo);
+    const link = buildSelectionSessionItemSummaryLink(uuid, version);
     expect(link).toBe(
       "items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/?_sl.stateId=1&a=coursesearch"
     );
   });
 
   it("will include the Integration ID in the URL if provided in SelectionSessionInfo", () => {
-    const link = buildSelectionSessionItemSummaryLink(
-      { ...selectionSessionInfo, integId: "2" },
-      uuid,
-      version
-    );
+    updateMockGetRenderData({ ...basicSelectionSessionInfo, integId: "2" });
+
+    const link = buildSelectionSessionItemSummaryLink(uuid, version);
     expect(link).toBe(
       "items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/?_sl.stateId=1&a=coursesearch&_int.id=2"
     );

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -30,6 +30,20 @@ import { languageStrings } from "../../../../tsrc/util/langstrings";
 import * as AppConfig from "../../../../tsrc/AppConfig";
 
 const mockGetRenderData = jest.spyOn(AppConfig, "getRenderData");
+// Mock the value of 'getRenderData'.
+const updateMockRenderData = () =>
+  mockGetRenderData.mockReturnValue({
+    baseResources: "p/r/2020.2.0/com.equella.core/",
+    newUI: true,
+    autotestMode: false,
+    newSearch: true,
+    selectionSessionInfo: {
+      stateId: "1",
+      integId: "2",
+      layout: "coursesearch",
+    },
+  });
+
 const defaultViewerPromise = jest
   .spyOn(MimeTypesModule, "getMimeTypeDefaultViewerDetails")
   .mockResolvedValue({
@@ -149,18 +163,7 @@ describe("<SearchResult/>", () => {
     let page = await renderSearchResult(item);
     checkItemTitleLink(page, `/${basicURL}`);
 
-    // Change the value of renderData and re-render the component.
-    mockGetRenderData.mockReturnValueOnce({
-      baseResources: "p/r/2020.2.0/com.equella.core/",
-      newUI: true,
-      autotestMode: false,
-      newSearch: true,
-      selectionSessionInfo: {
-        stateId: "1",
-        integId: "2",
-        layout: "coursesearch",
-      },
-    });
+    updateMockRenderData();
     page.unmount();
     page = await renderSearchResult(item);
     checkItemTitleLink(
@@ -168,4 +171,20 @@ describe("<SearchResult/>", () => {
       `${basicURL}?_sl.stateId=1&a=coursesearch&_int.id=2`
     );
   });
+
+  it.each<[string]>([
+    [languageStrings.searchpage.selectResource.summaryPage],
+    [languageStrings.searchpage.selectResource.allAttachments],
+    [languageStrings.searchpage.selectResource.attachment],
+  ])(
+    // todo: pass event handler in and check if it has been called.
+    "should display buttons for %s in Selection Session",
+    async (buttonLabel: string) => {
+      updateMockRenderData();
+      const { queryByLabelText } = await renderSearchResult(
+        mockData.attachSearchObj
+      );
+      expect(queryByLabelText(buttonLabel)).toBeInTheDocument();
+    }
+  );
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SelectionSessionModule.ts
@@ -15,26 +15,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AppConfig, SelectionSessionInfo } from "../AppConfig";
+import { AppConfig, getRenderData, SelectionSessionInfo } from "../AppConfig";
+
+const selectionSessionInfo:
+  | SelectionSessionInfo
+  | undefined
+  | null = getRenderData()?.selectionSessionInfo;
+
+/**
+ * Type guard to check whether an object is of type SelectionSessionInfo.
+ * @param data The data to be checked
+ */
+const isSelectionSession = (
+  data: unknown
+): data is { [K in keyof SelectionSessionInfo]: unknown } =>
+  typeof data === "object" && data !== null && "stateId" in data;
+
+/**
+ * True if the Selection Session info provided by renderData is neither null nor undefined.
+ */
+export const inSelectionSession = isSelectionSession(selectionSessionInfo);
+
 /**
  * Build a Selection Session specific ItemSummary Link.
- * @param selectionSessionInfo An object containing information of a Selection Session such as the layout and ID
  * @param uuid The UUID of an Item
  * @param version The version of an Item
  */
 export const buildSelectionSessionItemSummaryLink = (
-  selectionSessionInfo: SelectionSessionInfo,
   uuid: string,
   version: number
 ): string => {
-  const { stateId, integId, layout } = selectionSessionInfo;
-  const itemSummaryPageLink = AppConfig.baseUrl.concat(
-    `items/${uuid}/${version}/?_sl.stateId=${stateId}&a=${layout}`
-  );
+  if (isSelectionSession(selectionSessionInfo)) {
+    const { stateId, integId, layout } = selectionSessionInfo;
+    const itemSummaryPageLink = AppConfig.baseUrl.concat(
+      `items/${uuid}/${version}/?_sl.stateId=${stateId}&a=${layout}`
+    );
 
-  // integId can be null in 'Resource Selector'.
-  if (integId) {
-    return itemSummaryPageLink.concat(`&_int.id=${integId}`);
+    // integId can be null in 'Resource Selector'.
+    if (integId) {
+      return itemSummaryPageLink.concat(`&_int.id=${integId}`);
+    }
+    return itemSummaryPageLink;
+  } else {
+    throw new TypeError("The type of Selection Session Info is incorrect.");
   }
-  return itemSummaryPageLink;
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SelectionSessionModule.ts
@@ -17,27 +17,24 @@
  */
 import { AppConfig, getRenderData, SelectionSessionInfo } from "../AppConfig";
 
-const selectionSessionInfo:
-  | SelectionSessionInfo
-  | undefined
-  | null = getRenderData()?.selectionSessionInfo;
-
 /**
- * Type guard to check whether an object is of type SelectionSessionInfo.
+ * An internal Type guard used to check whether an object is of type SelectionSessionInfo.
  * @param data The data to be checked
  */
-const isSelectionSession = (
+const isSelectionSessionInfo = (
   data: unknown
 ): data is { [K in keyof SelectionSessionInfo]: unknown } =>
   typeof data === "object" && data !== null && "stateId" in data;
 
 /**
- * True if the Selection Session info provided by renderData is neither null nor undefined.
+ * Returns true if the Selection Session info provided by renderData is neither null nor undefined.
  */
-export const inSelectionSession = isSelectionSession(selectionSessionInfo);
+export const isSelectionSessionOpen = (): boolean =>
+  isSelectionSessionInfo(getRenderData()?.selectionSessionInfo);
 
 /**
- * Build a Selection Session specific ItemSummary Link.
+ * Build a Selection Session specific ItemSummary Link. Recommended to first call `isSelectionSessionOpen()`
+ * before use.
  * @param uuid The UUID of an Item
  * @param version The version of an Item
  */
@@ -45,7 +42,8 @@ export const buildSelectionSessionItemSummaryLink = (
   uuid: string,
   version: number
 ): string => {
-  if (isSelectionSession(selectionSessionInfo)) {
+  const selectionSessionInfo = getRenderData()?.selectionSessionInfo;
+  if (isSelectionSessionInfo(selectionSessionInfo)) {
     const { stateId, integId, layout } = selectionSessionInfo;
     const itemSummaryPageLink = AppConfig.baseUrl.concat(
       `items/${uuid}/${version}/?_sl.stateId=${stateId}&a=${layout}`

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ResourceSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ResourceSelector.tsx
@@ -1,0 +1,57 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IconButton } from "@material-ui/core";
+import Tooltip from "@material-ui/core/Tooltip";
+import DoubleArrowIcon from "@material-ui/icons/DoubleArrow";
+import * as React from "react";
+
+interface ResourceSelectorProps {
+  /**
+   * Text for the label of ResourceSelector
+   */
+  labelText: string;
+  /**
+   * Handler for clicking the ResourceSelector
+   */
+  onClick: () => void;
+  /**
+   * Whether to stop the propagation of a click event
+   */
+  isStopPropagation?: boolean;
+}
+
+export const ResourceSelector = ({
+  labelText,
+  onClick,
+  isStopPropagation = false,
+}: ResourceSelectorProps) => (
+  <Tooltip title={labelText}>
+    <IconButton
+      color="secondary"
+      aria-label={labelText}
+      onClick={(event) => {
+        if (isStopPropagation) {
+          event.stopPropagation();
+        }
+        onClick();
+      }}
+    >
+      <DoubleArrowIcon />
+    </IconButton>
+  </Tooltip>
+);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ResourceSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ResourceSelector.tsx
@@ -20,7 +20,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import DoubleArrowIcon from "@material-ui/icons/DoubleArrow";
 import * as React from "react";
 
-interface ResourceSelectorProps {
+export interface ResourceSelectorProps {
   /**
    * Text for the label of ResourceSelector
    */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ResourceSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ResourceSelector.tsx
@@ -35,6 +35,10 @@ export interface ResourceSelectorProps {
   isStopPropagation?: boolean;
 }
 
+/**
+ * This component is basically a double arrow icon wrapped by a Tooltip.
+ * A typical user case is selecting resources from the new search UI.
+ */
 export const ResourceSelector = ({
   labelText,
   onClick,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -327,7 +327,7 @@ export default function SearchResult({
                 <ResourceSelector
                   labelText={selectResourceStrings.attachment}
                   isStopPropagation
-                  onClick={nop} // todo: replace nop with an handler for selecting one attachment
+                  onClick={nop} // todo: replace nop with a handler for selecting one attachment
                 />
               </ListItemSecondaryAction>
             )}
@@ -347,7 +347,7 @@ export default function SearchResult({
           <ResourceSelector
             labelText={selectResourceStrings.allAttachments}
             isStopPropagation
-            onClick={nop} // todo: replace nop with an handler for selecting attachments
+            onClick={nop} // todo: replace nop with a handler for selecting attachments
           />
         </Grid>
       </Grid>
@@ -435,7 +435,7 @@ export default function SearchResult({
         <ResourceSelector
           labelText={selectResourceStrings.summaryPage}
           isStopPropagation
-          onClick={nop} // todo: replace nop with an handler for selecting summary page
+          onClick={nop} // todo: replace nop with a handler for selecting summary page
         />
       </Grid>
     </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -391,11 +391,7 @@ export default function SearchResult({
             </Grid>
           </AccordionSummary>
           <AccordionDetails>
-            <List
-              component="div"
-              disablePadding
-              className={classes.attachmentListItem}
-            >
+            <List disablePadding className={classes.attachmentListItem}>
               {attachmentsList}
             </List>
           </AccordionDetails>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -51,7 +51,7 @@ import { routes } from "../../mainui/routes";
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
 import {
   buildSelectionSessionItemSummaryLink,
-  inSelectionSession,
+  isSelectionSessionOpen,
 } from "../../modules/SelectionSessionModule";
 import { determineViewer } from "../../modules/ViewerModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
@@ -149,6 +149,7 @@ export default function SearchResult({
   }
   const nop = () => {}; // todo: remove this in next PR.
   const classes = useStyles();
+  const inSelectionSession: boolean = isSelectionSessionOpen();
 
   const [attachExpanded, setAttachExpanded] = useState(
     displayOptions?.standardOpen ?? false

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -43,14 +43,16 @@ import { SyntheticEvent, useEffect, useState } from "react";
 import ReactHtmlParser from "react-html-parser";
 import { Link } from "react-router-dom";
 import { sprintf } from "sprintf-js";
-import { getRenderData } from "../../AppConfig";
 import { Date as DateDisplay } from "../../components/Date";
 import ItemAttachmentLink from "../../components/ItemAttachmentLink";
 import OEQThumb from "../../components/OEQThumb";
 import { StarRating } from "../../components/StarRating";
 import { routes } from "../../mainui/routes";
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
-import { buildSelectionSessionItemSummaryLink } from "../../modules/SelectionSessionModule";
+import {
+  buildSelectionSessionItemSummaryLink,
+  inSelectionSession,
+} from "../../modules/SelectionSessionModule";
 import { determineViewer } from "../../modules/ViewerModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
@@ -145,8 +147,6 @@ export default function SearchResult({
     attachment: OEQ.Search.Attachment;
     viewerDetails?: OEQ.MimeType.MimeTypeViewerDetail;
   }
-  const renderData = getRenderData();
-  const selectionSessionData = renderData?.selectionSessionInfo;
   const nop = () => {}; // todo: remove this in next PR.
   const classes = useStyles();
 
@@ -322,7 +322,7 @@ export default function SearchResult({
             >
               <ListItemText color="primary" primary={description} />
             </ItemAttachmentLink>
-            {selectionSessionData && (
+            {inSelectionSession && (
               <ListItemSecondaryAction>
                 <ResourceSelector
                   labelText={selectResourceStrings.attachment}
@@ -340,7 +340,7 @@ export default function SearchResult({
       <Typography>{searchResultStrings.attachments}</Typography>
     );
 
-    const accordionSummaryContent = selectionSessionData ? (
+    const accordionSummaryContent = inSelectionSession ? (
       <Grid container alignItems="center">
         <Grid item>{accordionText}</Grid>
         <Grid>
@@ -408,13 +408,9 @@ export default function SearchResult({
     const basicLink = (
       <Link to={routes.ViewItem.to(uuid, version)}>{itemTitle}</Link>
     );
-    return selectionSessionData ? (
+    return inSelectionSession ? (
       <MUILink
-        href={buildSelectionSessionItemSummaryLink(
-          selectionSessionData,
-          uuid,
-          version
-        )}
+        href={buildSelectionSessionItemSummaryLink(uuid, version)}
         underline="none"
       >
         {itemTitle}
@@ -424,7 +420,7 @@ export default function SearchResult({
     );
   };
 
-  const itemPrimaryContent = selectionSessionData ? (
+  const itemPrimaryContent = inSelectionSession ? (
     <Grid container alignItems="center">
       <Grid item>{itemLink()}</Grid>
       <Grid item>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -402,6 +402,11 @@ export const languageStrings = {
     starRatings: {
       label: "Item star rating: %f",
     },
+    selectResource: {
+      summaryPage: "Select summary page",
+      attachment: "Select attachment",
+      allAttachments: "Select all attachments",
+    },
   },
   "com.equella.core.searching.search": {
     title: "Search",


### PR DESCRIPTION
#688 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR created a new component called `ResourceSelector` which is used to select the ItemSummary page and attachments in Selection Session.

This PR is more focused on UI so there are no concrete event handlers passed into `ResourceSelector` yet. 

![Screenshot from 2020-11-16 12-01-26](https://user-images.githubusercontent.com/47203811/99202501-794c7980-2803-11eb-8ebb-0a3883bbd8ec.png)
