### PR TITLE
Feature - REST API to list remote searches

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/BaseEntitySummary.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/BaseEntitySummary.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.entity
 
 import com.tle.beans.entity.BaseEntity

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/BaseEntitySummary.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/BaseEntitySummary.scala
@@ -1,0 +1,18 @@
+package com.tle.web.api.entity
+
+import com.tle.beans.entity.BaseEntity
+import com.tle.web.api.ApiHelper
+
+/**
+  * Summary information for a BaseEntity, which should be enough for display purposes and pulling
+  * any further information as required (due to the UUID).
+  *
+  * @param uuid The unique ID of the underlying BaseEntity
+  * @param name The default locale human readable name for a BaseEntity
+  */
+case class BaseEntitySummary(uuid: String, name: String)
+
+object BaseEntitySummary {
+  def apply(be: BaseEntity): BaseEntitySummary =
+    BaseEntitySummary(uuid = be.getUuid, name = ApiHelper.getEntityName(be))
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
@@ -18,29 +18,13 @@
 
 package com.tle.web.api.settings
 
-import com.tle.beans.entity.BaseEntityLabel
 import com.tle.legacy.LegacyGuice
-import com.tle.web.api.ApiHelper
+import com.tle.web.api.entity.BaseEntitySummary
 import io.swagger.annotations.{Api, ApiOperation}
 import javax.ws.rs.core.Response
 import javax.ws.rs.{GET, Path, Produces}
 
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
-
-/**
-  * A summary of key details of an Advanced Search Summary
-  * @param uuid the UUID for the specific Advanced Search
-  * @param name the default locale human readable name for this search
-  */
-case class AdvancedSearchSummary(uuid: String, name: String)
-
-object AdvancedSearchSummary {
-  private val powerSearchService = LegacyGuice.powerSearchService
-
-  def apply(bel: BaseEntityLabel): AdvancedSearchSummary =
-    AdvancedSearchSummary(uuid = bel.getUuid,
-                          name = ApiHelper.getEntityName(powerSearchService.getByUuid(bel.getUuid)))
-}
 
 /**
   * API for managing Advanced Searches (internally - and historically - known as Power Searches).
@@ -56,7 +40,7 @@ class AdvancedSearchResource {
     value = "List available Advanced Searches",
     notes =
       "This endpoint is used to retrieve available Advanced Searches and is secured by SEARCH_POWER_SEARCH",
-    response = classOf[AdvancedSearchSummary],
+    response = classOf[BaseEntitySummary],
     responseContainer = "List"
   )
   def getAll: Response =
@@ -64,8 +48,8 @@ class AdvancedSearchResource {
       .ok()
       .entity(
         powerSearchService
-          .listSearchable()
+          .enumerateSearchable()
           .asScala
-          .map(bel => AdvancedSearchSummary(bel)))
+          .map(be => BaseEntitySummary(be)))
       .build()
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/RemoteSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/RemoteSearchResource.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.settings
 
 import com.tle.legacy.LegacyGuice

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/RemoteSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/RemoteSearchResource.scala
@@ -1,0 +1,32 @@
+package com.tle.web.api.settings
+
+import com.tle.legacy.LegacyGuice
+import com.tle.web.api.entity.BaseEntitySummary
+import io.swagger.annotations.{Api, ApiOperation}
+import javax.ws.rs.core.Response
+import javax.ws.rs.{GET, Path, Produces}
+
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+
+@Path("settings/remotesearch/")
+@Produces(value = Array("application/json"))
+@Api(value = "Settings")
+class RemoteSearchResource {
+  private val federatedSearchService = LegacyGuice.federatedSearchService
+
+  @GET
+  @ApiOperation(
+    value = "List available Remote (Federated) Searches",
+    notes =
+      "This endpoint is used to retrieve available Remote Searches and is secured by SEARCH_FEDERATED_SEARCH",
+    response = classOf[BaseEntitySummary],
+    responseContainer = "List"
+  )
+  def getAll: Response =
+    Response
+      .ok()
+      .entity(
+        federatedSearchService.enumerateSearchable().asScala.map(be => BaseEntitySummary(be))
+      )
+      .build()
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchPrivileges.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchPrivileges.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.powersearch;
 
 public final class PowerSearchPrivileges {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchPrivileges.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchPrivileges.java
@@ -1,0 +1,10 @@
+package com.tle.core.powersearch;
+
+public final class PowerSearchPrivileges {
+
+  public static final String SEARCH_POWER_SEARCH = "SEARCH_POWER_SEARCH";
+
+  private PowerSearchPrivileges() {
+    throw new Error();
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/PowerSearchService.java
@@ -40,4 +40,11 @@ public interface PowerSearchService
   List<BaseEntityLabel> listAllForSchema(long schemaId);
 
   List<BaseEntityLabel> listAllForSchema(Schema schema);
+
+  /**
+   * List all available Power Searches (Advanced Searches) assuming 'SEARCH_POWER_SEARCH' ACL.
+   *
+   * @return available power searches
+   */
+  List<PowerSearch> enumerateSearchable();
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/impl/PowerSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/powersearch/impl/PowerSearchServiceImpl.java
@@ -31,6 +31,7 @@ import com.tle.core.entity.EntityEditingSession;
 import com.tle.core.entity.service.impl.AbstractEntityServiceImpl;
 import com.tle.core.guice.Bind;
 import com.tle.core.powersearch.PowerSearchDao;
+import com.tle.core.powersearch.PowerSearchPrivileges;
 import com.tle.core.powersearch.PowerSearchService;
 import com.tle.core.powersearch.event.PowerSearchDeletionEvent;
 import com.tle.core.remoting.RemotePowerSearchService;
@@ -73,7 +74,7 @@ public class PowerSearchServiceImpl
   }
 
   @Override
-  @SecureOnReturn(priv = "SEARCH_POWER_SEARCH")
+  @SecureOnReturn(priv = PowerSearchPrivileges.SEARCH_POWER_SEARCH)
   public List<BaseEntityLabel> listSearchable() {
     return listAll();
   }
@@ -118,6 +119,12 @@ public class PowerSearchServiceImpl
   protected void processClone(EntityPack<PowerSearch> pack) {
     PowerSearch psearch = pack.getEntity();
     psearch.setItemdefs(new ArrayList<ItemDefinition>(psearch.getItemdefs()));
+  }
+
+  @Override
+  @SecureOnReturn(priv = PowerSearchPrivileges.SEARCH_POWER_SEARCH)
+  public List<PowerSearch> enumerateSearchable() {
+    return enumerate();
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -96,149 +96,149 @@ import javax.inject.Provider;
 
 public class LegacyGuice extends AbstractModule {
 
-  @Inject public static TLEAclManager aclManager;
+  @Inject public static AccessibilityModeService accessibilityModeService;
 
-  @Inject public static ShortcutUrlsSettingsPrivilegeTreeProvider shortcutPrivProvider;
+  @Inject public static ActivationService activationService;
 
-  @Inject public static LanguageSettingsPrivilegeTreeProvider langPrivProvider;
+  @Inject public static AttachmentResourceService attachmentResourceService;
+
+  @Inject public static AttachmentSerializerProvider attachmentSerializerProvider;
+
+  @Inject public static AuditLogService auditLogService;
+
+  @Inject public static BasicFreemarkerFactory basicFreemarkerFactory;
+
+  @Inject public static BundleCache bundleCache;
+
+  @Inject public static CALService calService;
+
+  @Inject public static CALWebServiceImpl calWebService;
+
+  @Inject public static ConfigurationService configService;
+
+  @Inject public static ContentRestrictionsPrivilegeTreeProvider contentRestricPrivProvider;
+
+  @Inject public static CourseDefaultsSettingsPrivilegeTreeProvider courseDefPrivProvider;
+
+  @Inject public static DateFormatSettingsPrivilegeTreeProvider datePrivProvider;
+
+  @Inject public static DiagnosticsSettingsPrivilegeTreeProvider diagnosticPrivProvider;
+
+  @Inject public static DynaCollectionService dynaCollectionService;
+
+  @Inject public static EncryptionService encryptionService;
+
+  @Inject public static EventService eventService;
+
+  @Inject public static FacetedSearchClassificationService facetedSearchClassificationService;
+
+  @Inject public static FileSystemService fileSystemService;
+
+  @Inject public static FreeTextService freeTextService;
 
   @Inject public static GoogleAnalyticsPrivilegeTreeProvider analyticsPrivProvider;
 
   @Inject public static GoogleApiSettingsPrivilegeTreeProvider googlePrivProvider;
 
-  @Inject public static SearchPrivilegeTreeProvider searchPrivProvider;
+  @Inject public static HarvesterSkipDrmSettingsPrivilegeTreeProvider harvesterPrivProvider;
 
-  @Inject public static LoginSettingsPrivilegeTreeProvider loginPrivProvider;
+  @Inject public static HtmlEditorSettingsPrivilegeTreeProvider htmlEditorPrivProvider;
+
+  @Inject public static InstitutionService institutionService;
+
+  @Inject public static ItemCommentService itemCommentService;
+
+  @Inject public static ItemDefinitionService itemDefinitionService;
+
+  @Inject public static ItemEditorService itemEditorService;
+
+  @Inject public static ItemHelper itemHelper;
+
+  @Inject public static ItemLinkService itemLinkService;
+
+  @Inject public static ItemSerializerService itemSerializerService;
+
+  @Inject public static ItemXsltService itemXsltService;
+
+  @Inject public static LanguageService languageService;
+
+  @Inject public static LanguageSettingsPrivilegeTreeProvider langPrivProvider;
+
+  @Inject public static LoggedInUsersPrivilegeTreeProvider liuPrivProvider;
 
   @Inject
   public static LoginNoticeEditorPrivilegeTreeProvider loginNoticeEditorPrivilegeTreeProvider;
 
-  @Inject
-  public static QuickContributeAndVersionSettingsPrivilegeTreeProvider quickContribPrivProvider;
-
-  @Inject public static ManualDataFixesPrivilegeTreeProvider manualFixPrivProvider;
-
-  @Inject public static OaiIdentifierSettingsPrivilegeTreeProvider oaiPrivProvider;
-
-  @Inject public static HarvesterSkipDrmSettingsPrivilegeTreeProvider harvesterPrivProvider;
-
-  @Inject public static ScheduledTasksPrivilegeTreeProvider scheduledPrivProvider;
-
-  @Inject public static MimeSearchPrivilegeTreeProvider mimePrivProvider;
-
-  @Inject public static DateFormatSettingsPrivilegeTreeProvider datePrivProvider;
-
-  @Inject public static ThemePrivilegeTreeProvider themePrivProvider;
-
-  @Inject public static HtmlEditorSettingsPrivilegeTreeProvider htmlEditorPrivProvider;
-
-  @Inject public static DiagnosticsSettingsPrivilegeTreeProvider diagnosticPrivProvider;
+  @Inject public static LoginSettingsPrivilegeTreeProvider loginPrivProvider;
 
   @Inject public static MailSettingsPrivilegeTreeProvider mailPrivProvider;
 
-  @Inject public static RemoteCachingPrivilegeTreeProvider remoteCachePrivProvider;
-
-  @Inject public static LoggedInUsersPrivilegeTreeProvider liuPrivProvider;
-
-  @Inject public static CourseDefaultsSettingsPrivilegeTreeProvider courseDefPrivProvider;
-
-  @Inject public static ContentRestrictionsPrivilegeTreeProvider contentRestricPrivProvider;
-
-  @Inject public static PortletWebService portletWebService;
-
-  @Inject public static InstitutionService institutionService;
-
-  @Inject public static EventService eventService;
-
-  @Inject public static UserSessionService userSessionService;
-
-  @Inject public static UserPreferenceService userPreferenceService;
-
-  @Inject public static UserService userService;
-
-  @Inject public static AuditLogService auditLogService;
-
-  @Inject public static LanguageService languageService;
-
-  @Inject public static ConfigurationService configService;
-
-  @Inject public static TreeRegistry treeRegistry;
-
-  @Inject public static SectionsController sectionsController;
-
-  @Inject public static TLEUserDao tleUserDao;
-
-  @Inject public static UrlService urlService;
+  @Inject public static ManualDataFixesPrivilegeTreeProvider manualFixPrivProvider;
 
   @Inject public static MenuService menuService;
 
-  @Inject public static ViewableItemFactory viewableItemFactory;
+  @Inject public static MimeSearchPrivilegeTreeProvider mimePrivProvider;
+
+  @Inject public static MimeTypeService mimeTypeService;
 
   @Inject public static ModerationService moderationService;
 
-  @Inject public static FreeTextService freeTextService;
+  @Inject public static OAuthService oAuthService;
 
-  @Inject public static PowerSearchService powerSearchService;
-
-  @Inject public static DynaCollectionService dynaCollectionService;
-
-  @Inject public static ItemSerializerService itemSerializerService;
-
-  @Inject public static ItemDefinitionService itemDefinitionService;
-
-  @Inject public static ItemLinkService itemLinkService;
-
-  @Inject public static TemplateFilter templateFilter;
+  @Inject public static OaiIdentifierSettingsPrivilegeTreeProvider oaiPrivProvider;
 
   @Inject public static ObjectMapperService objectMapperService;
 
-  @Inject public static AttachmentResourceService attachmentResourceService;
+  @Inject public static PluginTracker<AbstractAttachmentEditor> attachEditorTracker;
 
-  @Inject public static ItemXsltService itemXsltService;
+  @Inject public static PortletWebService portletWebService;
 
-  @Inject public static ScriptingService scriptingService;
-
-  @Inject public static BasicFreemarkerFactory basicFreemarkerFactory;
-
-  @Inject public static ItemCommentService itemCommentService;
-
-  @Inject public static CALService calService;
-
-  @Inject public static ActivationService activationService;
-
-  @Inject public static CALWebServiceImpl calWebService;
-
-  @Inject public static ViewItemService viewItemService;
-
-  @Inject public static ItemHelper itemHelper;
-
-  @Inject public static FileSystemService fileSystemService;
+  @Inject public static PowerSearchService powerSearchService;
 
   @Inject public static Provider<IntegrationService> integrationService;
 
   @Inject public static Provider<SelectionService> selectionService;
 
+  @Inject
+  public static QuickContributeAndVersionSettingsPrivilegeTreeProvider quickContribPrivProvider;
+
+  @Inject public static RemoteCachingPrivilegeTreeProvider remoteCachePrivProvider;
+
   @Inject public static ReplicatedCacheService replicatedCacheService;
 
-  @Inject public static OAuthService oAuthService;
+  @Inject public static ScheduledTasksPrivilegeTreeProvider scheduledPrivProvider;
 
-  @Inject public static EncryptionService encryptionService;
+  @Inject public static ScriptingService scriptingService;
 
-  @Inject public static MimeTypeService mimeTypeService;
+  @Inject public static SearchPrivilegeTreeProvider searchPrivProvider;
 
-  @Inject public static AttachmentSerializerProvider attachmentSerializerProvider;
+  @Inject public static SectionsController sectionsController;
 
-  @Inject public static PluginTracker<AbstractAttachmentEditor> attachEditorTracker;
+  @Inject public static ShortcutUrlsSettingsPrivilegeTreeProvider shortcutPrivProvider;
 
-  @Inject public static ItemEditorService itemEditorService;
+  @Inject public static TLEAclManager aclManager;
+
+  @Inject public static TLEUserDao tleUserDao;
+
+  @Inject public static TemplateFilter templateFilter;
+
+  @Inject public static ThemePrivilegeTreeProvider themePrivProvider;
+
+  @Inject public static TreeRegistry treeRegistry;
+
+  @Inject public static UrlService urlService;
+
+  @Inject public static UserPreferenceService userPreferenceService;
+
+  @Inject public static UserService userService;
+
+  @Inject public static UserSessionService userSessionService;
+
+  @Inject public static ViewItemService viewItemService;
 
   @Inject public static ViewItemUrlFactory viewItemUrlFactory;
 
-  @Inject public static AccessibilityModeService accessibilityModeService;
-
-  @Inject public static FacetedSearchClassificationService facetedSearchClassificationService;
-
-  @Inject public static BundleCache bundleCache;
+  @Inject public static ViewableItemFactory viewableItemFactory;
 
   @Override
   protected void configure() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -30,6 +30,7 @@ import com.tle.core.dynacollection.DynaCollectionService;
 import com.tle.core.encryption.EncryptionService;
 import com.tle.core.events.services.EventService;
 import com.tle.core.facetedsearch.service.FacetedSearchClassificationService;
+import com.tle.core.fedsearch.FederatedSearchService;
 import com.tle.core.freetext.service.FreeTextService;
 import com.tle.core.i18n.BundleCache;
 import com.tle.core.i18n.service.LanguageService;
@@ -131,6 +132,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static EventService eventService;
 
   @Inject public static FacetedSearchClassificationService facetedSearchClassificationService;
+
+  @Inject public static FederatedSearchService federatedSearchService;
 
   @Inject public static FileSystemService fileSystemService;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
@@ -51,6 +51,7 @@ import com.tle.web.api.settings.AdvancedSearchResource;
 import com.tle.web.api.settings.CloudSearchSettingsResource;
 import com.tle.web.api.settings.FacetedSearch.FacetedSearchClassificationResource;
 import com.tle.web.api.settings.MimeTypeResource;
+import com.tle.web.api.settings.RemoteSearchResource;
 import com.tle.web.api.settings.SearchFilterResource;
 import com.tle.web.api.settings.SearchSettingsResource;
 import com.tle.web.api.settings.SettingsResource;
@@ -116,6 +117,7 @@ public class RestEasyServlet extends HttpServletDispatcher implements MapperExte
           LanguageResource.class,
           LegacyContentApi.class,
           MimeTypeResource.class,
+          RemoteSearchResource.class,
           SearchFilterResource.class,
           SearchResource.class,
           SearchSettingsResource.class,

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.tle.webtests.framework.TestConfig;
 import com.tle.webtests.framework.TestInstitution;
+import io.github.openequella.rest.models.BaseEntitySummary;
 import java.io.IOException;
 import java.util.List;
 import org.apache.commons.httpclient.HttpMethod;
@@ -27,39 +28,17 @@ public class AdvancedSearchApiTest extends AbstractRestApiTest {
 
   @Test
   public void testRetrieveAdvancedSearches() throws Exception {
-    final List<AdvancedSearchSummary> searches = getAdvancedSearches();
+    final List<BaseEntitySummary> searches = getAdvancedSearches();
     assertEquals(
         "The number of returned advanced searches should match the institution total.",
         3,
         searches.size());
   }
 
-  private List<AdvancedSearchSummary> getAdvancedSearches() throws IOException {
+  private List<BaseEntitySummary> getAdvancedSearches() throws IOException {
     final HttpMethod method = new GetMethod(ADVANCEDSEARCH_API_ENDPOINT);
     assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
     return mapper.readValue(
-        method.getResponseBodyAsString(), new TypeReference<List<AdvancedSearchSummary>>() {});
-  }
-
-  // Mirror of com.tle.web.api.settings.AdvancedSearchSummary
-  private static class AdvancedSearchSummary {
-    private String uuid;
-    private String name;
-
-    public String getUuid() {
-      return uuid;
-    }
-
-    public void setUuid(String uuid) {
-      this.uuid = uuid;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public void setName(String name) {
-      this.name = name;
-    }
+        method.getResponseBodyAsString(), new TypeReference<List<BaseEntitySummary>>() {});
   }
 }

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/RemoteSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/RemoteSearchApiTest.java
@@ -1,0 +1,44 @@
+package io.github.openequella.rest;
+
+import static org.junit.Assert.assertEquals;
+
+import com.tle.webtests.framework.TestConfig;
+import com.tle.webtests.framework.TestInstitution;
+import io.github.openequella.rest.models.BaseEntitySummary;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.codehaus.jackson.type.TypeReference;
+import org.testng.annotations.Test;
+
+@TestInstitution("vanilla")
+public class RemoteSearchApiTest extends AbstractRestApiTest {
+  private final String REMOTESEARCH_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/settings/remotesearch";
+
+  @Override
+  protected TestConfig getTestConfig() {
+    if (testConfig == null) {
+      testConfig = new TestConfig(RemoteSearchApiTest.class);
+    }
+    return testConfig;
+  }
+
+  @Test
+  public void testRetrieveRemoteSearches() throws Exception {
+    final List<BaseEntitySummary> searches = getRemoteSearches();
+    assertEquals(
+        "The number of returned remote searches should match the institution total.",
+        2,
+        searches.size());
+  }
+
+  private List<BaseEntitySummary> getRemoteSearches() throws IOException {
+    final HttpMethod method = new GetMethod(REMOTESEARCH_API_ENDPOINT);
+    assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
+    return mapper.readValue(
+        method.getResponseBodyAsString(), new TypeReference<List<BaseEntitySummary>>() {});
+  }
+}

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/models/BaseEntitySummary.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/models/BaseEntitySummary.java
@@ -1,0 +1,23 @@
+package io.github.openequella.rest.models;
+
+// Mirrored com.tle.web.api.entity.BaseEntitySummary
+public class BaseEntitySummary {
+  private String uuid;
+  private String name;
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public void setUuid(String uuid) {
+    this.uuid = uuid;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/oeq-ts-rest-api/src/AdvancedSearch.ts
+++ b/oeq-ts-rest-api/src/AdvancedSearch.ts
@@ -15,27 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { is } from 'typescript-is';
 import { GET } from './AxiosInstance';
-import { UuidString } from './Common';
-
-/**
- * A summary representation of an Advanced search.
- */
-interface AdvancedSearchSummary {
-  /**
-   * The unique system identifier for this entity.
-   */
-  uuid: UuidString;
-  /**
-   * A human readable name for this advanced search in the default locale.
-   */
-  name: string;
-}
-
-const isAdvancedSearchSummary = (
-  instance: unknown
-): instance is AdvancedSearchSummary[] => is<AdvancedSearchSummary[]>(instance);
+import { BaseEntitySummary, isBaseEntitySummaryArray } from './Common';
 
 const ADV_SEARCH_SETTINGS_ROOT_PATH = '/settings/advancedsearch/';
 
@@ -44,5 +25,5 @@ const ADV_SEARCH_SETTINGS_ROOT_PATH = '/settings/advancedsearch/';
  */
 export const listAdvancedSearches = (
   apiBasePath: string
-): Promise<AdvancedSearchSummary[]> =>
-  GET(apiBasePath + ADV_SEARCH_SETTINGS_ROOT_PATH, isAdvancedSearchSummary);
+): Promise<BaseEntitySummary[]> =>
+  GET(apiBasePath + ADV_SEARCH_SETTINGS_ROOT_PATH, isBaseEntitySummaryArray);

--- a/oeq-ts-rest-api/src/Common.ts
+++ b/oeq-ts-rest-api/src/Common.ts
@@ -73,6 +73,34 @@ export interface BaseEntityReference {
   // which means there's potential for additional fields added dynamically at runtime.
 }
 
+/**
+ * Summary information for a BaseEntity, which should be enough for display purposes and pulling
+ * any further information as required (due to the UUID).
+ *
+ * Although shape wise very similar to `BaseEntityReference`, on the server side this has a
+ * concrete implementation.
+ */
+export interface BaseEntitySummary {
+  /**
+   * The unique ID of the underlying BaseEntity
+   */
+  uuid: UuidString;
+  /**
+   * The default locale human readable name for a BaseEntity
+   */
+  name: string;
+}
+
+/**
+ * Helper validator function for checking for an array of `BaseEntitySummary`s implemented via
+ * typescript-is.
+ *
+ * @param instance A potential array of `BaseEntitySummary`s
+ */
+export const isBaseEntitySummaryArray = (
+  instance: unknown
+): instance is BaseEntitySummary[] => is<BaseEntitySummary[]>(instance);
+
 export const ItemStatuses = Union(
   Literal('ARCHIVED'),
   Literal('DELETED'),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Just another simple endpoint, this time to get a list of Remote Searches.

This is very similar to #2512 , and as a result includes a degree of refactoring to keep things DRY and pave the way for any future `BaseEntity` work we do. To some degree there is a whole framework on the Java side for this, however on this side we're attempting to keep it more concrete and explicit.

Also snuck in a minor refactor to sort the list of properties in `LegacyGuice`. (One day we probably want to sit down and consider if this approach is really what we want to be doing - one big bag for all the DI.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
