### PR TITLE
feature(new-ui): Add new Remote Search Selector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/RemoteSearchModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/RemoteSearchModule.mock.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const getRemoteSearchesFromServerResult: OEQ.Common.BaseEntitySummary[] = [
+  { name: "Remote Search 1", uuid: "123" },
+  { name: "Remote Search 2", uuid: "456" },
+  { name: "Remote Search 3", uuid: "789" },
+];

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/RemoteSearchSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/RemoteSearchSelector.stories.tsx
@@ -1,0 +1,35 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import { getRemoteSearchesFromServerResult } from "../../__mocks__/RemoteSearchModule.mock";
+import type { RemoteSearchSelectorProps } from "../../tsrc/search/components/RemoteSearchSelector";
+import { RemoteSearchSelector } from "../../tsrc/search/components/RemoteSearchSelector";
+
+export default {
+  title: "Search/RemoteSearchSelector",
+  component: RemoteSearchSelector,
+} as Meta<RemoteSearchSelectorProps>;
+
+export const standard: Story<RemoteSearchSelectorProps> = (
+  args: RemoteSearchSelectorProps
+) => <RemoteSearchSelector {...args} />;
+standard.args = {
+  remoteSearchesSupplier: () =>
+    Promise.resolve(getRemoteSearchesFromServerResult),
+};

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -32,6 +32,7 @@ import { act } from "react-dom/test-utils";
 import { Router } from "react-router-dom";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
+import { getRemoteSearchesFromServerResult } from "../../../__mocks__/RemoteSearchModule.mock";
 import {
   getEmptySearchResult,
   getSearchResult,
@@ -41,6 +42,7 @@ import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { Collection } from "../../../tsrc/modules/CollectionsModule";
 import * as MimeTypesModule from "../../../tsrc/modules/MimeTypesModule";
+import * as RemoteSearchModule from "../../../tsrc/modules/RemoteSearchModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
@@ -83,6 +85,7 @@ const mockConvertParamsToSearchOptions = jest.spyOn(
   "queryStringParamsToSearchOptions"
 );
 window.scrollTo = jest.fn();
+
 const searchSettingPromise = mockSearchSettings.mockResolvedValue(
   SearchSettingsModule.defaultSearchSettings
 );
@@ -97,6 +100,11 @@ jest
   .mockResolvedValue({
     viewerId: "fancy",
   } as OEQ.MimeType.MimeTypeViewerDetail);
+
+// Mock out collaborator which populates the Remote Search selector
+jest
+  .spyOn(RemoteSearchModule, "getRemoteSearchesFromServer")
+  .mockResolvedValue(getRemoteSearchesFromServerResult);
 
 const defaultSearchPageOptions: SearchPageOptions = {
   ...SearchModule.defaultSearchOptions,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -82,6 +82,11 @@ export const routes = {
         : "/page/search",
     render: (p: OEQRouteComponentProps) => <SearchPage {...p} />,
   },
+  RemoteSearch: {
+    to: function (uuid: string) {
+      return `/access/z3950.do?.repository=${uuid}`;
+    },
+  },
   SearchSettings: {
     path: "/page/searchsettings",
     render: (p: OEQRouteComponentProps) => <SearchPageSettings {...p} />,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/RemoteSearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/RemoteSearchModule.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { memoize } from "lodash";
+import { API_BASE_URL } from "../AppConfig";
+
+/**
+ * Retrieve the list of remote searches from the server, utilising cached (memoized) results
+ * if available.
+ */
+export const getRemoteSearchesFromServer: () => Promise<
+  OEQ.Common.BaseEntitySummary[]
+> = memoize(
+  async (): Promise<OEQ.Common.BaseEntitySummary[]> =>
+    await OEQ.RemoteSearch.listRemoteSearches(API_BASE_URL)
+);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -58,6 +58,7 @@ import {
   RefinePanelControl,
   RefineSearchPanel,
 } from "./components/RefineSearchPanel";
+import { RemoteSearchSelector } from "./components/RemoteSearchSelector";
 import { SearchAttachmentsSelector } from "./components/SearchAttachmentsSelector";
 import {
   mapSearchResultItems,
@@ -346,6 +347,12 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           value={searchPageOptions.collections}
         />
       ),
+      disabled: false,
+    },
+    {
+      idSuffix: "RemoteSearchSelector",
+      title: searchStrings.remoteSearchSelector.title,
+      component: <RemoteSearchSelector />,
       disabled: false,
     },
     {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RemoteSearchSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RemoteSearchSelector.tsx
@@ -1,0 +1,73 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FormControl, MenuItem, Select, Theme } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import LinkIcon from "@material-ui/icons/Link";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { routes } from "../../mainui/routes";
+import { getRemoteSearchesFromServer } from "../../modules/RemoteSearchModule";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  linkIcon: {
+    marginRight: theme.spacing(2),
+  },
+}));
+
+export interface RemoteSearchSelectorProps {
+  /**
+   * Function to provide a list of remote searches - exposed to support injection for testing/storybooking.
+   */
+  remoteSearchesSupplier?: () => Promise<OEQ.Common.BaseEntitySummary[]>;
+}
+/**
+ * A search 'selector' control to provide a list of remote searches. Clicking on a remote
+ * searches (currently) navigates you to the legacy UI remote search page for that remote
+ * search.
+ */
+export const RemoteSearchSelector = ({
+  remoteSearchesSupplier = getRemoteSearchesFromServer,
+}: RemoteSearchSelectorProps) => {
+  const classes = useStyles();
+
+  const [remoteSearches, setRemoteSearches] = useState<
+    OEQ.Common.BaseEntitySummary[]
+  >([]);
+
+  useEffect(() => {
+    remoteSearchesSupplier().then((searches) => setRemoteSearches(searches));
+  }, [setRemoteSearches, remoteSearchesSupplier]);
+
+  const buildRemoteSearchMenuItems = () =>
+    remoteSearches.map((summary) => (
+      <Link to={routes.RemoteSearch.to(summary.uuid)}>
+        <MenuItem value={summary.uuid}>
+          <LinkIcon className={classes.linkIcon} />
+          {summary.name}
+        </MenuItem>
+      </Link>
+    ));
+
+  return (
+    <FormControl variant="outlined" fullWidth>
+      <Select>{buildRemoteSearchMenuItems()}</Select>
+    </FormControl>
+  );
+};

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RemoteSearchSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RemoteSearchSelector.tsx
@@ -53,7 +53,7 @@ export const RemoteSearchSelector = ({
 
   useEffect(() => {
     remoteSearchesSupplier().then((searches) => setRemoteSearches(searches));
-  }, [setRemoteSearches, remoteSearchesSupplier]);
+  }, [remoteSearchesSupplier]);
 
   const buildRemoteSearchMenuItems = () =>
     remoteSearches.map((summary) => (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -377,6 +377,9 @@ export const languageStrings = {
     refineSearchPanel: {
       title: "Refine search",
     },
+    remoteSearchSelector: {
+      title: "Go to Remote Search",
+    },
     searchAttachmentsSelector: {
       title: "Search attachments",
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds a new 'selector' for the New Search UI to navigate to the remote legacy remote search pages. The New UI side of things all works, however it has unveiled a few bugs with the legacy UI remote searching (primarily excessive persisting of state). Those issues are well outside the scope of this work, however will definitely need to be fixed to release 2020.2 and so will be in a PR soon.

Video: https://streamable.com/on6ljx

![image](https://user-images.githubusercontent.com/43919233/99733527-65f82180-2b15-11eb-9928-b1c2d3408fb1.png) 
![image](https://user-images.githubusercontent.com/43919233/99733598-80ca9600-2b15-11eb-88bc-b10ee75fa7b0.png)


#1306

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
