### PR TITLE
Fix MimeTypeFilterDialog Story

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/MimeTypes.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/MimeTypes.mock.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const getMimeTypesFromServer: OEQ.MimeType.MimeTypeEntry[] = [
+  { mimeType: "image/gif", desc: "Image - GIF" },
+  { mimeType: "image/bmp", desc: "Image - BMP" },
+  { mimeType: "image/jpeg", desc: "Image - JPEG" },
+];

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/MimeTypeFilterEditingDialog.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/MimeTypeFilterEditingDialog.stories.tsx
@@ -17,6 +17,7 @@
  */
 import * as React from "react";
 import type { Meta, Story } from "@storybook/react";
+import { getMimeTypesFromServer } from "../../__mocks__/MimeTypes.mock";
 import MimeTypeFilterEditingDialog, {
   MimeTypeFilterEditingDialogProps,
 } from "../../tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog";
@@ -38,17 +39,18 @@ const mimeTypeFilter: MimeTypeFilter = {
   mimeTypes: ["image/png", "image/jpeg"],
 };
 
+export const withFilterNotProvided: Story<MimeTypeFilterEditingDialogProps> = (
+  args
+) => <MimeTypeFilterEditingDialog {...args} />;
+withFilterNotProvided.args = {
+  open: true,
+  mimeTypeSupplier: () => Promise.resolve(getMimeTypesFromServer),
+};
+
 export const withFilterProvided: Story<MimeTypeFilterEditingDialogProps> = (
   args
 ) => <MimeTypeFilterEditingDialog {...args} />;
 withFilterProvided.args = {
-  open: true,
+  ...withFilterNotProvided.args,
   mimeTypeFilter,
-};
-
-export const withFilterNotProvided: Story<MimeTypeFilterEditingDialogProps> = (
-  args
-) => <MimeTypeFilterEditingDialog {...args} />;
-withFilterProvided.args = {
-  open: true,
 };

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/MimeTypeFilterEditingDialog.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/MimeTypeFilterEditingDialog.test.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 
 import { shallow } from "enzyme";
+import { getMimeTypesFromServer } from "../../../__mocks__/MimeTypes.mock";
 import MimeTypeFilterEditingDialog from "../../../tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog";
 import { MimeTypeFilter } from "../../../tsrc/modules/SearchFilterSettingsModule";
 
@@ -33,6 +34,7 @@ describe("<MimeTypeFilterEditingDialog />", () => {
         addOrUpdate={addOrUpdate}
         mimeTypeFilter={filter}
         handleError={handleError}
+        mimeTypeSupplier={jest.fn().mockResolvedValue(getMimeTypesFromServer)}
       />
     );
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
@@ -26,6 +26,7 @@ import {
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
+import { getMIMETypesFromServer } from "../../../modules/MimeTypesModule";
 import {
   MimeTypeFilter,
   validateMimeTypeName,
@@ -60,7 +61,7 @@ export interface MimeTypeFilterEditingDialogProps {
   /**
    * An async function that returns a list of MimeTypeEntry.
    */
-  mimeTypeSupplier: () => Promise<OEQ.MimeType.MimeTypeEntry[]>;
+  mimeTypeSupplier?: () => Promise<OEQ.MimeType.MimeTypeEntry[]>;
 }
 
 /**
@@ -72,7 +73,7 @@ const MimeTypeFilterEditingDialog = ({
   mimeTypeFilter,
   addOrUpdate,
   handleError,
-  mimeTypeSupplier,
+  mimeTypeSupplier = getMIMETypesFromServer,
 }: MimeTypeFilterEditingDialogProps) => {
   const searchFilterStrings =
     languageStrings.settings.searching.searchfiltersettings;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
@@ -26,7 +26,6 @@ import {
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import { getMIMETypesFromServer } from "../../../modules/MimeTypesModule";
 import {
   MimeTypeFilter,
   validateMimeTypeName,
@@ -58,6 +57,10 @@ export interface MimeTypeFilterEditingDialogProps {
    * Error handling.
    */
   handleError: (error: Error) => void;
+  /**
+   * An async function that returns a list of MimeTypeEntry.
+   */
+  mimeTypeSupplier: () => Promise<OEQ.MimeType.MimeTypeEntry[]>;
 }
 
 /**
@@ -69,6 +72,7 @@ const MimeTypeFilterEditingDialog = ({
   mimeTypeFilter,
   addOrUpdate,
   handleError,
+  mimeTypeSupplier,
 }: MimeTypeFilterEditingDialogProps) => {
   const searchFilterStrings =
     languageStrings.settings.searching.searchfiltersettings;
@@ -84,10 +88,10 @@ const MimeTypeFilterEditingDialog = ({
   const isNameValid = validateMimeTypeName(filterName);
 
   useEffect(() => {
-    getMIMETypesFromServer()
+    mimeTypeSupplier()
       .then((mimeTypes) => setMimeTypeEntries(mimeTypes))
       .catch((error) => handleError(error));
-  }, []);
+  }, [mimeTypeSupplier]);
 
   /**
    * Clean up previously edited filter, depending on 'onClose'.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
@@ -37,6 +37,7 @@ import {
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
 import AddCircleIcon from "@material-ui/icons/AddCircle";
+import { getMIMETypesFromServer } from "../../../modules/MimeTypesModule";
 import { languageStrings } from "../../../util/langstrings";
 import SettingsList from "../../../components/SettingsList";
 import SettingsListControl from "../../../components/SettingsListControl";
@@ -372,6 +373,7 @@ const SearchFilterPage = ({ updateTemplate }: TemplateUpdateProps) => {
         addOrUpdate={addOrUpdateMimeTypeFilter}
         mimeTypeFilter={selectedMimeTypeFilter}
         handleError={handleError}
+        mimeTypeSupplier={getMIMETypesFromServer}
       />
 
       <MessageDialog

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/SearchFilterSettingsPage.tsx
@@ -37,7 +37,6 @@ import {
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
 import AddCircleIcon from "@material-ui/icons/AddCircle";
-import { getMIMETypesFromServer } from "../../../modules/MimeTypesModule";
 import { languageStrings } from "../../../util/langstrings";
 import SettingsList from "../../../components/SettingsList";
 import SettingsListControl from "../../../components/SettingsListControl";
@@ -373,7 +372,6 @@ const SearchFilterPage = ({ updateTemplate }: TemplateUpdateProps) => {
         addOrUpdate={addOrUpdateMimeTypeFilter}
         mimeTypeFilter={selectedMimeTypeFilter}
         handleError={handleError}
-        mimeTypeSupplier={getMIMETypesFromServer}
       />
 
       <MessageDialog


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR fixes the Storybook of component `MimeTypeFilterDialog`.

By doing this, I also refactor the props of the component to allow injecting a function which retrieves Mime Types.

This approach provides more flexibility and has been used in some components so I think we should use this approach for 
`MimeTypeFilterDialog`.

![image](https://user-images.githubusercontent.com/47203811/100167103-6710c080-2f12-11eb-8fb1-b72d4d2ba449.png)

![image](https://user-images.githubusercontent.com/47203811/100167119-70019200-2f12-11eb-8955-1a3082026ff7.png)

![image](https://user-images.githubusercontent.com/47203811/100167158-860f5280-2f12-11eb-8cb3-ddb09b1a6459.png)
