### PR TITLE
EBP: Fix inline Taxonomy term selector styles

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -59,6 +59,7 @@ $iframeDialogHeight: 650px;
 $singleMargin: 8px;
 $doubleMargin: 16px;
 $col2Width: 250px;
+$termSelectorHeight: 68px;
 
 @mixin boxShadow {
   box-shadow: $boxShadow;
@@ -2047,7 +2048,7 @@ div.skinnysearch {
 }
 
 .autocompleteControl .autocomplete-container {
-  float: left;
+  float: none;
   // 120px for width of the select button and padding with default text 'select'.
   width: calc(100% - 120px);
 }
@@ -5433,4 +5434,15 @@ button:focus {
 #ed_fin,
 #ed_fan {
   width: 200px;
+}
+
+#wizard-controls
+  .autocompleteControl
+  .autocomplete-container
+  .prompt[disabled="disabled"] {
+  display: none;
+}
+
+#wizard-controls .autocompleteControl table.zebra {
+  margin-top: $termSelectorHeight;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
Float on the autocomplete-container was causing graphical issues, different controls rendering on top of one another. Turned off float and added padding, and also hidden the disabled native input that was showing. 
Before: 
![Peek 2020-11-25 12-48](https://user-images.githubusercontent.com/24543345/100172460-7e54ab80-2f1c-11eb-87df-73361a5df803.gif)

![Peek 2020-11-25 12-46](https://user-images.githubusercontent.com/24543345/100172349-3e8dc400-2f1c-11eb-8eb2-76bde343995a.gif)

After:
![Peek 2020-11-25 12-41](https://user-images.githubusercontent.com/24543345/100172025-8b24cf80-2f1b-11eb-9ccf-0fb4ecc7c345.gif)
![Peek 2020-11-25 12-49](https://user-images.githubusercontent.com/24543345/100172536-ae9c4a00-2f1c-11eb-9ef5-70f8b67d9e0b.gif)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
