### PR TITLE
Don't show select summary button if it is disabled

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/RenderDataHelper.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/RenderDataHelper.ts
@@ -29,12 +29,17 @@ import { RenderData, SelectionSessionInfo } from "../../tsrc/AppConfig";
 export const basicSelectionSessionInfo: SelectionSessionInfo = {
   stateId: "1",
   layout: "coursesearch",
-  isSelectSummaryButtonDisabled: true,
+  isSelectSummaryButtonDisabled: false,
 };
 
 export const withIntegId: SelectionSessionInfo = {
   ...basicSelectionSessionInfo,
   integId: "2",
+};
+
+export const selectSummaryButtonDisabled: SelectionSessionInfo = {
+  ...basicSelectionSessionInfo,
+  isSelectSummaryButtonDisabled: true,
 };
 
 export const basicRenderData: RenderData = {

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/RenderDataHelper.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/RenderDataHelper.ts
@@ -29,6 +29,7 @@ import { RenderData, SelectionSessionInfo } from "../../tsrc/AppConfig";
 export const basicSelectionSessionInfo: SelectionSessionInfo = {
   stateId: "1",
   layout: "coursesearch",
+  isSelectSummaryButtonDisabled: true,
 };
 
 export const withIntegId: SelectionSessionInfo = {

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
@@ -22,12 +22,14 @@ import {
   buildPostDataForStructured,
   buildSelectionSessionItemSummaryLink,
   isSelectionSessionOpen,
+  isSelectSummaryButtonDisabled,
   SelectionSessionPostData,
 } from "../../../tsrc/modules/LegacySelectionSessionModule";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import {
   basicRenderData,
   renderDataForSelectOrAdd,
+  selectSummaryButtonDisabled,
   updateMockGetRenderData,
   withIntegId,
 } from "../RenderDataHelper";
@@ -187,6 +189,36 @@ describe("buildPostDataForSelectOrAdd", () => {
         attachmentUUIDs
       );
       expect(data).toMatchObject(expectedPostData);
+    }
+  );
+});
+
+describe("isSelectSummaryButtonDisabled", () => {
+  it.each<[string, boolean, RenderData | undefined]>([
+    ["'isSelectSummaryButtonDisabled' is false", false, basicRenderData],
+    [
+      "'isSelectSummaryButtonDisabled' is true",
+      true,
+      {
+        ...basicRenderData,
+        selectionSessionInfo: selectSummaryButtonDisabled,
+      },
+    ],
+    [
+      "selectionSessionInfo is null",
+      true,
+      { ...basicRenderData, selectionSessionInfo: null },
+    ],
+    ["renderData is undefined", true, undefined],
+  ])(
+    "when %s return %s",
+    (
+      when: string,
+      isButtonDisabled: boolean,
+      renderData: RenderData | undefined
+    ) => {
+      updateMockGetRenderData(renderData);
+      expect(isSelectSummaryButtonDisabled()).toBe(isButtonDisabled);
     }
   );
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -36,6 +36,7 @@ import { languageStrings } from "../../../../tsrc/util/langstrings";
 import {
   basicRenderData,
   renderDataForSelectOrAdd,
+  selectSummaryButtonDisabled,
   updateMockGetRenderData,
   withIntegId,
 } from "../../RenderDataHelper";
@@ -281,5 +282,16 @@ describe("<SearchResult/>", () => {
         expect(selectResourceFunc).toHaveBeenCalled();
       }
     );
+
+    it("should hide the Select Summary button if it's disabled", async () => {
+      updateMockGetRenderData({
+        ...basicRenderData,
+        selectionSessionInfo: selectSummaryButtonDisabled,
+      });
+      const { queryByLabelText } = await renderSearchResult(
+        mockData.attachSearchObj
+      );
+      expect(queryByLabelText(selectSummaryPageString)).toBeNull();
+    });
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
@@ -39,6 +39,10 @@ export interface SelectionSessionInfo {
    * The UI layout used in Selection Session
    */
   layout: "coursesearch" | "search" | "skinnysearch";
+  /**
+   * True if the Select Summary button is disabled
+   */
+  isSelectSummaryButtonDisabled: boolean;
 }
 
 export interface RenderData {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -114,6 +114,18 @@ export const isSelectionSessionOpen = (): boolean =>
   isSelectionSessionInfo(getRenderData()?.selectionSessionInfo);
 
 /**
+ * Indicates if the Select Summary button is disabled or not.
+ * Returns true if the Selection Session info is not available.
+ */
+export const isSelectSummaryButtonDisabled = (): boolean => {
+  const selectionSessionInfo = getRenderData()?.selectionSessionInfo;
+  if (isSelectionSessionInfo(selectionSessionInfo)) {
+    return selectionSessionInfo.isSelectSummaryButtonDisabled;
+  }
+  return true;
+};
+
+/**
  * Validate the selectionSessionInfo included in renderData.
  * And return selectionSessionInfo if the checking is passed, or throw a type error.
  */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -54,6 +54,7 @@ import {
   buildSelectionSessionItemSummaryLink,
   selectResource,
   isSelectionSessionOpen,
+  isSelectSummaryButtonDisabled,
 } from "../../modules/LegacySelectionSessionModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
@@ -447,22 +448,23 @@ export default function SearchResult({
     );
   };
 
-  const itemPrimaryContent = inSelectionSession ? (
-    <Grid container alignItems="center">
-      <Grid item>{itemLink()}</Grid>
-      <Grid item>
-        <ResourceSelector
-          labelText={selectResourceStrings.summaryPage}
-          isStopPropagation
-          onClick={() => {
-            handleSelectResource(itemKey);
-          }}
-        />
+  const itemPrimaryContent =
+    inSelectionSession && !isSelectSummaryButtonDisabled() ? (
+      <Grid container alignItems="center">
+        <Grid item>{itemLink()}</Grid>
+        <Grid item>
+          <ResourceSelector
+            labelText={selectResourceStrings.summaryPage}
+            isStopPropagation
+            onClick={() => {
+              handleSelectResource(itemKey);
+            }}
+          />
+        </Grid>
       </Grid>
-    </Grid>
-  ) : (
-    itemLink()
-  );
+    ) : (
+      itemLink()
+    );
 
   return (
     <ListItem alignItems="flex-start" divider>


### PR DESCRIPTION
#688 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR is about whether show the `Select SummaryPage button` or not.

The approach include a few steps:

1. Due to the fact that the visibility of this button is controlled by either `oEQ setting` or `LMS oEQ plugin setting`, read and merge the two settings into one boolean flag.
2. Include the flag in `renderData.selectionSessionInfo`.
3. Front-end shows/hides the button based on the flag.

I think what is most important is the logic of how the two settings are merged.

I only uploaded two screenshots for when the LMS setting is `No restrictions`.

![Screenshot from 2020-11-27 11-57-04](https://user-images.githubusercontent.com/47203811/100399690-d7047f80-30a7-11eb-984f-eb45d8c50996.png)
![Screenshot from 2020-11-27 11-57-18](https://user-images.githubusercontent.com/47203811/100399692-d835ac80-30a7-11eb-9c18-42d577aaabc2.png)
