### PR TITLE
Make sure that thumbnailing timeout kills both imagick and ghostscript

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -23,7 +23,6 @@ import com.google.common.io.Closeables;
 import com.tle.common.Triple;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Field;
@@ -56,67 +55,69 @@ public final class ExecUtils {
   }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
   /**
-   * For a given Process ID, kill any child processes and then kill the process.
-   * Works on Unix only, as it leverages pgrep and kill commands.
+   * For a given Process ID, kill any child processes and then kill the process. Works on Unix only,
+   * as it leverages pgrep and kill commands.
+   *
    * @param pid The Process for which to terminate including it's direct children.
    */
-    public static void killLinuxProcessTree(int pid) {
-      try {
-        if (pid > 0) {
-          // get child process PIDs as strings
-          String[] children = getChildUnixProcessPids(pid);
-          // Kill child process(es)
-            for (String child : children) {
-              sendSigKill(Integer.parseInt(child));
-            }
-          // kill process itself
-          sendSigKill(pid);
+  public static void killLinuxProcessTree(int pid) {
+    try {
+      if (pid > 0) {
+        // get child process PIDs as strings
+        String[] children = getChildUnixProcessPids(pid);
+        // Kill child process(es)
+        for (String child : children) {
+          sendSigKill(Integer.parseInt(child));
         }
-      } catch (Exception e) {
-        LOGGER.warn("Process Kill failed. Process may be left hanging",e);
+        // kill process itself
+        sendSigKill(pid);
       }
+    } catch (Exception e) {
+      LOGGER.warn("Process Kill failed. Process may be left hanging", e);
     }
+  }
 
   /**
-   * Runs pgrep -P for a given Process ID,
-   * to get a list of child processes as Process IDs.
+   * Runs pgrep -P for a given Process ID, to get a list of child processes as Process IDs.
+   *
    * @param pid The parent process ID to check for child processes.
    * @return String[] An array of process IDs for the children of pid. Can be empty.
    */
-    public static String[] getChildUnixProcessPids(int pid){
-      try {
-        Process getChildPid = Runtime.getRuntime().exec("pgrep -P " + pid);
-        getChildPid.waitFor();
-        StringBuilder childPid = new StringBuilder();
-        if (getChildPid.exitValue() == 0) {
-          CharStreams.copy(new InputStreamReader(getChildPid.getInputStream()), childPid);
-        }
-        getChildPid.destroy();
-        return childPid.toString().replaceAll("\n", "").split(" ");
-      }catch(Exception e){
-        LOGGER.error("Error getting child processes for: " + pid, e);
+  public static String[] getChildUnixProcessPids(int pid) {
+    try {
+      Process getChildPid = Runtime.getRuntime().exec("pgrep -P " + pid);
+      getChildPid.waitFor();
+      StringBuilder childPid = new StringBuilder();
+      if (getChildPid.exitValue() == 0) {
+        CharStreams.copy(new InputStreamReader(getChildPid.getInputStream()), childPid);
       }
-      return new String[]{};
+      getChildPid.destroy();
+      return childPid.toString().replaceAll("\n", "").split(" ");
+    } catch (Exception e) {
+      LOGGER.error("Error getting child processes for: " + pid, e);
     }
+    return new String[] {};
+  }
 
   /**
    * Creates a process which then sends a SIGKILL signal to a given process.
+   *
    * @param pid the Process ID of the process to kill.
    * @return the exitValue of the SIGKILL process (not the process being killed)
    */
-    public static int sendSigKill(int pid){
-      try {
-        Process sigKill = Runtime.getRuntime().exec("kill -9 " + pid);
-        sigKill.waitFor();
-        int returnValue = sigKill.exitValue();
-        sigKill.destroy();
-        return returnValue;
-      }catch(Exception e){
-        LOGGER.error("killing process " + pid + " failed.",e);
-      }
-      //shouldn't get here
-      return -1;
+  public static int sendSigKill(int pid) {
+    try {
+      Process sigKill = Runtime.getRuntime().exec("kill -9 " + pid);
+      sigKill.waitFor();
+      int returnValue = sigKill.exitValue();
+      sigKill.destroy();
+      return returnValue;
+    } catch (Exception e) {
+      LOGGER.error("killing process " + pid + " failed.", e);
     }
+    // shouldn't get here
+    return -1;
+  }
   /**
    * Gets the PID of a given process.
    *
@@ -224,10 +225,11 @@ public final class ExecUtils {
       proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
       if (!stdErr.isFinished() || !stdOut.isFinished()) {
         String platform = determinePlatform();
-        if(platform.equals(PLATFORM_LINUX) || platform.equals(PLATFORM_LINUX64)) {
+        if (platform.equals(PLATFORM_LINUX) || platform.equals(PLATFORM_LINUX64)) {
           killLinuxProcessTree(pid);
-        }else{
-          LOGGER.debug("Platform not yet supported for process tree kill. Processes may be left hanging");
+        } else {
+          LOGGER.debug(
+              "Platform not yet supported for process tree kill. Processes may be left hanging");
         }
         throw new InterruptedException();
       }

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -86,6 +86,10 @@ public final class ExecUtils {
       StringBuilder childPid = new StringBuilder();
       if (getChildPid.exitValue() == 0) {
         CharStreams.copy(new InputStreamReader(getChildPid.getInputStream()), childPid);
+      } else {
+        StringBuilder errorOutput = new StringBuilder();
+        CharStreams.copy(new InputStreamReader(getChildPid.getErrorStream()), errorOutput);
+        LOGGER.debug("getChildPid function did not run properly.\n" + errorOutput);
       }
       getChildPid.destroy();
       return childPid.toString().replaceAll("\n", "").split(" ");
@@ -106,6 +110,15 @@ public final class ExecUtils {
       Process sigKill = Runtime.getRuntime().exec("kill -9 " + pid);
       sigKill.waitFor();
       int returnValue = sigKill.exitValue();
+      if (sigKill.exitValue() == 0) {
+        StringBuilder successOutput = new StringBuilder();
+        CharStreams.copy(new InputStreamReader(sigKill.getInputStream()), successOutput);
+        LOGGER.debug("Output of kill function: " + successOutput);
+      } else {
+        StringBuilder errorOutput = new StringBuilder();
+        CharStreams.copy(new InputStreamReader(sigKill.getErrorStream()), errorOutput);
+        LOGGER.debug("kill function did not run properly.\n" + errorOutput);
+      }
       sigKill.destroy();
       return returnValue;
     } catch (IOException | InterruptedException e) {

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -79,10 +79,11 @@ public final class ExecUtils {
    */
   public static Optional<int[]> getChildUnixProcessPids(int pid) {
     Optional<int[]> pids = Optional.empty();
+    StringBuilder childPid = new StringBuilder();
     try {
       Process getChildPid = Runtime.getRuntime().exec("pgrep -P " + pid);
       getChildPid.waitFor();
-      StringBuilder childPid = new StringBuilder();
+
       if (getChildPid.exitValue() == 0) {
         CharStreams.copy(new InputStreamReader(getChildPid.getInputStream()), childPid);
       } else {

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -23,14 +23,17 @@ import com.google.common.io.Closeables;
 import com.tle.common.Triple;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -51,6 +54,71 @@ public final class ExecUtils {
   private static final String[] EXE_TYPES = {
     "", ".exe", ".bat"
   }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+  /**
+   * Creates a process which will then kill a given process and it's child processes on Linux.
+   * arg[0] should be the PID of the main process you want to terminate.
+   */
+  public static class LinuxKill {
+    public static void main(String[] args) {
+      try {
+        if (Integer.parseInt(args[0]) > 0) {
+          // get child process PIDs as string
+          Process getChildPid = Runtime.getRuntime().exec("pgrep -P " + args[0]);
+          getChildPid.waitFor();
+          StringBuilder childPid = new StringBuilder();
+          if (getChildPid.exitValue() == 0) {
+            InputStream procIn = getChildPid.getInputStream();
+            int c = 0;
+            while ((c = procIn.read()) != -1) {
+              childPid.append((char) c);
+            }
+          }
+
+          // Kill child process(es)
+          Process childKillProc = Runtime.getRuntime().exec("kill -9 " + childPid);
+          childKillProc.waitFor();
+          if (childKillProc.exitValue() == 0) {
+            LOGGER.debug("Child processes terminated: " + childPid);
+          }
+
+          // kill process itself
+          Process proc = Runtime.getRuntime().exec("kill -9 " + args[0]);
+          int exitVal = proc.waitFor();
+          LOGGER.debug("Exit value: " + exitVal); // often 1 under Ubuntu 12.10
+
+          proc.destroy();
+          childKillProc.destroy();
+          getChildPid.destroy();
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Process Kill failed. Process may be left hanging");
+      }
+    }
+  }
+
+  /**
+   * Gets the PID of a given process.
+   *
+   * @param p The Process of which to get the PID.
+   * @return An Optional long. If not on Linux, or if the PID declared field is not available, the
+   *     value will be empty.
+   */
+  public static synchronized Optional<Long> getPidOfProcess(Process p) {
+    Optional<Long> pid = Optional.empty();
+
+    try {
+      if (p.getClass().getName().equals("java.lang.UNIXProcess")) {
+        Field f = p.getClass().getDeclaredField("pid");
+        f.setAccessible(true);
+        pid = Optional.of(f.getLong(p));
+        f.setAccessible(false);
+      }
+    } catch (Exception e) {
+      return pid;
+    }
+    return pid;
+  }
 
   public static File findExe(File file) {
     return findExe(file.getParentFile(), file.getName());
@@ -130,10 +198,12 @@ public final class ExecUtils {
           createProcess(cmdarray, additionalEnv, dir);
       LOGGER.debug("Started timed process");
       final Process proc = cp.getFirst();
+      String pid = Long.toString(getPidOfProcess(proc).orElse(0L));
       final StreamReader stdOut = cp.getSecond();
       final StreamReader stdErr = cp.getThird();
       proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
       if (!stdErr.isFinished() || !stdOut.isFinished()) {
+        LinuxKill.main(new String[] {pid});
         throw new InterruptedException();
       }
       LOGGER.debug("Timed process finished");

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -75,7 +75,7 @@ public final class ExecUtils {
    * Runs pgrep -P for a given Process ID, to get a list of child processes as Process IDs.
    *
    * @param pid The parent process ID to check for child processes.
-   * @return Optional<String[]> An array of process IDs for the children of pid.
+   * @return Process IDs for the children of {@code pid}.
    */
   public static Optional<int[]> getChildUnixProcessPids(int pid) {
     Optional<int[]> pids = Optional.empty();
@@ -100,7 +100,9 @@ public final class ExecUtils {
     } catch (IOException | InterruptedException e) {
       LOGGER.error("Error getting child processes for: " + pid, e);
     } catch (NumberFormatException e) {
-      LOGGER.error("Output of getChildPids command not parsable as integers", e);
+      LOGGER.error("Unsupported output from 'pgrep -P'. Unable to terminate child processes.");
+      LOGGER.error("'pgrep' output: " + childPid.toString());
+      LOGGER.error("Parsing exception.", e);
     }
     return pids;
   }
@@ -128,7 +130,7 @@ public final class ExecUtils {
       } else {
         StringBuilder errorOutput = new StringBuilder();
         CharStreams.copy(new InputStreamReader(sigKill.getErrorStream()), errorOutput);
-        LOGGER.debug("kill function did not run properly.\n" + errorOutput);
+        LOGGER.warn("Attempt to terminate processes failed (" + command + "):\n" + errorOutput);
       }
       sigKill.destroy();
       return returnValue;

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -203,7 +203,12 @@ public final class ExecUtils {
       final StreamReader stdErr = cp.getThird();
       proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
       if (!stdErr.isFinished() || !stdOut.isFinished()) {
-        LinuxKill.main(new String[] {pid});
+        String platform = determinePlatform();
+        if(platform.equals(PLATFORM_LINUX) || platform.equals(PLATFORM_LINUX64)) {
+          killLinuxProcessTree(pid);
+        }else{
+          LOGGER.debug("Platform not yet supported for process tree kill. Processes may be left hanging");
+        }
         throw new InterruptedException();
       }
       LOGGER.debug("Timed process finished");

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -263,7 +263,9 @@ public final class ExecUtils {
           killLinuxProcessTree(pid);
         } else {
           LOGGER.debug(
-              "Platform not yet supported for process tree kill. Processes may be left hanging");
+              "Platform ("
+                  + platform
+                  + ") does not support process tree kill. Processes may be left hanging");
         }
         throw new InterruptedException();
       }

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -61,16 +61,17 @@ public final class ExecUtils {
    * @param pid The Process for which to terminate including it's direct children.
    */
   public static void killLinuxProcessTree(int pid) {
-    if (pid > 0) {
-      // get child process PIDs as strings
-      String[] children = getChildUnixProcessPids(pid);
-      // Kill child process(es)
-      for (String child : children) {
-        sendSigKill(Integer.parseInt(child));
-      }
-      // kill process itself
-      sendSigKill(pid);
+    if (pid < 1) {
+      throw new IllegalArgumentException("Process ID should be greater than 0");
     }
+    // get child process PIDs as strings
+    String[] children = getChildUnixProcessPids(pid);
+    // Kill child process(es)
+    for (String child : children) {
+      sendSigKill(Integer.parseInt(child));
+    }
+    // kill process itself
+    sendSigKill(pid);
   }
 
   /**

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -92,7 +92,7 @@ public final class ExecUtils {
         LOGGER.debug("getChildPid function did not run properly.\n" + errorOutput);
       }
       getChildPid.destroy();
-      return childPid.toString().replaceAll("\n", "").split(" ");
+      return childPid.toString().replaceAll("\n", " ").split(" ");
     } catch (IOException | InterruptedException e) {
       LOGGER.error("Error getting child processes for: " + pid, e);
     }

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -101,17 +101,17 @@ public final class ExecUtils {
    * Gets the PID of a given process.
    *
    * @param p The Process of which to get the PID.
-   * @return An Optional long. If not on Linux, or if the PID declared field is not available, the
+   * @return An Optional int. If not on Linux, or if the PID declared field is not available, the
    *     value will be empty.
    */
-  public static synchronized Optional<Long> getPidOfProcess(Process p) {
-    Optional<Long> pid = Optional.empty();
+  public static synchronized Optional<Integer> getPidOfProcess(Process p) {
+    Optional<Integer> pid = Optional.empty();
 
     try {
       if (p.getClass().getName().equals("java.lang.UNIXProcess")) {
         Field f = p.getClass().getDeclaredField("pid");
         f.setAccessible(true);
-        pid = Optional.of(f.getLong(p));
+        pid = Optional.of(f.getInt(p));
         f.setAccessible(false);
       }
     } catch (Exception e) {
@@ -198,7 +198,7 @@ public final class ExecUtils {
           createProcess(cmdarray, additionalEnv, dir);
       LOGGER.debug("Started timed process");
       final Process proc = cp.getFirst();
-      String pid = Long.toString(getPidOfProcess(proc).orElse(0L));
+      int pid = getPidOfProcess(proc).orElse(0);
       final StreamReader stdOut = cp.getSecond();
       final StreamReader stdErr = cp.getThird();
       proc.waitFor(durationInSeconds, TimeUnit.SECONDS);

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -115,7 +115,7 @@ public final class ExecUtils {
     return -1;
   }
   /**
-   * Gets the PID of a given process.
+   * Gets the process ID (PID) of a given *nix process.
    *
    * @param p The Process of which to get the PID.
    * @return An Optional int. If not on Linux, or if the PID declared field is not available, the

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -133,10 +133,8 @@ public final class ExecUtils {
       sigKill.destroy();
       return returnValue;
     } catch (IOException | InterruptedException e) {
-      LOGGER.error("killing processes " + Arrays.toString(pids) + " failed.", e);
+      throw new RuntimeException("killing processes " + Arrays.toString(pids) + " failed.", e);
     }
-    // shouldn't get here
-    return -1;
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
Related to #2527, the delegate `ghostscript` doesn't inherently close when imagemagick does. This PR ensures that when thumbnailing times out, any child processes of imagemagick are killed first. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
