### PR TITLE
Bugfix/remote search

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -84,7 +84,9 @@ export const routes = {
   },
   RemoteSearch: {
     to: function (uuid: string) {
-      return `/access/z3950.do?.repository=${uuid}`;
+      // uc parameter comes from sections code (AbstractRootSearchSection.Model.java). Setting it to true clears out the Session State for Remote Repository pages.
+      // This replicates the behaviour for links inside the 'Within' dropdown in the legacy ui. See com.tle.web.searching.section.SearchQuerySection.forwardToRemote
+      return `/access/z3950.do?.repository=${uuid}&uc=true`;
     },
   },
   SearchSettings: {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoterepo/section/AbstractRootRemoteRepoSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoterepo/section/AbstractRootRemoteRepoSection.java
@@ -85,6 +85,9 @@ public abstract class AbstractRootRemoteRepoSection
     crumbs.add(breadcrumbService.getContributeCrumb(info));
     if (resultViewer != null && resultViewer.isShowing(info)) {
       resultViewer.addCrumbs(info, crumbs);
+      // clear the result, so the breadcrumb actually takes you back to the search results, instead
+      // of keeping you on the selected result
+      resultViewer.clearResult(info);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
This PR addresses two issues with the Remote search functionality:

- On a result page (old and new ui), the breadcrumb to go back to the remote repo results page was not functioning correctly. It just kept you on the page you were already on.
  - This was happening because the current remote repo page of the user is on is persisted in the session. So when you get to the result page (resultViewer), that's the page that is currently stored in the session. 
  - So, when the breadcrumb is clicked, it will go into the render method of AbstractRootRemoteRepoSection, and the resultViewer will be showing, so the same page content will be displayed.
  - In AbstractRootRemoteRepoSection, the resultViewer variable is only used to alter the layout of the page, and decide if the breadcrumb should be showed or not. So, after those two checks have occurred, the result can be cleared out, so the searchResults will get shown when the breadcrumb is clicked.
  - I really struggled to explain this in text form, so let me know if it makes no sense 
- Then, on the new ui side, there was an issue when accessing multiple remote repositories in the same session. For each remote repository type (eg. z3960) only one session entry can exist.
  - This means that going from one z3950 repo to another will persist the current page, query used, ect. The old ui got around this by clearing the relevant data when a remote search is clicked in the 'within' dropdown.
  - I have matched this functionality when clicking a remote repo on the new search page, by adding the uc=true (update context) to the remote repo route.




<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
