### PR TITLE
EBP Bugfix: Stop arrows from appearing on dialogs that don't use them

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1138,13 +1138,11 @@ div.area {
 }
 
 #fancybox-left {
-  display: flex;
   align-content: flex-end;
   @include replaceImageTag("material_design_chevron_left.png", 18px, 18px);
 }
 
 #fancybox-right {
-  display: flex;
   align-content: flex-end;
   @include replaceImageTag("material_design_chevron_right.png", 18px, 18px);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#2546 brought in a bug in which various fancybox dialogs that did not use arrows would start showing them. This is because in places where fancybox doesn't specifically set "display:none" inline it gets overridden by "display:flex" in legacy.scss. Thankfully, when the arrows are required "display:flex" is set inline to the tag by fancybox so we don't need to set it directly. 
Before: 
![image](https://user-images.githubusercontent.com/24543345/100563157-da9b3f00-3311-11eb-8739-55fd8244ec36.png)
After:
![image](https://user-images.githubusercontent.com/24543345/100563252-159d7280-3312-11eb-8fa6-be48e7f20f7c.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
