### PR TITLE
Feature - Advanced search selector

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/AdvancedSearchModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/AdvancedSearchModule.mock.ts
@@ -18,7 +18,7 @@
 import * as OEQ from "@openequella/rest-api-client";
 
 export const getAdvancedSearchesFromServerResult: OEQ.Common.BaseEntitySummary[] = [
-  { name: "Advanced Search 1", uuid: "123" },
-  { name: "Advanced Search 2", uuid: "456" },
-  { name: "Advanced Search 3", uuid: "789" },
+  { name: "Advanced Search 1", uuid: "369c92fa-ae59-4845-957d-8fcaa22c15e3" },
+  { name: "Advanced Search 2", uuid: "3e7e68dd-3aa0-4e05-a70c-d6a559c53aa3" },
+  { name: "Advanced Search 3", uuid: "a07212ff-3af9-4d78-89d5-48c2d263a810" },
 ];

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/AdvancedSearchModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/AdvancedSearchModule.mock.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const getAdvancedSearchesFromServerResult: OEQ.Common.BaseEntitySummary[] = [
+  { name: "Advanced Search 1", uuid: "123" },
+  { name: "Advanced Search 2", uuid: "456" },
+  { name: "Advanced Search 3", uuid: "789" },
+];

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/RemoteSearchModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/RemoteSearchModule.mock.ts
@@ -18,7 +18,7 @@
 import * as OEQ from "@openequella/rest-api-client";
 
 export const getRemoteSearchesFromServerResult: OEQ.Common.BaseEntitySummary[] = [
-  { name: "Remote Search 1", uuid: "123" },
-  { name: "Remote Search 2", uuid: "456" },
-  { name: "Remote Search 3", uuid: "789" },
+  { name: "Remote Search 1", uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41862" },
+  { name: "Remote Search 2", uuid: "a590e7bf-6fa9-4737-9a93-16b0e9ea82c9" },
+  { name: "Remote Search 3", uuid: "2c949159-6b61-41b7-964b-0cea6c67730f" },
 ];

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/AuxiliarySearchSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/AuxiliarySearchSelector.stories.tsx
@@ -18,18 +18,21 @@
 import { Meta, Story } from "@storybook/react";
 import * as React from "react";
 import { getRemoteSearchesFromServerResult } from "../../__mocks__/RemoteSearchModule.mock";
-import type { RemoteSearchSelectorProps } from "../../tsrc/search/components/RemoteSearchSelector";
-import { RemoteSearchSelector } from "../../tsrc/search/components/RemoteSearchSelector";
+import {
+  AuxiliarySearchSelector,
+  AuxiliarySearchSelectorProps,
+} from "../../tsrc/search/components/AuxiliarySearchSelector";
 
 export default {
-  title: "Search/RemoteSearchSelector",
-  component: RemoteSearchSelector,
-} as Meta<RemoteSearchSelectorProps>;
+  title: "Search/AuxiliarySearchSelector",
+  component: AuxiliarySearchSelector,
+} as Meta<AuxiliarySearchSelectorProps>;
 
-export const standard: Story<RemoteSearchSelectorProps> = (
-  args: RemoteSearchSelectorProps
-) => <RemoteSearchSelector {...args} />;
+export const standard: Story<AuxiliarySearchSelectorProps> = (
+  args: AuxiliarySearchSelectorProps
+) => <AuxiliarySearchSelector {...args} />;
 standard.args = {
-  remoteSearchesSupplier: () =>
+  auxiliarySearchesSupplier: () =>
     Promise.resolve(getRemoteSearchesFromServerResult),
+  urlGenerator: (uuid: string) => uuid,
 };

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -30,6 +30,7 @@ import { createMemoryHistory } from "history";
 import * as React from "react";
 import { act } from "react-dom/test-utils";
 import { Router } from "react-router-dom";
+import { getAdvancedSearchesFromServerResult } from "../../../__mocks__/AdvancedSearchModule.mock";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
 import { getRemoteSearchesFromServerResult } from "../../../__mocks__/RemoteSearchModule.mock";
@@ -39,6 +40,7 @@ import {
   getSearchResultsCustom,
 } from "../../../__mocks__/SearchResult.mock";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
+import * as AdvancedSearchModule from "../../../tsrc/modules/AdvancedSearchModule";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { Collection } from "../../../tsrc/modules/CollectionsModule";
 import * as MimeTypesModule from "../../../tsrc/modules/MimeTypesModule";
@@ -111,6 +113,11 @@ jest
 jest
   .spyOn(RemoteSearchModule, "getRemoteSearchesFromServer")
   .mockResolvedValue(getRemoteSearchesFromServerResult);
+
+// Mock out collaborator which populates the Advanced Search selector
+jest
+  .spyOn(AdvancedSearchModule, "getAdvancedSearchesFromServer")
+  .mockResolvedValue(getAdvancedSearchesFromServerResult);
 
 const defaultSearchPageOptions: SearchPageOptions = {
   ...SearchModule.defaultSearchOptions,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/IndexPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/IndexPage.tsx
@@ -165,6 +165,26 @@ export default function IndexPage() {
     const oldSearchPagePath = "/searching.do";
     const newSearchPagePath = "/page/search";
 
+    /**
+     * Determine whether the **new** search page or the **old/legacy** search page should be
+     * displayed. This is based on the requested path (route) as well as the request params.
+     * This is somewhat complicated due to the need to support shared searches from legacy UI, and
+     * the need to support Advanced Searches in legacy UI which are accessed via `searching.do`.
+     *
+     * (In the future, when all is New UI, this will not be needed.)
+     *
+     * The truth table would look like:
+     *
+     * - path is `newSearchPagePath` : true
+     * - path is **not** `newSearchPagePath` but New Search is enabled and there are no advanced
+     *   search params : true
+     * - path is **not** `newSearchPagePath` but New Search is enabled and there **are** advanced
+     *   search params : false
+     * - and anything else : false
+     *
+     * @param location the applicable `window.location` state
+     * @return `true` for new, or `false` for old
+     */
     const newOrOldSearch = (location: Location): boolean => {
       const currentParams = new URLSearchParams(location.search);
       const currentPath = location.pathname;
@@ -173,6 +193,7 @@ export default function IndexPage() {
         currentParams.get("in")?.startsWith("P") ?? false;
       const advancedSearchRequested: boolean =
         currentPath.endsWith(oldSearchPagePath) && advancedSearchParamsPresent;
+      // TODO: Before we release 2020.2 this can be removed, as the 'newSearch' toggle wil be removed
       const newSearchEnabled: boolean =
         typeof renderData !== "undefined" && renderData?.newSearch;
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -54,7 +54,8 @@ export interface OEQRouteComponentProps<T = TemplateUpdateProps>
   isReloadNeeded: boolean;
 }
 
-type To = (uuid: string, version: number) => string;
+type To = (uuid: string) => string;
+type ToVersion = (uuid: string, version: number) => string;
 
 export interface OEQRoute<T> {
   component?:
@@ -65,7 +66,7 @@ export interface OEQRoute<T> {
   exact?: boolean;
   sensitive?: boolean;
   strict?: boolean;
-  to?: string | To;
+  to?: string | To | ToVersion;
 }
 
 export const routes = {
@@ -83,9 +84,7 @@ export const routes = {
     render: (p: OEQRouteComponentProps) => <SearchPage {...p} />,
   },
   RemoteSearch: {
-    to: function (uuid: string) {
-      return `/access/z3950.do?.repository=${uuid}`;
-    },
+    to: (uuid: string) => `/access/z3950.do?.repository=${uuid}`,
   },
   SearchSettings: {
     path: "/page/searchsettings",
@@ -104,9 +103,7 @@ export const routes = {
     render: (p: OEQRouteComponentProps) => <FacetedSearchSettingsPage {...p} />,
   },
   ViewItem: {
-    to: function (uuid: string, version: number) {
-      return `/items/${uuid}/${version}/`;
-    },
+    to: (uuid: string, version: number) => `/items/${uuid}/${version}/`,
   },
   ThemeConfig: { path: "/page/themeconfiguration", component: ThemePage },
   LoginNoticeConfig: {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -15,15 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { LocationDescriptor } from "history";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
-import { LocationDescriptor } from "history";
 import { TemplateUpdate, TemplateUpdateProps } from "./Template";
-import { RenderData } from "./index";
 
-declare const renderData: RenderData | undefined;
-
-const SearchPage = React.lazy(() => import("../search/SearchPage"));
 const ThemePage = React.lazy(() => import("../theme/ThemePage"));
 const CloudProviderListPage = React.lazy(
   () => import("../cloudprovider/CloudProviderListPage")
@@ -75,13 +71,8 @@ export const routes = {
     to: "/page/settings",
     component: SettingsPage,
   },
-  Search: {
-    //we need to make sure accessing searching.do only renders SearchPage when the New Search page config option is enabled.
-    path:
-      typeof renderData !== "undefined" && renderData?.newSearch
-        ? "(/page/search|/searching.do)"
-        : "/page/search",
-    render: (p: OEQRouteComponentProps) => <SearchPage {...p} />,
+  AdvancedSearch: {
+    to: (uuid: string) => `/searching.do?in=P${uuid}&editquery=true`,
   },
   RemoteSearch: {
     to: (uuid: string) => `/access/z3950.do?.repository=${uuid}`,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/AdvancedSearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/AdvancedSearchModule.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { memoize } from "lodash";
+import { API_BASE_URL } from "../AppConfig";
+
+/**
+ * Retrieve the list of advanced searches from the server, utilising cached (memoized) results
+ * if available.
+ */
+export const getAdvancedSearchesFromServer: () => Promise<
+  OEQ.Common.BaseEntitySummary[]
+> = memoize(
+  async (): Promise<OEQ.Common.BaseEntitySummary[]> =>
+    await OEQ.AdvancedSearch.listAdvancedSearches(API_BASE_URL)
+);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -28,12 +28,14 @@ import { AppConfig } from "../AppConfig";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import MessageInfo from "../components/MessageInfo";
 import type { RenderData } from "../mainui";
+import { routes } from "../mainui/routes";
 import {
   templateDefaults,
   templateError,
   TemplateUpdateProps,
 } from "../mainui/Template";
 import type { Collection } from "../modules/CollectionsModule";
+import { getRemoteSearchesFromServer } from "../modules/RemoteSearchModule";
 import {
   Classification,
   listClassifications,
@@ -55,6 +57,7 @@ import {
 } from "../modules/SearchSettingsModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
+import { AuxiliarySearchSelector } from "./components/AuxiliarySearchSelector";
 import { CategorySelector } from "./components/CategorySelector";
 import { CollectionSelector } from "./components/CollectionSelector";
 import OwnerSelector from "./components/OwnerSelector";
@@ -62,7 +65,6 @@ import {
   RefinePanelControl,
   RefineSearchPanel,
 } from "./components/RefineSearchPanel";
-import { RemoteSearchSelector } from "./components/RemoteSearchSelector";
 import { SearchAttachmentsSelector } from "./components/SearchAttachmentsSelector";
 import {
   mapSearchResultItems,
@@ -383,7 +385,12 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     {
       idSuffix: "RemoteSearchSelector",
       title: searchStrings.remoteSearchSelector.title,
-      component: <RemoteSearchSelector />,
+      component: (
+        <AuxiliarySearchSelector
+          auxiliarySearchesSupplier={getRemoteSearchesFromServer}
+          urlGenerator={routes.RemoteSearch.to}
+        />
+      ),
       disabled: false,
     },
     {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -27,13 +27,13 @@ import { generateFromError } from "../api/errors";
 import { AppConfig } from "../AppConfig";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import MessageInfo from "../components/MessageInfo";
-import type { RenderData } from "../mainui";
 import { routes } from "../mainui/routes";
 import {
   templateDefaults,
   templateError,
   TemplateUpdateProps,
 } from "../mainui/Template";
+import { getAdvancedSearchesFromServer } from "../modules/AdvancedSearchModule";
 import type { Collection } from "../modules/CollectionsModule";
 import { getRemoteSearchesFromServer } from "../modules/RemoteSearchModule";
 import {
@@ -71,8 +71,6 @@ import {
   SearchResultList,
 } from "./components/SearchResultList";
 import StatusSelector from "./components/StatusSelector";
-
-declare const renderData: RenderData | undefined;
 
 /**
  * Type of search options that are specific to Search page presentation layer.
@@ -381,6 +379,19 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         />
       ),
       disabled: false,
+      alwaysVisible: true,
+    },
+    {
+      idSuffix: "AdvancedSearchSelector",
+      title: searchStrings.advancedSearchSelector.title,
+      component: (
+        <AuxiliarySearchSelector
+          auxiliarySearchesSupplier={getAdvancedSearchesFromServer}
+          urlGenerator={routes.AdvancedSearch.to}
+        />
+      ),
+      disabled: false,
+      alwaysVisible: true,
     },
     {
       idSuffix: "RemoteSearchSelector",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/AuxiliarySearchSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/AuxiliarySearchSelector.tsx
@@ -22,8 +22,6 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { routes } from "../../mainui/routes";
-import { getRemoteSearchesFromServer } from "../../modules/RemoteSearchModule";
 
 const useStyles = makeStyles((theme: Theme) => ({
   linkIcon: {
@@ -31,20 +29,27 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export interface RemoteSearchSelectorProps {
+export interface AuxiliarySearchSelectorProps {
   /**
-   * Function to provide a list of remote searches - exposed to support injection for testing/storybooking.
+   * Function to provide a list of auxiliary searches
    */
-  remoteSearchesSupplier?: () => Promise<OEQ.Common.BaseEntitySummary[]>;
+  auxiliarySearchesSupplier: () => Promise<OEQ.Common.BaseEntitySummary[]>;
+
+  /**
+   * Function to produce the URL for a specific search using the UUID returned in the
+   * `OEQ.Common.BaseEntitySummary` from the `auxiliarySearchesSupplier` function.
+   */
+  urlGenerator: (uuid: string) => string;
 }
 /**
  * A search 'selector' control to provide a list of remote searches. Clicking on a remote
  * searches (currently) navigates you to the legacy UI remote search page for that remote
  * search.
  */
-export const RemoteSearchSelector = ({
-  remoteSearchesSupplier = getRemoteSearchesFromServer,
-}: RemoteSearchSelectorProps) => {
+export const AuxiliarySearchSelector = ({
+  auxiliarySearchesSupplier,
+  urlGenerator,
+}: AuxiliarySearchSelectorProps) => {
   const classes = useStyles();
 
   const [remoteSearches, setRemoteSearches] = useState<
@@ -52,12 +57,12 @@ export const RemoteSearchSelector = ({
   >([]);
 
   useEffect(() => {
-    remoteSearchesSupplier().then((searches) => setRemoteSearches(searches));
-  }, [remoteSearchesSupplier]);
+    auxiliarySearchesSupplier().then((searches) => setRemoteSearches(searches));
+  }, [auxiliarySearchesSupplier]);
 
-  const buildRemoteSearchMenuItems = () =>
+  const buildSearchMenuItems = () =>
     remoteSearches.map((summary) => (
-      <Link to={routes.RemoteSearch.to(summary.uuid)}>
+      <Link to={urlGenerator(summary.uuid)}>
         <MenuItem value={summary.uuid}>
           <LinkIcon className={classes.linkIcon} />
           {summary.name}
@@ -67,7 +72,7 @@ export const RemoteSearchSelector = ({
 
   return (
     <FormControl variant="outlined" fullWidth>
-      <Select>{buildRemoteSearchMenuItems()}</Select>
+      <Select>{buildSearchMenuItems()}</Select>
     </FormControl>
   );
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
@@ -48,6 +48,10 @@ export interface RefinePanelControl {
    * True if the control is configured not to be showed.
    */
   disabled?: boolean;
+  /**
+   * True if the control should be outside the 'show more' section.
+   */
+  alwaysVisible?: boolean;
 }
 
 interface RefinePanelProps {
@@ -79,9 +83,24 @@ export const RefineSearchPanel = ({
 
   const { showMore, showLess } = languageStrings.common.action;
 
-  const [alwaysVisibleControl, ...collapsedControls] = controls.filter(
-    (c) => !c.disabled
-  );
+  const {
+    visible: alwaysVisibleControls,
+    collapsed: collapsedControls,
+  } = controls
+    .filter((c) => !c.disabled)
+    .reduce(
+      (acc, cur: RefinePanelControl) => {
+        (cur.alwaysVisible ? acc.visible : acc.collapsed).push(cur);
+        return acc;
+      },
+      {
+        visible: [] as RefinePanelControl[],
+        collapsed: [] as RefinePanelControl[],
+      }
+    );
+
+  const alwaysVisibleSection = (controls: RefinePanelControl[]) =>
+    controls.map((control) => renderRefineControl(control));
 
   const collapsibleSection = (controls: RefinePanelControl[]) => {
     return (
@@ -129,7 +148,7 @@ export const RefineSearchPanel = ({
       <CardContent>
         <Typography variant="h5">{title}</Typography>
         <List>
-          {renderRefineControl(alwaysVisibleControl)}
+          {alwaysVisibleSection(alwaysVisibleControls)}
           {collapsibleSection(collapsedControls)}
         </List>
       </CardContent>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -379,6 +379,9 @@ export const languageStrings = {
     refineSearchPanel: {
       title: "Refine search",
     },
+    advancedSearchSelector: {
+      title: "Access Advanced searches",
+    },
     remoteSearchSelector: {
       title: "Access Remote repositories",
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] ~screenshots are~ **video** _is_ included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Add a new selector which navigates uses to the legacy Advanced Search UIs (as Advanced Search is not planned to be implemented until 2021.x).

To do this, I refactored the `RemoteSearchSelector` into the generic `AuxiliarySearchSelector` and then plugged it in. There was also a requirement that it should always be displayed along with the Collections selector, so I also modified that logic in the `RefineSearchPanel`.

Lastly, due to the support for saved search URLs from legacy UI (using `searching.do`) requiring logic in the routes, I had to further rework this as Advanced Searches are access by `searching.do`. This required refactoring out of `routes.tsx` and into the main router `Switch` in `IndexPage` so as to achieve the dynamic nature needed. This seems rather valid, as the route is not strictly New or Legacy, it does a bit of both depending on about three pre-conditions (now).

There is still some persistence of state for the Advanced Searches, but if required we can revisit in another PR. Unlike initial Remote Searches though, that persistence has no functional issues. Just a slightly different UX than hoped.

Video:

https://streamable.com/ye65ht

#1306
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
