### PR TITLE
Drag and drop in new search page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/CourseListHelper.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/CourseListHelper.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as LegacySelectionSessionModule from "../../tsrc/modules/LegacySelectionSessionModule";
+
+const mockGlobalCourseList = jest.spyOn(
+  LegacySelectionSessionModule,
+  "getGlobalCourseList"
+);
+
+const basicCourseList = {
+  updateCourseList: jest.fn(),
+  prepareDraggableAndBind: jest.fn(),
+  newSearchPageItemClass: "SearchPage-Item",
+  newSearchPageAttachmentClass: "SearchPage-Attachment",
+};
+
+export const updateMockGlobalCourseList = (courseList = basicCourseList) =>
+  mockGlobalCourseList.mockReturnValue(courseList);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -41,7 +41,6 @@ import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { Collection } from "../../../tsrc/modules/CollectionsModule";
 import { getGlobalCourseList } from "../../../tsrc/modules/LegacySelectionSessionModule";
-import * as LegacySelectionSessionModule from "../../../tsrc/modules/LegacySelectionSessionModule";
 import * as MimeTypesModule from "../../../tsrc/modules/MimeTypesModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
@@ -55,6 +54,7 @@ import * as UserModule from "../../../tsrc/modules/UserModule";
 import SearchPage, { SearchPageOptions } from "../../../tsrc/search/SearchPage";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import { queryPaginatorControls } from "../components/SearchPaginationTestHelper";
+import { updateMockGlobalCourseList } from "../CourseListHelper";
 import { selectOption } from "../MuiTestHelpers";
 import { basicRenderData, updateMockGetRenderData } from "../RenderDataHelper";
 import {
@@ -708,14 +708,7 @@ describe("conversion of parameters to SearchPageOptions", () => {
 });
 
 describe("In Selection Session", () => {
-  const mockGlobalCourseList = jest.spyOn(
-    LegacySelectionSessionModule,
-    "getGlobalCourseList"
-  );
-  mockGlobalCourseList.mockReturnValue({
-    updateCourseList: jest.fn(),
-    prepareDraggableAndBind: jest.fn(),
-  });
+  updateMockGlobalCourseList();
 
   it("should make each Search result Item draggable", async () => {
     updateMockGetRenderData(basicRenderData);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -715,7 +715,11 @@ describe("In Selection Session", () => {
     mockSearch.mockResolvedValue(getSearchResult);
     await renderSearchPage();
 
-    getSearchResult.results.forEach(({ uuid }) => {
+    const searchResults = getSearchResult.results;
+    // Make sure the search result definitely has Items.
+    expect(searchResults.length).toBeGreaterThan(0);
+
+    searchResults.forEach(({ uuid }) => {
       expect(
         getGlobalCourseList().prepareDraggableAndBind
       ).toHaveBeenCalledWith(`#${uuid}`, true);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -40,6 +40,8 @@ import {
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { Collection } from "../../../tsrc/modules/CollectionsModule";
+import { getGlobalCourseList } from "../../../tsrc/modules/LegacySelectionSessionModule";
+import * as LegacySelectionSessionModule from "../../../tsrc/modules/LegacySelectionSessionModule";
 import * as MimeTypesModule from "../../../tsrc/modules/MimeTypesModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
@@ -54,6 +56,7 @@ import SearchPage, { SearchPageOptions } from "../../../tsrc/search/SearchPage";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import { queryPaginatorControls } from "../components/SearchPaginationTestHelper";
 import { selectOption } from "../MuiTestHelpers";
+import { basicRenderData, updateMockGetRenderData } from "../RenderDataHelper";
 import {
   clearSelection,
   selectUser,
@@ -701,5 +704,28 @@ describe("conversion of parameters to SearchPageOptions", () => {
     expect(SearchModule.queryStringParamsToSearchOptions).toHaveBeenCalledTimes(
       1
     );
+  });
+});
+
+describe("In Selection Session", () => {
+  const mockGlobalCourseList = jest.spyOn(
+    LegacySelectionSessionModule,
+    "getGlobalCourseList"
+  );
+  mockGlobalCourseList.mockReturnValue({
+    updateCourseList: jest.fn(),
+    prepareDraggableAndBind: jest.fn(),
+  });
+
+  it("should make each Search result Item draggable", async () => {
+    updateMockGetRenderData(basicRenderData);
+    mockSearch.mockResolvedValue(getSearchResult);
+    await renderSearchPage();
+
+    getSearchResult.results.forEach(({ uuid }) => {
+      expect(
+        getGlobalCourseList().prepareDraggableAndBind
+      ).toHaveBeenCalledWith(`#${uuid}`, true);
+    });
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -26,6 +26,7 @@ import { sprintf } from "sprintf-js";
 import * as mockData from "../../../../__mocks__/searchresult_mock_data";
 import type { RenderData } from "../../../../tsrc/AppConfig";
 import {
+  getGlobalCourseList,
   selectResourceForCourseList,
   selectResourceForNonCourseList,
 } from "../../../../tsrc/modules/LegacySelectionSessionModule";
@@ -197,7 +198,10 @@ describe("<SearchResult/>", () => {
       LegacySelectionSessionModule,
       "getGlobalCourseList"
     );
-    mockGlobalCourseList.mockReturnValue({ updateCourseList: jest.fn() });
+    mockGlobalCourseList.mockReturnValue({
+      updateCourseList: jest.fn(),
+      prepareDraggableAndBind: jest.fn(),
+    });
 
     const mockSelectResourceForCourseList = jest.spyOn(
       LegacySelectionSessionModule,
@@ -305,6 +309,16 @@ describe("<SearchResult/>", () => {
       );
       expect(expandedAttachment.queryByText("image.png")).toBeVisible();
       expect(collapsedAttachment.queryByText("config.json")).not.toBeVisible();
+    });
+
+    it("should make each attachment draggable", async () => {
+      updateMockGetRenderData(basicRenderData);
+      await renderSearchResult(mockData.attachSearchObj);
+      mockData.attachSearchObj.attachments!.forEach((attachment) => {
+        expect(
+          getGlobalCourseList().prepareDraggableAndBind
+        ).toHaveBeenCalledWith(`#${attachment.id}`, false);
+      });
     });
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -201,6 +201,8 @@ describe("<SearchResult/>", () => {
     mockGlobalCourseList.mockReturnValue({
       updateCourseList: jest.fn(),
       prepareDraggableAndBind: jest.fn(),
+      newSearchPageItemClass: "SearchPage-Item",
+      newSearchPageAttachmentClass: "SearchPage-Attachment",
     });
 
     const mockSelectResourceForCourseList = jest.spyOn(

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -308,7 +308,12 @@ describe("<SearchResult/>", () => {
     it("should make each attachment draggable", async () => {
       updateMockGetRenderData(basicRenderData);
       await renderSearchResult(mockData.attachSearchObj);
-      mockData.attachSearchObj.attachments!.forEach((attachment) => {
+
+      const attachments = mockData.attachSearchObj.attachments!;
+      // Make sure there are attachments in the SearchResult.
+      expect(attachments.length).toBeGreaterThan(0);
+
+      attachments.forEach((attachment) => {
         expect(
           getGlobalCourseList().prepareDraggableAndBind
         ).toHaveBeenCalledWith(`#${attachment.id}`, false);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -34,6 +34,7 @@ import * as MimeTypesModule from "../../../../tsrc/modules/MimeTypesModule";
 import * as LegacySelectionSessionModule from "../../../../tsrc/modules/LegacySelectionSessionModule";
 import SearchResult from "../../../../tsrc/search/components/SearchResult";
 import { languageStrings } from "../../../../tsrc/util/langstrings";
+import { updateMockGlobalCourseList } from "../../CourseListHelper";
 import {
   basicRenderData,
   renderDataForSelectOrAdd,
@@ -194,16 +195,7 @@ describe("<SearchResult/>", () => {
   });
 
   describe("In Selection Session", () => {
-    const mockGlobalCourseList = jest.spyOn(
-      LegacySelectionSessionModule,
-      "getGlobalCourseList"
-    );
-    mockGlobalCourseList.mockReturnValue({
-      updateCourseList: jest.fn(),
-      prepareDraggableAndBind: jest.fn(),
-      newSearchPageItemClass: "SearchPage-Item",
-      newSearchPageAttachmentClass: "SearchPage-Attachment",
-    });
+    updateMockGlobalCourseList();
 
     const mockSelectResourceForCourseList = jest.spyOn(
       LegacySelectionSessionModule,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -92,6 +92,8 @@ export interface SelectionSessionPostData {
 declare const CourseList: {
   updateCourseList: (data: unknown) => void;
   prepareDraggableAndBind: (selector: string, forItem: boolean) => void;
+  newSearchPageItemClass: string;
+  newSearchPageAttachmentClass: string;
 };
 
 /**
@@ -109,6 +111,22 @@ export const prepareDraggable = (id: string, forItem = true) => {
  * The intention of having this function is to help Jest test mock CourseList.
  */
 export const getGlobalCourseList = () => CourseList;
+
+/**
+ * When Selection Session is open, provide access to the CSS class 'newSearchPageItemClass'
+ * defined in 'couselist.js'.
+ */
+export const getSearchPageItemClass = (): string =>
+  isSelectionSessionOpen() ? getGlobalCourseList().newSearchPageItemClass : "";
+
+/**
+ * When Selection Session is open, provide access to the CSS class 'newSearchPageAttachmentClass'
+ * defined in 'couselist.js'.
+ */
+export const getSearchPageAttachmentClass = (): string =>
+  isSelectionSessionOpen()
+    ? getGlobalCourseList().newSearchPageAttachmentClass
+    : "";
 
 /**
  * An internal Type guard used to check whether an object is of type SelectionSessionInfo.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -91,6 +91,18 @@ export interface SelectionSessionPostData {
  */
 declare const CourseList: {
   updateCourseList: (data: unknown) => void;
+  prepareDraggableAndBind: (selector: string, forItem: boolean) => void;
+};
+
+/**
+ * Prepare draggables for Items and attachments. ONLY works for HTML elements that
+ * have an ID.
+ *
+ * @param id A string representing a DOM element's ID.
+ * @param forItem True if prepare draggables for Items
+ */
+export const prepareDraggable = (id: string, forItem = true) => {
+  CourseList.prepareDraggableAndBind(`#${id}`, forItem);
 };
 
 /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -102,7 +102,7 @@ declare const CourseList: {
  * @param forItem True if prepare draggables for Items
  */
 export const prepareDraggable = (id: string, forItem = true) => {
-  CourseList.prepareDraggableAndBind(`#${id}`, forItem);
+  getGlobalCourseList().prepareDraggableAndBind(`#${id}`, forItem);
 };
 
 /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -49,7 +49,10 @@ import {
   SearchSettings,
   SortOrder,
 } from "../modules/SearchSettingsModule";
-import { isSelectionSessionOpen } from "../modules/LegacySelectionSessionModule";
+import {
+  isSelectionSessionOpen,
+  prepareDraggable,
+} from "../modules/LegacySelectionSessionModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
 import { CategorySelector } from "./components/CategorySelector";
@@ -181,6 +184,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       state: { searchPageOptions, filterExpansion },
     });
   }, [filterExpansion, pagedSearchResult]);
+
+  // In Selection Session, once a new search result is returned, make each
+  // new search result Item draggable.
+  useEffect(() => {
+    if (inSelectionSession) {
+      pagedSearchResult.results.forEach(({ uuid }) => {
+        prepareDraggable(uuid);
+      });
+    }
+  }, [pagedSearchResult]);
 
   // When Search options get changed, also update the Classification list.
   useEffect(() => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -224,7 +224,7 @@ export default function SearchResult({
   useEffect(() => {
     if (inSelectionSession) {
       attachmentsWithViewerDetails.forEach(({ attachment }) => {
-        prepareDraggable(attachment.id);
+        prepareDraggable(attachment.id, false);
       });
     }
   }, [attachmentsWithViewerDetails]);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -58,6 +58,8 @@ import {
   isSelectionSessionOpen,
   isSelectSummaryButtonDisabled,
   prepareDraggable,
+  getSearchPageItemClass,
+  getSearchPageAttachmentClass,
 } from "../../modules/LegacySelectionSessionModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
@@ -345,7 +347,7 @@ export default function SearchResult({
             key={id}
             id={id}
             button
-            className={`${classes.nested} NewSearchPage-Attachment`} // Give a class so each attachment can be dropped to the course list.
+            className={`${classes.nested} ${getSearchPageAttachmentClass()}`} // Give a class so each attachment can be dropped to the course list.
             data-itemuuid={uuid} // These 'data-xx' attributes are used in the 'dropCallBack' of 'courselist.js'.
             data-itemversion={version}
             data-attachmentuuid={id}
@@ -476,7 +478,7 @@ export default function SearchResult({
         id={uuid}
         container
         alignItems="center"
-        className="NewSearchPage-Item" // Give a class so each item can be dropped to the course list.
+        className={getSearchPageItemClass()} // Give a class so each item can be dropped to the course list.
         data-itemuuid={uuid}
         data-itemversion={version}
       >

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -36,6 +36,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import AttachFile from "@material-ui/icons/AttachFile";
 import ExpandMore from "@material-ui/icons/ExpandMore";
 import InsertDriveFile from "@material-ui/icons/InsertDriveFile";
+import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
 import Search from "@material-ui/icons/Search";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
@@ -55,6 +56,7 @@ import {
   selectResource,
   isSelectionSessionOpen,
   isSelectSummaryButtonDisabled,
+  prepareDraggable,
 } from "../../modules/LegacySelectionSessionModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
@@ -218,6 +220,15 @@ export default function SearchResult({
     };
   }, [attachments, getViewerDetails]);
 
+  // In Selection Session, make each attachment draggable.
+  useEffect(() => {
+    if (inSelectionSession) {
+      attachmentsWithViewerDetails.forEach(({ attachment }) => {
+        prepareDraggable(attachment.id);
+      });
+    }
+  }, [attachmentsWithViewerDetails]);
+
   const handleAttachmentPanelClick = (event: SyntheticEvent) => {
     /** prevents the SearchResult onClick from firing when attachment panel is clicked */
     event.stopPropagation();
@@ -329,9 +340,17 @@ export default function SearchResult({
           filePath
         );
         return (
-          <ListItem key={id} button className={classes.nested}>
+          <ListItem
+            key={id}
+            id={id}
+            button
+            className={`${classes.nested} NewSearchPage-Attachment`} // Give a class so each attachment can be dropped to the course list.
+            data-itemuuid={uuid} // These 'data-xx' attributes are used in the 'dropCallBack' of 'courselist.js'.
+            data-itemversion={version}
+            data-attachmentuuid={id}
+          >
             <ListItemIcon>
-              <InsertDriveFile />
+              {inSelectionSession ? <DragIndicatorIcon /> : <InsertDriveFile />}
             </ListItemIcon>
             <ItemAttachmentLink
               description={description}
@@ -452,7 +471,14 @@ export default function SearchResult({
 
   const itemPrimaryContent =
     inSelectionSession && !isSelectSummaryButtonDisabled() ? (
-      <Grid container alignItems="center">
+      <Grid
+        id={uuid}
+        container
+        alignItems="center"
+        className="NewSearchPage-Item" // Give a class so each item can be dropped to the course list.
+        data-itemuuid={uuid}
+        data-itemversion={version}
+      >
         <Grid item>{itemLink()}</Grid>
         <Grid item>
           <ResourceSelector

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -22,6 +22,7 @@ import {
   Badge,
   Divider,
   Grid,
+  IconButton,
   List,
   ListItem,
   ListItemIcon,
@@ -479,6 +480,11 @@ export default function SearchResult({
         data-itemuuid={uuid}
         data-itemversion={version}
       >
+        <Grid item>
+          <IconButton>
+            <DragIndicatorIcon />
+          </IconButton>
+        </Grid>
         <Grid item>{itemLink()}</Grid>
         <Grid item>
           <ResourceSelector

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/courselist.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/courselist.js
@@ -40,7 +40,8 @@ var CourseList = {
 		$rhs.find('.foldertree').height(rhsHeight - $rhs.find('.courselisttop').height() - 55);
 		CourseList.scrollToSelected();
 	},
-
+  newSearchPageItemClass: 'SearchPage-Item',
+  newSearchPageAttachmentClass: 'SearchPage-Attachment',
 	/**
 	 * @param ajaxCb AJAX event when content is dropped onto a folder
 	 * @param ajaxClickCb AJAX event when a folder is clicked
@@ -63,8 +64,8 @@ var CourseList = {
 		var itemResultSelector = '.selectable.' + itemResultClass;
 		var itemSummarySelector = "h2." + itemSummaryClass;
 		var attachmentSelector = '.selectable .attachmentrow.with-select';
-		var newSearchPageItemSelector = '.NewSearchPage-Item';
-		var newSearchPageAttachmentSelector = '.NewSearchPage-Attachment';
+		var newSearchPageItemSelector = '.' + CourseList.newSearchPageItemClass;
+		var newSearchPageAttachmentSelector = '.' + CourseList.newSearchPageAttachmentClass;
 
     var dropCallback = function(event, ui)
     {

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/courselist.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/courselist.js
@@ -63,114 +63,147 @@ var CourseList = {
 		var itemResultSelector = '.selectable.' + itemResultClass;
 		var itemSummarySelector = "h2." + itemSummaryClass;
 		var attachmentSelector = '.selectable .attachmentrow.with-select';
+		var newSearchPageItemSelector = '.NewSearchPage-Item';
+		var newSearchPageAttachmentSelector = '.NewSearchPage-Attachment';
 
-		var dropCallback = function(event, ui)
-		{
-			var $res = $(ui.draggable);
-			var $data = $res.find('[data-itemuuid]');
-			if ($data.length == 0)
-			{
-				$data = $res;
-			}
-			var uuid = $data.attr('data-itemuuid');
-			var version = 0 + $data.attr('data-itemversion');
-			var attachmentUuid = $data.attr('data-attachmentuuid');
-			var type = (attachmentUuid ? 'a' : 'p');
-			var extensionType = $data.attr('data-extensiontype');
+    var dropCallback = function(event, ui)
+    {
+      var $res = $(ui.draggable);
+      var $data = $res.find('[data-itemuuid]');
+      if ($data.length == 0)
+      {
+        $data = $res;
+      }
+      var uuid = $data.attr('data-itemuuid');
+      var version = 0 + $data.attr('data-itemversion');
+      var attachmentUuid = $data.attr('data-attachmentuuid');
+      var type = (attachmentUuid ? 'a' : 'p');
+      var extensionType = $data.attr('data-extensiontype');
 
-			var $target = $(this);
-			var folder = $target.attr('data-folderid');
+      var $target = $(this);
+      var folder = $target.attr('data-folderid');
 
-			if (ajaxDropCallback)
-			{
-				ajaxDropCallback(
-					JSON.stringify({
-						"uuid": uuid,
-						"version": version,
-						"type": type,
-						"attachmentUuid": attachmentUuid,
-						"folderId": folder,
-						"extensionType": extensionType}),
-					folder);
-			}
-		}
-		var makeHelper = function()
-		{
-			var $dragged = $(this);
-			var $div = $dragged.clone();
-			$div.find('button').remove();
-			debug('dw' + $dragged.width());
-			debug('dh' + $dragged.height());
-			$div.width($dragged.width());
-			$div.height($dragged.height());
-			$div.zIndex(10000);
-			return $div;
-		};
-		var draggableOpts = {
-				cursor: 'move',
-				distance: 10,
-				helper: makeHelper,
-				opacity: 0.8,
-				revert: 'invalid',
-				scroll: false
-			};
+      if (ajaxDropCallback)
+      {
+        ajaxDropCallback(
+          JSON.stringify({
+            "uuid": uuid,
+            "version": version,
+            "type": type,
+            "attachmentUuid": attachmentUuid,
+            "folderId": folder,
+            "extensionType": extensionType}),
+          folder);
+      }
+    }
+		if(doItems) {
+      CourseList.prepareDraggableAndBind(listSelector + ' ' + itemResultSelector, true);
+      // According to the existing code, there is no need to bind any handler to drag events happening in the ItemSummary page.
+      CourseList.prepareDraggable(itemSummarySelector);
+    }
 
-		if (doItems)
-		{
-			var itemListWatcher = function()
-			{
-				$(listSelector + ' ' + itemResultSelector).draggable(draggableOpts);
-			};
-			$(itemListWatcher);
-			$(document).bind('equella_searchresults.courselist', itemListWatcher);
+		if(doAttachments) {
+      CourseList.prepareDraggableAndBind(attachmentSelector, false)
+    }
 
-			$(function()
-			{
-				$(itemSummarySelector).draggable(draggableOpts);
-			});
-		}
-
-		if (doAttachments)
-		{
-			var attachmentWatcher = function()
-			{
-					$(attachmentSelector).draggable(draggableOpts);
-			};
-			$(attachmentWatcher);
-			$(document).bind('equella_showattachments.courselist', attachmentWatcher);
-		}
-
-		var droppableOpts = {
-				accept: itemResultSelector + ', ' + attachmentSelector + ', ' + itemSummarySelector,
-				activeClass: 'droptarget',
-				hoverClass: 'hover',
-				tolerance: 'pointer',
-				drop: dropCallback
-			};
-		var courseListWatcher = function()
-		{
-			$('.targetfolder').droppable(droppableOpts).on('click.courselist', function()
-					{
-						var $t = $(this);
-						$('.targetfolder').removeClass('selected');
-						//Don't call click(), you get stuck in a nasty event loop
-						$t.find('input[type=radio]').attr('checked', true);
-						$t.addClass('selected');
-						if (clickFolderCallback)
-						{
-							clickFolderCallback(function(){});
-						}
-					}
-			);
-		};
-		$(courseListWatcher);
-		$(document).bind('equella_courselistupdate.courselist', courseListWatcher);
+    CourseList.prepareDroppable(
+      itemResultSelector +
+      ', ' + attachmentSelector +
+      ', ' + itemSummarySelector +
+      ', ' + newSearchPageItemSelector +
+      ', ' + newSearchPageAttachmentSelector, // Also accept draggables made in new Search UI.
+      dropCallback, clickFolderCallback)
 
 		//sizing code... yuck
 		$(document).ready(function(){setTimeout(CourseList.resize,50)});
 		$(window).resize(CourseList.resize);
 		$(document).bind('equella_searchresults.courselist', CourseList.resize);
 	},
+
+  /**
+   *  A function used to set up Draggables and attach the drag event handler to oEQ events.
+   *
+   *  @param selector A valid jQuery selector
+   *  @param forItem True if set up for Items
+   */
+  prepareDraggableAndBind: function(selector, forItem) {
+    var dragHandler = CourseList.prepareDraggable(selector);
+    if(forItem) {
+      $(document).bind('equella_searchresults.courselist', dragHandler);
+    }
+    else{
+      $(document).bind('equella_showattachments.courselist', dragHandler);
+    }
+  },
+
+  // Make a DOM element draggable and return the drag event handler.
+  prepareDraggable: function(selector) {
+    var makeDraggableHelper = function() {
+      var $dragged = $(this);
+      var $div = $dragged.clone();
+      // In new UI some attachments are renderer as buttons due to their viewers so removing buttons will
+      // result in attachment title missing in the dragged div. Hence, we need to keep them.
+      $div.find('button').not('.MuiLink-button').remove();
+      debug('dw' + $dragged.width());
+      debug('dh' + $dragged.height());
+      $div.width($dragged.width());
+      $div.height($dragged.height());
+      // Due to appendTo: "#body", font size is wrong in this dragged div so need to reset the font size.
+      $div.css({'font-size': $dragged.css('font-size')})
+      $div.zIndex(10000);
+      return $div;
+    };
+
+    var draggableOpts = {
+      cursor: 'move',
+      distance: 10,
+      helper: makeDraggableHelper,
+      opacity: 0.8,
+      revert: 'invalid',
+      scroll: false,
+      // Append to '#body' can ensure the dragged div is always visible in new UI
+      // regardless of MUI Card's 'overflow:hidden'.
+      appendTo: "#body",
+      cancel: false // Buttons are not allowed to drag by default so set 'cancel' to false to drag buttons
+    };
+
+    var dragHandler = function()
+    {
+      $(selector).draggable(draggableOpts);
+    };
+    $(dragHandler);
+    return dragHandler;
+  },
+
+  // Although there is no need to set up droppables in new UI, making this function independent
+  // can improve readability of this file.
+  prepareDroppable: function(acceptDraggables, dropCallback, clickFolderCallback) {
+    var droppableOpts = {
+      accept: acceptDraggables,
+      activeClass: 'droptarget',
+      hoverClass: 'hover',
+      tolerance: 'pointer',
+      drop: dropCallback
+    };
+    var courseListWatcher = function()
+    {
+      $('.targetfolder').droppable(droppableOpts).on('click.courselist', function()
+        {
+          var $t = $(this);
+          $('.targetfolder').removeClass('selected');
+          //Don't call click(), you get stuck in a nasty event loop
+          $t.find('input[type=radio]').attr('checked', true);
+          $t.addClass('selected');
+          if (clickFolderCallback)
+          {
+            clickFolderCallback(function(){});
+          }
+        }
+      );
+    };
+    $(courseListWatcher);
+    $(document).bind('equella_courselistupdate.courselist', courseListWatcher);
+  },
 
 	updateTargetFolder: function(ajax, folderId, eventArgs, ajaxIds)
 	{

--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/courselist.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/courselist.js
@@ -97,23 +97,20 @@ var CourseList = {
           folder);
       }
     }
-		if(doItems) {
+    if (doItems) {
       CourseList.prepareDraggableAndBind(listSelector + ' ' + itemResultSelector, true);
       // According to the existing code, there is no need to bind any handler to drag events happening in the ItemSummary page.
       CourseList.prepareDraggable(itemSummarySelector);
     }
 
-		if(doAttachments) {
+    if (doAttachments) {
       CourseList.prepareDraggableAndBind(attachmentSelector, false)
     }
 
-    CourseList.prepareDroppable(
-      itemResultSelector +
-      ', ' + attachmentSelector +
-      ', ' + itemSummarySelector +
-      ', ' + newSearchPageItemSelector +
-      ', ' + newSearchPageAttachmentSelector, // Also accept draggables made in new Search UI.
-      dropCallback, clickFolderCallback)
+    var droppableSelectors =
+      [itemResultSelector, attachmentSelector, itemSummarySelector,
+        newSearchPageItemSelector, newSearchPageAttachmentSelector].join();
+    CourseList.prepareDroppable(droppableSelectors, dropCallback, clickFolderCallback);
 
 		//sizing code... yuck
 		$(document).ready(function(){setTimeout(CourseList.resize,50)});


### PR DESCRIPTION
#688 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the feature of 'Drag and Drop' to the new Search UI so each Item and attachment is draggable and they can be dropped to the course list in Selection Session.

The approach is basically to reuse some old JS functions provided in `courselist.js` to make TS component draggable. 

The whole logic should be: 

1.  `CourseListSection.java` prepares a droppable area which is the course list, including setting up the `onDrop` event handler, and specifying what elements can be dropped.

2. A search is in done in new search UI and returns some search result Items.

3. Make each search result Item draggable.

4. After the async call for attachment viewer details is completed, make each attachment draggable.


Please view this [Video](https://streamable.com/768cpf). 