### PR TITLE
Parse Youtube Date Modified dates properly

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentSerializer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentSerializer.java
@@ -30,6 +30,7 @@ import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
+import org.joda.time.format.ISODateTimeFormat;
 
 @Bind
 @Singleton
@@ -45,7 +46,10 @@ public class YoutubeAttachmentSerializer extends AbstractAttachmentSerializer {
     ybean.setThumbUrl((String) cattach.getData(YoutubeUtils.PROPERTY_THUMB_URL));
     ybean.setViewUrl((String) cattach.getData(YoutubeUtils.PROPERTY_PLAY_URL));
     ybean.setCustomParameters((String) cattach.getData(YoutubeUtils.PROPERTY_PARAMETERS));
-    final Long date = (Long) cattach.getData(YoutubeUtils.PROPERTY_DATE);
+    final Long date =
+        ISODateTimeFormat.dateTimeNoMillis()
+            .parseDateTime((String) cattach.getData(YoutubeUtils.PROPERTY_DATE))
+            .getMillis();
     if (date != null) {
       ybean.setUploadedDate(new Date(date));
     }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentSerializer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentSerializer.java
@@ -28,9 +28,7 @@ import com.tle.core.item.edit.ItemEditor;
 import com.tle.core.item.serializer.AbstractAttachmentSerializer;
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
 import java.time.Duration;
-import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 
 @Bind
 @Singleton
@@ -46,9 +44,8 @@ public class YoutubeAttachmentSerializer extends AbstractAttachmentSerializer {
     ybean.setThumbUrl((String) cattach.getData(YoutubeUtils.PROPERTY_THUMB_URL));
     ybean.setViewUrl((String) cattach.getData(YoutubeUtils.PROPERTY_PLAY_URL));
     ybean.setCustomParameters((String) cattach.getData(YoutubeUtils.PROPERTY_PARAMETERS));
-    final Optional<Date> date =
-        YoutubeUtils.parseDateModifiedToDate((String) cattach.getData(YoutubeUtils.PROPERTY_DATE));
-    date.ifPresent(ybean::setUploadedDate);
+    YoutubeUtils.parseDateModifiedToDate(cattach.getData(YoutubeUtils.PROPERTY_DATE))
+        .ifPresent(ybean::setUploadedDate);
     ybean.setUploader((String) cattach.getData(YoutubeUtils.PROPERTY_AUTHOR));
     final Object durationData = cattach.getData(YoutubeUtils.PROPERTY_DURATION);
     String duration = null;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentSerializer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentSerializer.java
@@ -30,7 +30,7 @@ import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
-import org.joda.time.format.ISODateTimeFormat;
+import java.util.Optional;
 
 @Bind
 @Singleton
@@ -46,13 +46,9 @@ public class YoutubeAttachmentSerializer extends AbstractAttachmentSerializer {
     ybean.setThumbUrl((String) cattach.getData(YoutubeUtils.PROPERTY_THUMB_URL));
     ybean.setViewUrl((String) cattach.getData(YoutubeUtils.PROPERTY_PLAY_URL));
     ybean.setCustomParameters((String) cattach.getData(YoutubeUtils.PROPERTY_PARAMETERS));
-    final Long date =
-        ISODateTimeFormat.dateTimeNoMillis()
-            .parseDateTime((String) cattach.getData(YoutubeUtils.PROPERTY_DATE))
-            .getMillis();
-    if (date != null) {
-      ybean.setUploadedDate(new Date(date));
-    }
+    final Optional<Date> date =
+        YoutubeUtils.parseDateModifiedToDate((String) cattach.getData(YoutubeUtils.PROPERTY_DATE));
+    date.ifPresent(ybean::setUploadedDate);
     ybean.setUploader((String) cattach.getData(YoutubeUtils.PROPERTY_AUTHOR));
     final Object durationData = cattach.getData(YoutubeUtils.PROPERTY_DURATION);
     String duration = null;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
@@ -86,9 +86,9 @@ import java.math.BigInteger;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.joda.time.format.ISODateTimeFormat;
 
 @SuppressWarnings("nls")
 @Bind
@@ -287,7 +287,10 @@ public class YoutubeHandler
               YoutubeResultOption result = new YoutubeResultOption(videoId);
               result.setAuthor(new KeyLabel(ADD_AUTHOR_LABEL, vidInfo.getChannelTitle()));
               result.setDate(
-                  dateRendererFactory.createDateRenderer(new Date(vidInfo.getPublishedAt())));
+                  dateRendererFactory.createDateRenderer(
+                      ISODateTimeFormat.dateTimeNoMillis()
+                          .parseDateTime(vidInfo.getPublishedAt())
+                          .toDate()));
 
               String description = vidInfo.getDescription();
               result.setDescription(

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
@@ -86,9 +86,7 @@ import java.math.BigInteger;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("nls")
@@ -287,10 +285,8 @@ public class YoutubeHandler
 
               YoutubeResultOption result = new YoutubeResultOption(videoId);
               result.setAuthor(new KeyLabel(ADD_AUTHOR_LABEL, vidInfo.getChannelTitle()));
-              Optional<Date> parsedDate =
-                  YoutubeUtils.parseDateModifiedToDate(vidInfo.getPublishedAt());
-              parsedDate.ifPresent(
-                  date -> result.setDate(dateRendererFactory.createDateRenderer(date)));
+              YoutubeUtils.parseDateModifiedToDate(vidInfo.getPublishedAt())
+                  .ifPresent(date -> result.setDate(dateRendererFactory.createDateRenderer(date)));
               String description = vidInfo.getDescription();
               result.setDescription(
                   Check.isEmpty(description)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeHandler.java
@@ -86,9 +86,10 @@ import java.math.BigInteger;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
-import org.joda.time.format.ISODateTimeFormat;
 
 @SuppressWarnings("nls")
 @Bind
@@ -286,12 +287,10 @@ public class YoutubeHandler
 
               YoutubeResultOption result = new YoutubeResultOption(videoId);
               result.setAuthor(new KeyLabel(ADD_AUTHOR_LABEL, vidInfo.getChannelTitle()));
-              result.setDate(
-                  dateRendererFactory.createDateRenderer(
-                      ISODateTimeFormat.dateTimeNoMillis()
-                          .parseDateTime(vidInfo.getPublishedAt())
-                          .toDate()));
-
+              Optional<Date> parsedDate =
+                  YoutubeUtils.parseDateModifiedToDate(vidInfo.getPublishedAt());
+              parsedDate.ifPresent(
+                  date -> result.setDate(dateRendererFactory.createDateRenderer(date)));
               String description = vidInfo.getDescription();
               result.setDescription(
                   Check.isEmpty(description)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
@@ -93,18 +93,22 @@ public final class YoutubeUtils {
    * @param date The date object to parse (Expects it to be a string in ISO_DATE_TIME format, or an
    *     epoch long)
    * @return The date represented as a java.util.Date.
+   * @throws IllegalArgumentException if passed in Object is not an instance of long or string
    */
   public static Optional<Date> parseDateModifiedToDate(Object date) {
     Optional<Date> parsedDate = Optional.empty();
     if (date instanceof Long) {
       // if its a long, assume its an epoch long
       parsedDate = Optional.of(new Date((Long) date));
-    } else {
+    } else if (date instanceof String) {
       // assume its an ISO_DATE_TIME string
       Optional<Long> parsedLong = parseDateModifiedToMillis((String) date);
       if (parsedLong.isPresent()) {
         parsedDate = Optional.of(new Date(parsedLong.get()));
       }
+    } else {
+      throw new IllegalArgumentException(
+          "Date object must be a long or a string. Unable to parse " + date + "as a date.");
     }
     return parsedDate;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
@@ -87,7 +87,7 @@ public final class YoutubeUtils {
    * Wrapper for parseDateModifiedToMillis which if present will return the date as a
    * java.util.Date.
    *
-   * <p>Youtube Data API v3 returns ISO_DATE_TIME strings, but existing attachments returned from v2
+   * Youtube Data API v3 returns ISO_DATE_TIME strings, but existing attachments returned from v2
    * will be stored as epoch millis, so this function supports both.
    *
    * @param date The date object to parse (Expects it to be a string in ISO_DATE_TIME format, or an

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
@@ -60,13 +60,14 @@ public final class YoutubeUtils {
   }
 
   /**
-   * Parses a date string returned from the Youtube Data API V3's "modified"
-   * entry for a given Youtube search result.
-   * Returns a date epoch long.
+   * Parses a date string returned from the Youtube Data API V3's "modified" entry for a given
+   * Youtube search result. Returns a date epoch long.
+   *
    * @param date The string to parse (Expects it to be in ISO_DATE_TIME format)
-   * @return a long containing the date represented as the number of milliseconds since midnight January 1, 1970.
+   * @return a long containing the date represented as the number of milliseconds since midnight
+   *     January 1, 1970.
    * @throws RuntimeException when the date cannot be parsed.
-   * */
+   */
   public static Optional<Long> parseDateModifiedToMillis(String date) {
     Optional<Long> parsedDate;
     try {
@@ -82,8 +83,9 @@ public final class YoutubeUtils {
   }
 
   /**
-   * Wrapper for parseDateModifiedToMillis which if present will return
-   * the date as a java.util.Date.
+   * Wrapper for parseDateModifiedToMillis which if present will return the date as a
+   * java.util.Date.
+   *
    * @param date The string to parse (Expects it to be in ISO_DATE_TIME format)
    * @return The date represented as a java.util.Date.
    */

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
@@ -19,6 +19,11 @@
 package com.tle.web.controls.youtube;
 
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import java.util.Optional;
 
 @SuppressWarnings("nls")
 public final class YoutubeUtils {
@@ -34,7 +39,6 @@ public final class YoutubeUtils {
   public static final String PROPERTY_THUMB_URL = "thumbUrl";
 
   @Deprecated public static final String PROPERTY_TAGS = "tags";
-
   // ISO-8601 Duration string
   public static final String PROPERTY_DURATION = "duration";
   public static final String PROPERTY_PARAMETERS = "custom_parameters";
@@ -53,6 +57,43 @@ public final class YoutubeUtils {
     long seconds = minusHours.minus(Duration.ofMinutes(minutes)).getSeconds();
     String format = hours > 0 ? "%3$d:%2$02d:%1$02d" : "%2$d:%1$02d";
     return String.format(format, seconds, minutes, hours);
+  }
+
+  /**
+   * Parses a date string returned from the Youtube Data API V3's "modified"
+   * entry for a given Youtube search result.
+   * Returns a date epoch long.
+   * @param date The string to parse (Expects it to be in ISO_DATE_TIME format)
+   * @return a long containing the date represented as the number of milliseconds since midnight January 1, 1970.
+   * @throws RuntimeException when the date cannot be parsed.
+   * */
+  public static Optional<Long> parseDateModifiedToMillis(String date) {
+    Optional<Long> parsedDate;
+    try {
+      parsedDate =
+          Optional.of(
+              ZonedDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME)
+                  .toInstant()
+                  .toEpochMilli());
+    } catch (DateTimeParseException e) {
+      throw new RuntimeException("Unable to parse youtube date modified: " + date, e);
+    }
+    return parsedDate;
+  }
+
+  /**
+   * Wrapper for parseDateModifiedToMillis which if present will return
+   * the date as a java.util.Date.
+   * @param date The string to parse (Expects it to be in ISO_DATE_TIME format)
+   * @return The date represented as a java.util.Date.
+   */
+  public static Optional<Date> parseDateModifiedToDate(String date) {
+    Optional<Long> parsedLong = parseDateModifiedToMillis(date);
+    Optional<Date> parsedDate = Optional.empty();
+    if (parsedLong.isPresent()) {
+      parsedDate = Optional.of(new Date(parsedLong.get()));
+    }
+    return parsedDate;
   }
 
   private YoutubeUtils() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
@@ -87,7 +87,7 @@ public final class YoutubeUtils {
    * Wrapper for parseDateModifiedToMillis which if present will return the date as a
    * java.util.Date.
    *
-   * Youtube Data API v3 returns ISO_DATE_TIME strings, but existing attachments returned from v2
+   * <p>Youtube Data API v3 returns ISO_DATE_TIME strings, but existing attachments returned from v2
    * will be stored as epoch millis, so this function supports both.
    *
    * @param date The date object to parse (Expects it to be a string in ISO_DATE_TIME format, or an

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeUtils.java
@@ -102,10 +102,9 @@ public final class YoutubeUtils {
       parsedDate = Optional.of(new Date((Long) date));
     } else if (date instanceof String) {
       // assume its an ISO_DATE_TIME string
-      Optional<Long> parsedLong = parseDateModifiedToMillis((String) date);
-      if (parsedLong.isPresent()) {
-        parsedDate = Optional.of(new Date(parsedLong.get()));
-      }
+      parsedDate =
+          parseDateModifiedToMillis((String) date).flatMap(millis -> Optional.of(new Date(millis)));
+
     } else {
       throw new IllegalArgumentException(
           "Date object must be a long or a string. Unable to parse " + date + "as a date.");

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeViewableResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeViewableResource.java
@@ -41,10 +41,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 @SuppressWarnings("nls")
 public class YoutubeViewableResource extends AbstractWrappedResource {
@@ -189,13 +187,11 @@ public class YoutubeViewableResource extends AbstractWrappedResource {
     }
 
     // Uploaded
-    Optional<Date> date =
-        YoutubeUtils.parseDateModifiedToDate(
-            (String) youTubeAttachment.getData(YoutubeUtils.PROPERTY_DATE));
-    date.ifPresent(
-        parsedDate ->
-            commonDetails.add(
-                makeDetail(UPLOADED, dateRendererFactory.createDateRenderer(parsedDate))));
+    YoutubeUtils.parseDateModifiedToDate(youTubeAttachment.getData(YoutubeUtils.PROPERTY_DATE))
+        .ifPresent(
+            parsedDate ->
+                commonDetails.add(
+                    makeDetail(UPLOADED, dateRendererFactory.createDateRenderer(parsedDate))));
 
     // Tags
     String tags = (String) youTubeAttachment.getData(YoutubeUtils.PROPERTY_TAGS);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeViewableResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeViewableResource.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import org.joda.time.format.ISODateTimeFormat;
+import java.util.Optional;
 
 @SuppressWarnings("nls")
 public class YoutubeViewableResource extends AbstractWrappedResource {
@@ -189,14 +189,13 @@ public class YoutubeViewableResource extends AbstractWrappedResource {
     }
 
     // Uploaded
-    Long date =
-        ISODateTimeFormat.dateTimeNoMillis()
-            .parseDateTime((String) youTubeAttachment.getData(YoutubeUtils.PROPERTY_DATE))
-            .getMillis();
-    if (date != null) {
-      commonDetails.add(
-          makeDetail(UPLOADED, dateRendererFactory.createDateRenderer(new Date(date))));
-    }
+    Optional<Date> date =
+        YoutubeUtils.parseDateModifiedToDate(
+            (String) youTubeAttachment.getData(YoutubeUtils.PROPERTY_DATE));
+    date.ifPresent(
+        parsedDate ->
+            commonDetails.add(
+                makeDetail(UPLOADED, dateRendererFactory.createDateRenderer(parsedDate))));
 
     // Tags
     String tags = (String) youTubeAttachment.getData(YoutubeUtils.PROPERTY_TAGS);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeViewableResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeViewableResource.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import org.joda.time.format.ISODateTimeFormat;
 
 @SuppressWarnings("nls")
 public class YoutubeViewableResource extends AbstractWrappedResource {
@@ -188,7 +189,10 @@ public class YoutubeViewableResource extends AbstractWrappedResource {
     }
 
     // Uploaded
-    Long date = (Long) youTubeAttachment.getData(YoutubeUtils.PROPERTY_DATE);
+    Long date =
+        ISODateTimeFormat.dateTimeNoMillis()
+            .parseDateTime((String) youTubeAttachment.getData(YoutubeUtils.PROPERTY_DATE))
+            .getMillis();
     if (date != null) {
       commonDetails.add(
           makeDetail(UPLOADED, dateRendererFactory.createDateRenderer(new Date(date))));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change
The YouTube controls were not working properly. This is because once oEQ got to parsing the date modified string that was returned for a YouTube result it was found to be unparsable. It used to work properly but updates to the YouTube API involved changes to the date format. 
This PR addresses the issue by parsing the date properly, in the YoutubeHandler when running Youtube searches and displaying results, in the YoutubeAttachmentSerializer when saving attachments to the database, and YoutubeViewableResource when displaying the resource summary.
![image](https://user-images.githubusercontent.com/24543345/100833335-df045b00-34bd-11eb-97b9-5d1b287ac49b.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
