### PR TITLE
Support Advanced/Remote searches in Selection Session

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/AuxiliarySearchSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/AuxiliarySearchSelector.stories.tsx
@@ -34,5 +34,6 @@ export const standard: Story<AuxiliarySearchSelectorProps> = (
 standard.args = {
   auxiliarySearchesSupplier: () =>
     Promise.resolve(getRemoteSearchesFromServerResult),
-  urlGenerator: (uuid: string) => uuid,
+  urlGeneratorForRouteLink: (uuid: string) => uuid,
+  urlGeneratorForMuiLink: (uuid: string) => uuid,
 };

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/BaseUrlHelper.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/BaseUrlHelper.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as AppConfig from "../../tsrc/AppConfig";
+
+export const defaultBaseUrl = "http://localhost:8080/vanilla/";
+
+const mockGetBaseUrl = jest.spyOn(AppConfig, "getBaseUrl");
+export const updateMockGetBaseUrl = (url: string = defaultBaseUrl) => {
+  mockGetBaseUrl.mockReturnValue(url);
+};

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
@@ -26,6 +26,7 @@ import {
   SelectionSessionPostData,
 } from "../../../tsrc/modules/LegacySelectionSessionModule";
 import { languageStrings } from "../../../tsrc/util/langstrings";
+import { defaultBaseUrl, updateMockGetBaseUrl } from "../BaseUrlHelper";
 import {
   basicRenderData,
   renderDataForSelectOrAdd,
@@ -48,12 +49,15 @@ const attachmentUUIDs = [
 
 describe("buildSelectionSessionItemSummaryLink", () => {
   const { uuid, version } = getSearchResult.results[0];
+  beforeAll(() => {
+    updateMockGetBaseUrl();
+  });
 
   it("builds basic URLs for accessing ItemSummary pages in Selection Session mode", () => {
     updateMockGetRenderData(basicRenderData);
     const link = buildSelectionSessionItemSummaryLink(uuid, version);
     expect(link).toBe(
-      "items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/?_sl.stateId=1&a=coursesearch"
+      `${defaultBaseUrl}items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/?_sl.stateId=1&a=coursesearch`
     );
   });
 
@@ -65,7 +69,7 @@ describe("buildSelectionSessionItemSummaryLink", () => {
 
     const link = buildSelectionSessionItemSummaryLink(uuid, version);
     expect(link).toBe(
-      "items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/?_sl.stateId=1&a=coursesearch&_int.id=2"
+      `${defaultBaseUrl}items/9b9bf5a9-c5af-490b-88fe-7e330679fad2/1/?_sl.stateId=1&_int.id=2&a=coursesearch`
     );
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -57,6 +57,7 @@ import * as SearchSettingsModule from "../../../tsrc/modules/SearchSettingsModul
 import * as UserModule from "../../../tsrc/modules/UserModule";
 import SearchPage, { SearchPageOptions } from "../../../tsrc/search/SearchPage";
 import { languageStrings } from "../../../tsrc/util/langstrings";
+import { updateMockGetBaseUrl } from "../BaseUrlHelper";
 import { queryPaginatorControls } from "../components/SearchPaginationTestHelper";
 import { updateMockGlobalCourseList } from "../CourseListHelper";
 import { selectOption } from "../MuiTestHelpers";
@@ -749,7 +750,10 @@ describe("conversion of parameters to SearchPageOptions", () => {
 });
 
 describe("In Selection Session", () => {
-  updateMockGlobalCourseList();
+  beforeAll(() => {
+    updateMockGlobalCourseList();
+    updateMockGetBaseUrl();
+  });
 
   it("should make each Search result Item draggable", async () => {
     updateMockGetRenderData(basicRenderData);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -34,6 +34,7 @@ import * as MimeTypesModule from "../../../../tsrc/modules/MimeTypesModule";
 import * as LegacySelectionSessionModule from "../../../../tsrc/modules/LegacySelectionSessionModule";
 import SearchResult from "../../../../tsrc/search/components/SearchResult";
 import { languageStrings } from "../../../../tsrc/util/langstrings";
+import { defaultBaseUrl, updateMockGetBaseUrl } from "../../BaseUrlHelper";
 import { updateMockGlobalCourseList } from "../../CourseListHelper";
 import {
   basicRenderData,
@@ -170,6 +171,8 @@ describe("<SearchResult/>", () => {
   );
 
   it("should use different link to open ItemSummary page, depending on renderData", async () => {
+    updateMockGetBaseUrl();
+    updateMockGlobalCourseList();
     const item = mockData.basicSearchObj;
     const checkItemTitleLink = (page: RenderResult, url: string) => {
       expect(page.getByText(item.name!, { selector: "a" })).toHaveAttribute(
@@ -190,12 +193,15 @@ describe("<SearchResult/>", () => {
     page = await renderSearchResult(item);
     checkItemTitleLink(
       page,
-      `${basicURL}?_sl.stateId=1&a=coursesearch&_int.id=2`
+      `${defaultBaseUrl}${basicURL}?_sl.stateId=1&_int.id=2&a=coursesearch`
     );
   });
 
   describe("In Selection Session", () => {
-    updateMockGlobalCourseList();
+    beforeAll(() => {
+      updateMockGlobalCourseList();
+      updateMockGetBaseUrl();
+    });
 
     const mockSelectResourceForCourseList = jest.spyOn(
       LegacySelectionSessionModule,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
@@ -60,5 +60,5 @@ export const getRenderData = (): RenderData | undefined =>
 export const AppConfig: Config = {
   baseUrl: document?.getElementsByTagName("base")[0]?.href ?? "",
 };
-
+export const getBaseUrl = () => AppConfig.baseUrl;
 export const API_BASE_URL = `${AppConfig.baseUrl}api`;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/OeqLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/OeqLink.tsx
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import MUILink from "@material-ui/core/Link";
+import { ReactNode } from "react";
+import * as React from "react";
+import { Link } from "react-router-dom";
+import { isSelectionSessionOpen } from "../modules/LegacySelectionSessionModule";
+
+interface OeqLinkProps {
+  /**
+   * The content of a link
+   */
+  children: ReactNode;
+  /**
+   * A function providing a URL for React Router Link
+   */
+  routeLinkUrlProvider: () => string;
+  /**
+   * A function providing a URL for MUI Link
+   */
+  muiLinkUrlProvider: () => string;
+}
+
+/**
+ * Provide a Link which is either a React Route Link or a MUI Link, depending
+ * on whether Selection Session is open or not.
+ */
+export const OeqLink = ({
+  children,
+  routeLinkUrlProvider,
+  muiLinkUrlProvider,
+}: OeqLinkProps) =>
+  isSelectionSessionOpen() ? (
+    <MUILink href={muiLinkUrlProvider()} underline="none">
+      {children}
+    </MUILink>
+  ) : (
+    <Link to={routeLinkUrlProvider()}>{children}</Link>
+  );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -72,7 +72,7 @@ export const routes = {
     component: SettingsPage,
   },
   AdvancedSearch: {
-    to: (uuid: string) => `/searching.do?in=P${uuid}&editquery=true`,
+    to: (uuid: string) => `/advanced/searching.do?in=P${uuid}&editquery=true`,
   },
   RemoteSearch: {
     // `uc` parameter comes from sections code (AbstractRootSearchSection.Model.java). Setting it to

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -216,6 +216,42 @@ export const buildSelectionSessionItemSummaryLink = (
 };
 
 /**
+ * Build a Selection Session specific Remote search Link. Recommended to first call `isSelectionSessionOpen()`
+ * before use.
+ * @param uuid The UUID of a Remote search
+ */
+export const buildSelectionSessionRemoteSearchLink = (uuid: string): string => {
+  const { stateId, integId } = getSelectionSessionInfo();
+  const remoteSearchLink = AppConfig.baseUrl.concat(
+    `access/z3950.do?.repository=${uuid}&uc=true&_sl.stateId=${stateId}`
+  );
+
+  if (integId) {
+    return remoteSearchLink.concat(`&_int.id=${integId}`);
+  }
+  return remoteSearchLink;
+};
+
+/**
+ * Build a Selection Session specific Advanced search Link. Recommended to first call `isSelectionSessionOpen()`
+ * before use.
+ * @param uuid The UUID of an Advanced search
+ */
+export const buildSelectionSessionAdvancedSearchLink = (
+  uuid: string
+): string => {
+  const { stateId, integId } = getSelectionSessionInfo();
+  const remoteSearchLink = AppConfig.baseUrl.concat(
+    `searching.do?in=P${uuid}&editquery=true&_sl.stateId=${stateId}`
+  );
+
+  if (integId) {
+    return remoteSearchLink.concat(`&_int.id=${integId}`);
+  }
+  return remoteSearchLink;
+};
+
+/**
  * Update the content of DIV "selection-summary". This function is primarily for
  * 'selectOrAdd' mode. In this mode, what is returned from 'searching.do' is an
  * object of 'LegacyContentResponse'.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -16,7 +16,12 @@
  * limitations under the License.
  */
 import Axios from "axios";
-import { getBaseUrl, getRenderData, SelectionSessionInfo } from "../AppConfig";
+import {
+  API_BASE_URL,
+  getBaseUrl,
+  getRenderData,
+  SelectionSessionInfo,
+} from "../AppConfig";
 import { LegacyContentResponse } from "../legacycontent/LegacyContent";
 import { routes } from "../mainui/routes";
 
@@ -174,7 +179,7 @@ const getSelectionSessionInfo = (): SelectionSessionInfo => {
   throw new TypeError("The type of Selection Session Info is incorrect.");
 };
 
-const submitBaseUrl = `${getBaseUrl()}/content/submit`;
+const submitBaseUrl = `${API_BASE_URL}/content/submit`;
 
 const getBasicPostData = () => {
   const { stateId, integId, layout } = getSelectionSessionInfo();

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -253,7 +253,7 @@ export const buildSelectionSessionAdvancedSearchLink = (
 ): string => {
   const { stateId, integId } = getSelectionSessionInfo();
   const remoteSearchLink = AppConfig.baseUrl.concat(
-    `searching.do?in=P${uuid}&editquery=true&_sl.stateId=${stateId}`
+    `advanced/searching.do?in=P${uuid}&editquery=true&_sl.stateId=${stateId}`
   );
 
   if (integId) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -117,14 +117,16 @@ export const getGlobalCourseList = () => CourseList;
  * defined in 'couselist.js'.
  */
 export const getSearchPageItemClass = (): string =>
-  isSelectionSessionOpen() ? getGlobalCourseList().newSearchPageItemClass : "";
+  isSelectionSessionInStructured()
+    ? getGlobalCourseList().newSearchPageItemClass
+    : "";
 
 /**
  * When Selection Session is open, provide access to the CSS class 'newSearchPageAttachmentClass'
  * defined in 'couselist.js'.
  */
 export const getSearchPageAttachmentClass = (): string =>
-  isSelectionSessionOpen()
+  isSelectionSessionInStructured()
     ? getGlobalCourseList().newSearchPageAttachmentClass
     : "";
 
@@ -143,6 +145,15 @@ const isSelectionSessionInfo = (
 export const isSelectionSessionOpen = (): boolean =>
   isSelectionSessionInfo(getRenderData()?.selectionSessionInfo);
 
+/**
+ * Return true if Selection Session is in 'Structured'.
+ */
+export const isSelectionSessionInStructured = (): boolean => {
+  if (isSelectionSessionOpen()) {
+    return getSelectionSessionInfo().layout === "coursesearch";
+  }
+  return false;
+};
 /**
  * Indicates if the Select Summary button is disabled or not.
  * Returns true if the Selection Session info is not available.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -252,14 +252,14 @@ export const buildSelectionSessionAdvancedSearchLink = (
   uuid: string
 ): string => {
   const { stateId, integId } = getSelectionSessionInfo();
-  const remoteSearchLink = AppConfig.baseUrl.concat(
+  const advancedSearchLink = AppConfig.baseUrl.concat(
     `advanced/searching.do?in=P${uuid}&editquery=true&_sl.stateId=${stateId}`
   );
 
   if (integId) {
-    return remoteSearchLink.concat(`&_int.id=${integId}`);
+    return advancedSearchLink.concat(`&_int.id=${integId}`);
   }
-  return remoteSearchLink;
+  return advancedSearchLink;
 };
 
 /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -58,6 +58,8 @@ import {
 import {
   isSelectionSessionOpen,
   prepareDraggable,
+  buildSelectionSessionAdvancedSearchLink,
+  buildSelectionSessionRemoteSearchLink,
 } from "../modules/LegacySelectionSessionModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
@@ -405,7 +407,8 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       component: (
         <AuxiliarySearchSelector
           auxiliarySearchesSupplier={getAdvancedSearchesFromServer}
-          urlGenerator={routes.AdvancedSearch.to}
+          urlGeneratorForRouteLink={routes.AdvancedSearch.to}
+          urlGeneratorForMuiLink={buildSelectionSessionAdvancedSearchLink}
         />
       ),
       disabled: false,
@@ -417,7 +420,8 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
       component: (
         <AuxiliarySearchSelector
           auxiliarySearchesSupplier={getRemoteSearchesFromServer}
-          urlGenerator={routes.RemoteSearch.to}
+          urlGeneratorForRouteLink={routes.RemoteSearch.to}
+          urlGeneratorForMuiLink={buildSelectionSessionRemoteSearchLink}
         />
       ),
       disabled: false,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -60,6 +60,7 @@ import {
   prepareDraggable,
   buildSelectionSessionAdvancedSearchLink,
   buildSelectionSessionRemoteSearchLink,
+  isSelectionSessionInStructured,
 } from "../modules/LegacySelectionSessionModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
@@ -140,7 +141,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const [classifications, setClassifications] = useState<Classification[]>([]);
 
   const location = useLocation();
-  const inSelectionSession: boolean = isSelectionSessionOpen();
 
   /**
    * Update the page title and retrieve Search settings.
@@ -155,7 +155,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     Promise.all([
       getSearchSettingsFromServer(),
       // Do not convert query string params to search options in Selection Session.
-      inSelectionSession
+      isSelectionSessionOpen()
         ? Promise.resolve(undefined)
         : queryStringParamsToSearchOptions(location),
     ]).then((results) => {
@@ -198,7 +198,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   // In Selection Session, once a new search result is returned, make each
   // new search result Item draggable.
   useEffect(() => {
-    if (inSelectionSession) {
+    if (isSelectionSessionInStructured()) {
       pagedSearchResult.results.forEach(({ uuid }) => {
         prepareDraggable(uuid);
       });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/AuxiliarySearchSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/AuxiliarySearchSelector.tsx
@@ -21,7 +21,7 @@ import LinkIcon from "@material-ui/icons/Link";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { OeqLink } from "../../components/OeqLink";
 
 const useStyles = makeStyles((theme: Theme) => ({
   linkIcon: {
@@ -36,38 +36,52 @@ export interface AuxiliarySearchSelectorProps {
   auxiliarySearchesSupplier: () => Promise<OEQ.Common.BaseEntitySummary[]>;
 
   /**
-   * Function to produce the URL for a specific search using the UUID returned in the
+   * Function to produce the URL for React Route Link using the UUID returned in the
    * `OEQ.Common.BaseEntitySummary` from the `auxiliarySearchesSupplier` function.
    */
-  urlGenerator: (uuid: string) => string;
+  urlGeneratorForRouteLink: (uuid: string) => string;
+  /**
+   * Function to produce the URL for MUI Link using the UUID returned in the
+   * `OEQ.Common.BaseEntitySummary` from the `auxiliarySearchesSupplier` function.
+   * Typically, the MUI Link is used in Selection Session.
+   */
+  urlGeneratorForMuiLink: (uuid: string) => string;
 }
 /**
- * A search 'selector' control to provide a list of remote searches. Clicking on a remote
- * searches (currently) navigates you to the legacy UI remote search page for that remote
- * search.
+ * A search 'selector' control to provide a list of auxiliary searches (e.g. Remote search and advanced search).
+ * Clicking on an auxiliary search (currently) navigates you to the legacy UI page.
  */
 export const AuxiliarySearchSelector = ({
   auxiliarySearchesSupplier,
-  urlGenerator,
+  urlGeneratorForRouteLink,
+  urlGeneratorForMuiLink,
 }: AuxiliarySearchSelectorProps) => {
   const classes = useStyles();
-
-  const [remoteSearches, setRemoteSearches] = useState<
+  const [auxiliarySearches, setAuxiliarySearches] = useState<
     OEQ.Common.BaseEntitySummary[]
   >([]);
 
   useEffect(() => {
-    auxiliarySearchesSupplier().then((searches) => setRemoteSearches(searches));
+    auxiliarySearchesSupplier().then((searches) =>
+      setAuxiliarySearches(searches)
+    );
   }, [auxiliarySearchesSupplier]);
 
+  const getLinkContent = (summary: OEQ.Common.BaseEntitySummary) => (
+    <MenuItem value={summary.uuid}>
+      <LinkIcon className={classes.linkIcon} />
+      {summary.name}
+    </MenuItem>
+  );
+
   const buildSearchMenuItems = () =>
-    remoteSearches.map((summary) => (
-      <Link to={urlGenerator(summary.uuid)}>
-        <MenuItem value={summary.uuid}>
-          <LinkIcon className={classes.linkIcon} />
-          {summary.name}
-        </MenuItem>
-      </Link>
+    auxiliarySearches.map((summary) => (
+      <OeqLink
+        routeLinkUrlProvider={() => urlGeneratorForRouteLink(summary.uuid)}
+        muiLinkUrlProvider={() => urlGeneratorForMuiLink(summary.uuid)}
+      >
+        {getLinkContent(summary)}
+      </OeqLink>
     ));
 
   return (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -59,6 +59,7 @@ import {
   prepareDraggable,
   getSearchPageItemClass,
   getSearchPageAttachmentClass,
+  isSelectionSessionInStructured,
 } from "../../modules/LegacySelectionSessionModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
@@ -159,6 +160,7 @@ export default function SearchResult({
   const itemKey = `${uuid}/${version}`;
   const classes = useStyles();
   const inSelectionSession: boolean = isSelectionSessionOpen();
+  const inStructured = isSelectionSessionInStructured();
 
   const [attachExpanded, setAttachExpanded] = useState(
     (inSelectionSession
@@ -224,7 +226,7 @@ export default function SearchResult({
 
   // In Selection Session, make each attachment draggable.
   useEffect(() => {
-    if (inSelectionSession) {
+    if (inStructured) {
       attachmentsWithViewerDetails.forEach(({ attachment }) => {
         prepareDraggable(attachment.id, false);
       });
@@ -352,7 +354,7 @@ export default function SearchResult({
             data-attachmentuuid={id}
           >
             <ListItemIcon>
-              {inSelectionSession ? <DragIndicatorIcon /> : <InsertDriveFile />}
+              {inStructured ? <DragIndicatorIcon /> : <InsertDriveFile />}
             </ListItemIcon>
             <ItemAttachmentLink
               description={description}
@@ -478,11 +480,13 @@ export default function SearchResult({
         data-itemuuid={uuid}
         data-itemversion={version}
       >
-        <Grid item>
-          <IconButton>
-            <DragIndicatorIcon />
-          </IconButton>
-        </Grid>
+        {inStructured && (
+          <Grid item>
+            <IconButton>
+              <DragIndicatorIcon />
+            </IconButton>
+          </Grid>
+        )}
         <Grid item>{itemLink()}</Grid>
         <Grid item>
           <ResourceSelector

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -31,7 +31,6 @@ import {
   Theme,
   Typography,
 } from "@material-ui/core";
-import MUILink from "@material-ui/core/Link";
 import { makeStyles } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
 import AttachFile from "@material-ui/icons/AttachFile";
@@ -43,11 +42,11 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { SyntheticEvent, useEffect, useState } from "react";
 import ReactHtmlParser from "react-html-parser";
-import { Link } from "react-router-dom";
 import { HashLink } from "react-router-hash-link";
 import { sprintf } from "sprintf-js";
 import { Date as DateDisplay } from "../../components/Date";
 import ItemAttachmentLink from "../../components/ItemAttachmentLink";
+import { OeqLink } from "../../components/OeqLink";
 import OEQThumb from "../../components/OEQThumb";
 import { StarRating } from "../../components/StarRating";
 import { routes } from "../../mainui/routes";
@@ -457,18 +456,15 @@ export default function SearchResult({
 
   const itemLink = () => {
     const itemTitle = name ? highlightField(name) : uuid;
-    const basicLink = (
-      <Link to={routes.ViewItem.to(uuid, version)}>{itemTitle}</Link>
-    );
-    return inSelectionSession ? (
-      <MUILink
-        href={buildSelectionSessionItemSummaryLink(uuid, version)}
-        underline="none"
+    return (
+      <OeqLink
+        routeLinkUrlProvider={() => routes.ViewItem.to(uuid, version)}
+        muiLinkUrlProvider={() =>
+          buildSelectionSessionItemSummaryLink(uuid, version)
+        }
       >
         {itemTitle}
-      </MUILink>
-    ) : (
-      basicLink
+      </OeqLink>
     );
   };
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -470,37 +470,42 @@ export default function SearchResult({
     );
   };
 
-  const itemPrimaryContent =
-    inSelectionSession && !isSelectSummaryButtonDisabled() ? (
-      <Grid
-        id={uuid}
-        container
-        alignItems="center"
-        className={getSearchPageItemClass()} // Give a class so each item can be dropped to the course list.
-        data-itemuuid={uuid}
-        data-itemversion={version}
-      >
-        {inStructured && (
-          <Grid item>
-            <IconButton>
-              <DragIndicatorIcon />
-            </IconButton>
-          </Grid>
-        )}
-        <Grid item>{itemLink()}</Grid>
+  // In Selection Session, if the Select Summary button is enabled, add 'ResourceSelector'
+  // to the content. On top of that, if Selection Session is in 'structured', add one
+  // 'Drag indicator' icon.
+  const selectSessionItemContent = (
+    <Grid
+      id={uuid}
+      container
+      alignItems="center"
+      className={getSearchPageItemClass()} // Give a class so each item can be dropped to the course list.
+      data-itemuuid={uuid}
+      data-itemversion={version}
+    >
+      {inStructured && (
         <Grid item>
-          <ResourceSelector
-            labelText={selectResourceStrings.summaryPage}
-            isStopPropagation
-            onClick={() => {
-              handleSelectResource(itemKey);
-            }}
-          />
+          <IconButton>
+            <DragIndicatorIcon />
+          </IconButton>
         </Grid>
+      )}
+      <Grid item>{itemLink()}</Grid>
+      <Grid item>
+        <ResourceSelector
+          labelText={selectResourceStrings.summaryPage}
+          isStopPropagation
+          onClick={() => {
+            handleSelectResource(itemKey);
+          }}
+        />
       </Grid>
-    ) : (
-      itemLink()
-    );
+    </Grid>
+  );
+
+  const itemPrimaryContent =
+    inSelectionSession && !isSelectSummaryButtonDisabled()
+      ? selectSessionItemContent
+      : itemLink();
 
   return (
     <ListItem alignItems="flex-start" divider>

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -201,6 +201,7 @@
     <parameter id="class" value="com.tle.web.searching.guice.SearchTrackerModule" />
     <parameter id="class" value="com.tle.web.searching.guice.SkinnySearchModule" />
     <parameter id="class" value="com.tle.web.searching.guice.StandardSearchModule" />
+    <parameter id="class" value="com.tle.web.searching.guice.AdvancedSearchModule" />
     <parameter id="class" value="com.tle.web.sections.equella.guice.SectionsEquellaModule" />
     <parameter id="class" value="com.tle.web.sections.equella.guice.SimpleEquellaModule" />
     <parameter id="class" value="com.tle.web.selection.guice.SelectionModule" />
@@ -2405,6 +2406,10 @@
   <extension plugin-id="com.tle.web.sections" point-id="sectionTree" id="selectoradd-searching">
     <parameter id="path" value="/selectoradd/searching.do" />
     <parameter id="root" value="bean:/selectoradd/search" />
+  </extension>
+  <extension plugin-id="com.tle.web.sections" point-id="sectionTree" id="advanced-searching">
+    <parameter id="path" value="/advanced/searching.do" />
+    <parameter id="root" value="bean:/advanced/search" />
   </extension>
   <extension plugin-id="com.tle.web.sections" point-id="sectionTree" id="skinny-searching">
     <parameter id="path" value="/access/skinny/searching.do" />

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/guice/AdvancedSearchModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/guice/AdvancedSearchModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.searching.guice;
+
+import com.tle.web.searching.section.RootAdvancedSearchSection;
+
+public class AdvancedSearchModule extends StandardSearchModule {
+  @Override
+  public NodeProvider getRootNode() {
+    return node(RootAdvancedSearchSection.class);
+  }
+
+  @Override
+  protected String getTreeName() {
+    return "/advanced/search";
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootAdvancedSearchSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootAdvancedSearchSection.java
@@ -73,6 +73,8 @@ public class RootAdvancedSearchSection extends RootSearchSection {
 
   @Override
   public boolean useNewSearch() {
+    // Because we haven't built any new UI for Advanced search, return false
+    // to keep using old UI.
     return false;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootAdvancedSearchSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootAdvancedSearchSection.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.searching.section;
+
+import com.tle.web.sections.SectionResult;
+import com.tle.web.sections.SectionTree;
+import com.tle.web.sections.events.RenderEventContext;
+import com.tle.web.sections.events.RenderEventListener;
+import com.tle.web.sections.render.HtmlRendererListener;
+import com.tle.web.selection.SelectionSession;
+import com.tle.web.selection.section.RootSelectionSection.Layout;
+import com.tle.web.selection.section.SelectionSummarySection;
+
+public class RootAdvancedSearchSection extends RootSearchSection {
+
+  @Override
+  public SectionResult renderHtml(RenderEventContext context) {
+    SelectionSession selectionSession = selectionService.getCurrentSession(context);
+    if (selectionSession != null) {
+      // As we keep SelectionSummarySection in the tree for 'advanced/searching.do' regardless of
+      // Selection Session's layout, we need to dynamically handle whether to show it or not.
+      // The approach is to remove or add the RenderEventListener for SelectionSummarySection.
+      SelectionSummarySection selectionSummarySection =
+          context.lookupSection(SelectionSummarySection.class);
+      String selectionSummarySectionId = selectionSummarySection.getSectionId();
+      Layout selectionSessionLayout = selectionSession.getLayout();
+      boolean selectionSummaryListenerExisting =
+          context
+                  .getTree()
+                  .getListeners(selectionSummarySectionId, RenderEventListener.class)
+                  .size()
+              > 0;
+
+      // Remove the listener in 'structured'.
+      if (selectionSessionLayout == Layout.COURSE && selectionSummaryListenerExisting) {
+        context.getTree().removeListeners(selectionSummarySectionId);
+      }
+      // Or add the listener back in 'selectOrAdd'.
+      else if (selectionSessionLayout == Layout.NORMAL && !selectionSummaryListenerExisting) {
+        context
+            .getTree()
+            .addListener(
+                selectionSummarySectionId,
+                RenderEventListener.class,
+                new HtmlRendererListener(
+                    selectionSummarySectionId, selectionSummarySection, getTree()));
+      }
+    }
+
+    return super.renderHtml(context);
+  }
+
+  @Override
+  public void registered(String id, SectionTree tree) {
+    super.registered(id, tree);
+  }
+
+  @Override
+  public boolean useNewSearch() {
+    return false;
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootSearchSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootSearchSection.java
@@ -70,8 +70,10 @@ public class RootSearchSection extends ContextableSearchSection<ContextableSearc
     return SEARCH_SESSIONKEY;
   }
 
-  // For child sections that need to skip new Search UI, override this function and return false.
-  public boolean useNewSearch() {
+  /**
+   * For child sections that need to skip new Search UI, override this function and return false.
+   */
+  protected boolean useNewSearch() {
     return true;
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootSearchSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootSearchSection.java
@@ -70,6 +70,11 @@ public class RootSearchSection extends ContextableSearchSection<ContextableSearc
     return SEARCH_SESSIONKEY;
   }
 
+  // For child sections that need to skip new Search UI, override this function and return false.
+  public boolean useNewSearch() {
+    return true;
+  }
+
   @Override
   public SectionResult renderHtml(RenderEventContext context) {
     if (aclManager.filterNonGrantedPrivileges(WebConstants.SEARCH_PAGE_PRIVILEGE).isEmpty()) {
@@ -87,7 +92,7 @@ public class RootSearchSection extends ContextableSearchSection<ContextableSearc
     // If this method is triggered from Selection Section, then check if Selection Section
     // is in 'structured' mode. If yes, then render the new search page if it's enabled.
     SelectionSession selectionSession = selectionService.getCurrentSession(context);
-    if (isNewSearchUIInSelectionSession(selectionSession)) {
+    if (isNewSearchUIInSelectionSession(selectionSession) && useNewSearch()) {
       getModel(context).setNewSearchUIContent(RenderNewSearchPage.renderNewSearchPage(context));
     }
     return super.renderHtml(context);


### PR DESCRIPTION
#688 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR addresses the issue that Remote search page and Advanced search page didn't display properly in Selection Session if they are open from new search UI.

There are three changes: 

1. Create a new TS component named 'OeqLink'. The reason is we have a few places where we need to switch between `React Route Link` and `MUI Link`, depending on whether the page is in Selection Session. 

2. For Advanced search requests coming from new search UI in Selection Session, create a new Legacy endpoint which is `advanced/searching.do`. To support this endpoint, also create a Section module and a Section. 

3. Make sure functions related to `Drag and Drop` are only called when Selection Session is in structured.
