### PR TITLE
Don't display the Leave or Cancel dialog when saving a new item

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -118,8 +118,13 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
     // This regex matches the relative url of Item Summary page
     // For example 'items/95075bdd-4049-46ab-a1aa-043902e239a3/3/'
     // The last forward slash does not exist in some cases
+
+    // This regex also works for those that have query params.
+    // For example, in Selection Session, the URL would be
+    // 'items/95075bdd-4049-46ab-a1aa-043902e239a3/3/?_sl.stateId=1&_int.id=2'.
+
     val itemSummaryUrlPattern =
-      "items\\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\\/\\d+\\/?".r
+      "items\\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\\/\\d+\\/?\\??.+".r
 
     // This regex explicitly matches the relative Url of logon
     // For example, 'logon.do' or 'logon.do?.page=home.do'


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The previous fix made in #1330 does not work in Selection Session because the ItemSummary page URL has some query params (e.g. `stateId=2`). 

So in this PR, I slightly modified the ItemSummary URL Regex to make sure it also works for above situation.

A video is available [here](https://streamable.com/rdrck4).