### PR TITLE
Address eslint warnings (not exhaustive/deps)

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/Date.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/Date.stories.tsx
@@ -15,14 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Meta } from "@storybook/react";
 import * as React from "react";
 import { boolean, date } from "@storybook/addon-knobs";
-import { Date as DateDisplay } from "../../tsrc/components/Date";
+import { Date as DateDisplay, DateProps } from "../../tsrc/components/Date";
 
 export default {
   title: "DateDisplay",
   component: DateDisplay,
-};
+} as Meta<DateProps>;
 
 function dateKnob(name: string) {
   const timestamp = date(name);

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/DateRangeSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/DateRangeSelector.stories.tsx
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Meta } from "@storybook/react";
 import * as React from "react";
 import {
   DateRangeSelector,
@@ -28,7 +29,7 @@ import LuxonUtils from "@date-io/luxon";
 export default {
   title: "DateRangeSelector",
   component: DateRangeSelector,
-};
+} as Meta<DateRangeSelectorProps>;
 
 const actions: DateRangeSelectorProps = {
   onDateRangeChange: action("onDateRangeChange called"),

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/SearchBar.stories.tsx
@@ -15,14 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Meta } from "@storybook/react";
 import * as React from "react";
-import SearchBar from "../../tsrc/search/components/SearchBar";
 import { action } from "@storybook/addon-actions";
+import SearchBar, {
+  SearchBarProps,
+} from "../../tsrc/search/components/SearchBar";
 
 export default {
   title: "SearchBar",
   component: SearchBar,
-};
+} as Meta<SearchBarProps>;
 
 const actions = {
   onQueryChange: action("onQueryChange called"),

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/UserSearch.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/UserSearch.stories.tsx
@@ -15,8 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Meta } from "@storybook/react";
 import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
-import UserSearch from "../../tsrc/components/UserSearch";
+import UserSearch, { UserSearchProps } from "../../tsrc/components/UserSearch";
 import { action } from "@storybook/addon-actions";
 import * as React from "react";
 import { number } from "@storybook/addon-knobs";
@@ -24,7 +25,7 @@ import { number } from "@storybook/addon-knobs";
 export default {
   title: "UserSearch",
   component: UserSearch,
-};
+} as Meta<UserSearchProps>;
 
 export const DefaultState = () => (
   <UserSearch

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/OwnerSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/OwnerSelector.stories.tsx
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Meta } from "@storybook/react";
 import * as React from "react";
-import OwnerSelector from "../../tsrc/search/components/OwnerSelector";
+import OwnerSelector, {
+  OwnerSelectorProps,
+} from "../../tsrc/search/components/OwnerSelector";
 import { action } from "@storybook/addon-actions";
 import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
 
 export default {
   title: "Search/OwnerSelector",
   component: OwnerSelector,
-};
+} as Meta<OwnerSelectorProps>;
 
 const commonParams = {
   onClearSelect: action("onClearSelect"),

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchAttachmentsSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchAttachmentsSelector.stories.tsx
@@ -15,14 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Meta } from "@storybook/react";
 import * as React from "react";
 import { action } from "@storybook/addon-actions";
-import { SearchAttachmentsSelector } from "../../tsrc/search/components/SearchAttachmentsSelector";
+import {
+  SearchAttachmentsSelector,
+  SearchAttachmentsSelectorProps,
+} from "../../tsrc/search/components/SearchAttachmentsSelector";
 
 export default {
   title: "Search/SearchAttachmentsSelector",
   component: SearchAttachmentsSelector,
-};
+} as Meta<SearchAttachmentsSelectorProps>;
 
 const commonParams = {
   onChange: action("onChange"),

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/SearchResult.stories.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Story } from "@storybook/react";
+import type { Meta, Story } from "@storybook/react";
 import * as React from "react";
 import * as mockData from "../../__mocks__/searchresult_mock_data";
 import SearchResult, {
@@ -25,7 +25,7 @@ import SearchResult, {
 export default {
   title: "Search/SearchResult",
   component: SearchResult,
-};
+} as Meta<SearchResultProps>;
 
 export const BasicSearchResult: Story<SearchResultProps> = (args) => (
   <SearchResult {...args} />

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/StatusSelector.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/StatusSelector.stories.tsx
@@ -16,14 +16,17 @@
  * limitations under the License.
  */
 import { action } from "@storybook/addon-actions";
+import { Meta } from "@storybook/react";
 import * as React from "react";
 import { liveStatuses, nonLiveStatuses } from "../../tsrc/modules/SearchModule";
-import StatusSelector from "../../tsrc/search/components/StatusSelector";
+import StatusSelector, {
+  StatusSelectorProps,
+} from "../../tsrc/search/components/StatusSelector";
 
 export default {
   title: "Search/StatusSelector",
   component: StatusSelector,
-};
+} as Meta<StatusSelectorProps>;
 
 const commonParams = {
   onChange: action("onChange"),

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/UserSearch.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/UserSearch.tsx
@@ -35,7 +35,7 @@ import * as UserModule from "../modules/UserModule";
 import { languageStrings } from "../util/langstrings";
 import { sprintf } from "sprintf-js";
 
-interface UserSearchProps {
+export interface UserSearchProps {
   /** An optional `id` attribute for the component. Will also be used to prefix core child elements. */
   id?: string;
   /** How high (in pixels) the list of users should be. */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -26,7 +26,7 @@ export type EntryPage = "mainDiv" | "searchPage" | "settingsPage";
 // before loading of the full app.
 const App = React.lazy(() => import("./App"));
 
-export default function (entry: EntryPage) {
+export default function main(entry: EntryPage) {
   initStrings();
   ReactDOM.render(
     <React.Suspense fallback={<>loading</>}>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DateRange } from "@material-ui/icons";
+
 import * as OEQ from "@openequella/rest-api-client";
 import { Location } from "history";
 import { pick } from "lodash";
@@ -408,14 +408,14 @@ export const legacyQueryStringToSearchOptions = async (
   const datePrimary = getQueryParam("dp");
   const dateSecondary = getQueryParam("ds");
 
-  const RangeType = Union(
+  const RangeTypeLiterals = Union(
     Literal("between"),
     Literal("after"),
     Literal("before"),
     Literal("on")
   );
 
-  type RangeType = Static<typeof RangeType>;
+  type RangeType = Static<typeof RangeTypeLiterals>;
 
   const getLastModifiedDateRange = (
     rangeType: RangeType,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/OwnerSelector.tsx
@@ -37,7 +37,7 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import UserSearch from "../../components/UserSearch";
 import { languageStrings } from "../../util/langstrings";
 
-interface OwnerSelectorProps {
+export interface OwnerSelectorProps {
   /** The currently selected user or undefined if none. */
   value?: OEQ.UserQuery.UserDetails;
   /** Handler for when current selection is cleared. */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchAttachmentsSelector.tsx
@@ -19,7 +19,7 @@ import { Button, ButtonGroup } from "@material-ui/core";
 import * as React from "react";
 import { languageStrings } from "../../util/langstrings";
 
-interface SearchAttachmentsSelectorProps {
+export interface SearchAttachmentsSelectorProps {
   /**
    * A boolean value indicating whether 'yes' or 'no' is selected.
    */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles({
   },
 });
 
-interface SearchBarProps {
+export interface SearchBarProps {
   /** Current value for the search field. */
   query: string;
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/StatusSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/StatusSelector.tsx
@@ -22,7 +22,7 @@ import * as React from "react";
 import { liveStatuses, nonLiveStatuses } from "../../modules/SearchModule";
 import { languageStrings } from "../../util/langstrings";
 
-interface StatusSelectorProps {
+export interface StatusSelectorProps {
   /**
    * A list of the currently selected statuses. This list is then used to determine one of two
    * possible sets: live OR all. The main reason to not simply abstract this out to a boolean, is


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
This PR aims to address all remaining eslint warnings except those that fall under `react-hooks/exhaustive-deps`. Since those will take a lot more investigation to fix without breaking functionality, they will be done separately.

- Add typing of `Meta<propsOfStorySubject>` to all storybook default exports. Added export to interfaces where necessary.
- Add name to the default export function in index.tsx
- Removed false import of DateRange Material UI icon from SearchModule.ts
- Renamed RangeType so it doesn't get reassigned
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
