### PR TITLE
EBP: Make sure Youtube dialog doesn't stretch offscreen

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -540,6 +540,11 @@ select[multiple="multiple"] {
   width: 200px;
 }
 
+#youtube-query ~ .modal-search-results {
+  max-height: 300px;
+  overflow-y: scroll;
+}
+
 .modal-search-result li {
   position: relative;
   margin: 0 0 10px 0;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -63,6 +63,7 @@ $col2Width: 250px;
 $standardBorderRadius: 4px;
 $roundButtonRadius: 50px;
 $termSelectorHeight: 68px;
+$youtubeSearchOffset: -275px;
 
 @mixin boxShadow {
   box-shadow: $boxShadow;
@@ -540,9 +541,16 @@ select[multiple="multiple"] {
   width: 200px;
 }
 
-#youtube-query ~ .modal-search-results {
-  max-height: 300px;
-  overflow-y: scroll;
+.youTubeHandler {
+  @include buttonShadowBorder;
+  //make room for more search results with a negative margin
+  margin-top: $youtubeSearchOffset;
+  .modal_close {
+    margin-top: $youtubeSearchOffset;
+  }
+  .modal-content-inner {
+    max-height: 75vh;
+  }
 }
 
 .modal-search-result li {
@@ -3314,7 +3322,7 @@ button + .repeater-groups {
 
   input[type="text"],
   #youtube-query select {
-    width: 528px;
+    width: 515px;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
Bit of a quick win that fell out of work involved with #2577. I won't be adding additional EBP changes to this PR as this is not scheduled work.
When the YouTube search happens, all of the results get put into the dialog list. Without a max-height, this causes the dialog to stretch down which looks strange. 
- Added a max-height for the YouTube Dialog
- Set overflow-y to scroll
- Added standard box shadow and border radius to dialog
- Move dialog upwards to make room for more results

Before change: 
![Peek 2020-12-08 16-35](https://user-images.githubusercontent.com/24543345/101444348-69900300-3973-11eb-92df-e64a91161c5d.gif)
After change: 
![Peek 2020-12-15 10-15](https://user-images.githubusercontent.com/24543345/102147269-99cd2980-3ebe-11eb-9b68-e6b56371414c.gif)




<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
