### PR TITLE
Fix Bb LTI / REST caching and request all course folders

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/connectors/ConnectorFolder.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/connectors/ConnectorFolder.java
@@ -113,4 +113,23 @@ public class ConnectorFolder implements Serializable {
   public void setAvailable(boolean available) {
     this.available = available;
   }
+
+  public String toString() {
+    final String folderCount = (folders == null) ? "N/A" : "" + folders.size();
+    final String contentCount = (content == null) ? "N/A" : "" + content.size();
+    final String courseId = (course == null) ? "N/A" : course.getId();
+    return "ConnectorFolder(id="
+        + id
+        + ", course="
+        + courseId
+        + ", name="
+        + name
+        + ", leaf="
+        + leaf
+        + ", folders="
+        + folderCount
+        + ", content="
+        + contentCount
+        + ")";
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/BlackboardRESTConnectorConstants.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/BlackboardRESTConnectorConstants.java
@@ -36,6 +36,8 @@ public final class BlackboardRESTConnectorConstants {
 
   public static final String AUTH_URL = "blackboardrestauth";
 
+  public static final String USER_SESSION_AUTH_KEY = "USER_AUTH";
+
   private BlackboardRESTConnectorConstants() {
     throw new Error();
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/BlackboardRestAppContext.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/BlackboardRestAppContext.java
@@ -29,7 +29,8 @@ public class BlackboardRestAppContext {
   private static final String KEY_VALUE_RESPONSE_TYPE_CODE = "response_type=code";
   private static final String FIELD_CLIENT_ID = "client_id";
   private static final String FIELD_SCOPE = "scope";
-  private static final String VALUE_READ_WRITE_DELETE = "read write delete";
+  // Scope `offline` is required to obtain refresh tokens
+  private static final String VALUE_READ_WRITE_DELETE = "read write delete offline";
 
   private final String _appId;
   private final String _appKey;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Availability.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Availability.java
@@ -57,4 +57,8 @@ public class Availability implements Serializable {
       this.type = type;
     }
   }
+
+  public String toString() {
+    return "available=" + available;
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Course.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Course.java
@@ -193,4 +193,31 @@ public class Course implements Serializable {
       this.force = force;
     }
   }
+
+  public String toString() {
+
+    return "Course(id="
+        + id
+        + ", externalId="
+        + externalId
+        + ", dataSourceId="
+        + dataSourceId
+        + ", courseId="
+        + courseId
+        + ", name="
+        + name
+        + ", created="
+        + created
+        + ", organization="
+        + organization
+        + ", ultraStatus="
+        + ultraStatus
+        + ", allowGuests="
+        + allowGuests
+        + ", readOnly="
+        + readOnly
+        + ", "
+        + availability
+        + ")";
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Token.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Token.java
@@ -19,10 +19,11 @@
 package com.tle.core.connectors.blackboard.beans;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
-public class Token {
+public class Token implements Serializable {
   @JsonProperty("access_token")
   private String accessToken;
 
@@ -37,6 +38,9 @@ public class Token {
 
   @JsonProperty("user_id")
   private String userId;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
 
   public String getAccessToken() {
     return accessToken;
@@ -76,5 +80,28 @@ public class Token {
 
   public void setUserId(String userId) {
     this.userId = userId;
+  }
+
+  public String getRefreshToken() {
+    return refreshToken;
+  }
+
+  public void setRefreshToken(String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
+
+  public String toString() {
+    return "accessToken="
+        + accessToken
+        + ", tokenType="
+        + tokenType
+        + ", expiresIn="
+        + expiresIn
+        + ", scope="
+        + scope
+        + ", userId="
+        + userId
+        + ", refreshToken="
+        + refreshToken;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/BlackboardRESTConnectorService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/BlackboardRESTConnectorService.java
@@ -24,8 +24,6 @@ import com.tle.core.connectors.blackboard.beans.Token;
 import com.tle.core.connectors.service.ConnectorRepositoryImplementation;
 
 public interface BlackboardRESTConnectorService extends ConnectorRepositoryImplementation {
-  // TODO may need more method sigs
-
   /**
    * Admin setup function
    *
@@ -47,14 +45,20 @@ public interface BlackboardRESTConnectorService extends ConnectorRepositoryImple
    * The connector object will need to store an encrypted admin token in the DB. Use this method to
    * encrypt the one returned from Blackboard.
    *
-   * @param data
-   * @return
+   * @param data content to encrypt
+   * @return encrypted content
    */
   String encrypt(String data);
 
   String decrypt(String encryptedData);
 
-  String encryptKeyAndSecret(Connector connector);
+  /**
+   * Creates a Base 64 encoded string of the connector's key and secret.
+   *
+   * @param connector used to launch this REST flow
+   * @return encoded string of connector key and secret
+   */
+  String buildBasicAuthorizationCredentials(Connector connector);
 
   void setAuth(Connector connector, Token token);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/BlackboardRESTConnectorService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/BlackboardRESTConnectorService.java
@@ -20,6 +20,7 @@ package com.tle.core.connectors.blackboard.service;
 
 import com.tle.annotation.Nullable;
 import com.tle.common.connectors.entity.Connector;
+import com.tle.core.connectors.blackboard.beans.Token;
 import com.tle.core.connectors.service.ConnectorRepositoryImplementation;
 
 public interface BlackboardRESTConnectorService extends ConnectorRepositoryImplementation {
@@ -46,16 +47,16 @@ public interface BlackboardRESTConnectorService extends ConnectorRepositoryImple
    * The connector object will need to store an encrypted admin token in the DB. Use this method to
    * encrypt the one returned from Blackboard.
    *
-   * @param token
+   * @param data
    * @return
    */
   String encrypt(String data);
 
   String decrypt(String encryptedData);
 
-  void setToken(Connector connector, String value);
+  String encryptKeyAndSecret(Connector connector);
 
-  void setUserId(Connector connector, String value);
+  void setAuth(Connector connector, Token token);
 
   void removeCachedCoursesForConnector(Connector connector);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -636,7 +636,7 @@ public class BlackboardRESTConnectorServiceImpl extends AbstractIntegrationConne
       LOGGER.error(exception.getMessage());
       // Likely an expired auth token that failed to refresh.  Guide the user to try again
       removeCachedValue(authCache, buildCacheKey(CACHE_ID_AUTH, connector));
-      new AuthenticationException("Unable to refresh auth token.  Please retry action.");
+      throw new AuthenticationException("Unable to refresh auth token.  Please retry action.");
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -855,10 +855,20 @@ public class BlackboardRESTConnectorServiceImpl extends AbstractIntegrationConne
       return Optional.absent();
     }
 
-    return convert(
-        folders.get().stream()
-            .filter(folder -> ConnectorEntityUtils.findFolder(folder, folderId).isPresent())
-            .findFirst());
+    for (ConnectorFolder topLevelFolder : folders.get()) {
+      // Interesting bit here - we are looping through the top level folders looking
+      //  for a folder - the `foundFolder` _may_ be the `folder`, or it _may_ be a
+      //  descendant of the `folder`.
+      // Due to findFolder possibly returning a descendant of `folder`, it's not
+      //  suited well for the `streams` api.
+      Optional<ConnectorFolder> possibleFoundFolder =
+          ConnectorEntityUtils.findFolder(topLevelFolder, folderId);
+      if (possibleFoundFolder.isPresent()) {
+        return possibleFoundFolder;
+      }
+    }
+
+    return Optional.absent();
   }
 
   private Optional<Course> getCachedCourse(Connector connector, String courseId) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -611,13 +611,8 @@ public class BlackboardRESTConnectorServiceImpl extends AbstractIntegrationConne
   }
 
   private void refreshBlackboardToken(Connector connector) {
-    Token expAuth = getUserSessionAuth();
-
-    // Make a reasonable effort to obtain the latest refresh token
-    Optional<Token> cachedAuth = getAuth(connector);
-    if (cachedAuth.isPresent()) {
-      expAuth = cachedAuth.get();
-    }
+    Token expAuth = getAuth(connector)
+      .orElse(() -> getUserSessionAuth());
 
     final String path =
         "learn/api/public/v1/oauth2/token?grant_type=refresh_token&refresh_token="

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -597,13 +597,9 @@ public class BlackboardRESTConnectorServiceImpl extends AbstractIntegrationConne
   }
 
   private Token getUserSessionAuth() {
-    Optional<Token> auth =
-        userSessionService.getAttribute(BlackboardRESTConnectorConstants.USER_SESSION_AUTH_KEY);
-    if (!auth.isPresent()) {
-      throw new AuthenticationException(
-          "User authentication details are not available in the session");
-    }
-    return auth.get();
+    return userSessionService.getAttribute(BlackboardRESTConnectorConstants.USER_SESSION_AUTH_KEY)
+      .orElseThrow(
+        () -> new AuthenticationException("User authentication details are not available in the session"));
   }
 
   private void setUserSessionAuth(Optional<Token> t) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/utils/ConnectorEntityUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/utils/ConnectorEntityUtils.java
@@ -18,7 +18,6 @@
 
 package com.tle.core.connectors.utils;
 
-import com.google.common.base.Optional;
 import com.tle.common.connectors.ConnectorCourse;
 import com.tle.common.connectors.ConnectorFolder;
 import com.tle.core.connectors.blackboard.beans.Availability;
@@ -27,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.log4j.Logger;
 
 // Thread safe, and currently leveraged for the generic LTI flows
@@ -38,7 +38,7 @@ public class ConnectorEntityUtils {
       Content currentRawFolder, ConnectorCourse course, Map<String, List<Content>> folderMap) {
     if (currentRawFolder == null) {
       LOGGER.error("currentRawFolder is null.");
-      return Optional.absent();
+      return Optional.empty();
     }
     final Content.ContentHandler handler = currentRawFolder.getContentHandler();
     if (handler != null
@@ -77,7 +77,7 @@ public class ConnectorEntityUtils {
       return Optional.of(cc);
     }
     // Not a content folder.  Caller is responsible for checking null.
-    return Optional.absent();
+    return Optional.empty();
   }
 
   /**
@@ -162,6 +162,6 @@ public class ConnectorEntityUtils {
     }
 
     // The folder and its subfolders do not contain the folderId
-    return Optional.absent();
+    return Optional.empty();
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/utils/ConnectorEntityUtils.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/utils/ConnectorEntityUtils.java
@@ -144,6 +144,9 @@ public class ConnectorEntityUtils {
    */
   public static Optional<ConnectorFolder> findFolder(ConnectorFolder folder, String folderId) {
     if (folder.getId().equals(folderId)) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("With ID=" + folderId + ", found: " + folder);
+      }
       return Optional.of(folder);
     }
 
@@ -151,6 +154,9 @@ public class ConnectorEntityUtils {
     for (ConnectorFolder subFolder : folder.getFolders()) {
       Optional<ConnectorFolder> possibleSubFolder = findFolder(subFolder, folderId);
       if (possibleSubFolder.isPresent()) {
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("With ID=" + folderId + ", found subfolder: " + possibleSubFolder.get());
+        }
         return possibleSubFolder;
       }
     }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/blackboard/servlet/BlackboardRestOauthSignonServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/blackboard/servlet/BlackboardRestOauthSignonServlet.java
@@ -101,7 +101,7 @@ public class BlackboardRestOauthSignonServlet extends HttpServlet {
 
     // Ask for the token.
     final Connector connector = connectorService.getByUuid(connectorUuid);
-    final String b64 = blackboardRestConnectorService.encryptKeyAndSecret(connector);
+    final String b64 = blackboardRestConnectorService.buildBasicAuthorizationCredentials(connector);
 
     final Request oauthReq =
         new Request(

--- a/Source/Plugins/Core/com.equella.core/test/java/com/tle/core/connectors/utils/ConnectorEntityUtilsTest.java
+++ b/Source/Plugins/Core/com.equella.core/test/java/com/tle/core/connectors/utils/ConnectorEntityUtilsTest.java
@@ -4,7 +4,6 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
-import com.google.common.base.Optional;
 import com.tle.common.connectors.ConnectorCourse;
 import com.tle.common.connectors.ConnectorFolder;
 import com.tle.core.connectors.blackboard.beans.Availability;
@@ -12,6 +11,7 @@ import com.tle.core.connectors.blackboard.beans.Content;
 import com.tle.core.connectors.blackboard.beans.Content.ContentHandler;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 
 @SuppressWarnings("nls")


### PR DESCRIPTION
History in #2587

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included - N/A
- [x] screenshots are included showing significant UI changes - N/A
- [x] documentation is changed or added - N/A

##### Description of change

Caching adjustments:
* Leverage Bb REST API refresh tokens so the user does not have to log back into Bb during the same oEQ session
* User session caching now in place for auth token
* Auth caches now combined into a single cache of the entire `Token`
* `Course`s and `Folder`s requests are now setup to check the cache, and if none are available, pull a fresh set of results from Bb

Found a unrelated bug where only the first 200 content items from a Bb course were being returned.  Now pulls all pages of content results.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
