### PR TITLE
Properly check whether thumbnail generation is timeout or not.

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -89,7 +89,7 @@ public final class ExecUtils {
       } else {
         StringBuilder errorOutput = new StringBuilder();
         CharStreams.copy(new InputStreamReader(getChildPid.getErrorStream()), errorOutput);
-        LOGGER.debug("getChildPid function did not run properly.\n" + errorOutput);
+        LOGGER.warn("getChildPid function did not run properly.\n" + errorOutput);
       }
       getChildPid.destroy();
 
@@ -261,8 +261,10 @@ public final class ExecUtils {
       int pid = getPidOfProcess(proc).orElse(0);
       final StreamReader stdOut = cp.getSecond();
       final StreamReader stdErr = cp.getThird();
-      boolean isFinished = proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
-      if (!isFinished) {
+      final boolean timeout = !proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
+      if (timeout) {
+        // If the process is not terminated before the given timeout is reached,
+        // kill the process and throw an InterruptedException.
         String platform = determinePlatform();
         if (platform.equals(PLATFORM_LINUX) || platform.equals(PLATFORM_LINUX64)) {
           killLinuxProcessTree(pid);

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/ExecUtils.java
@@ -92,12 +92,16 @@ public final class ExecUtils {
         LOGGER.debug("getChildPid function did not run properly.\n" + errorOutput);
       }
       getChildPid.destroy();
-      // convert string to array of ints
-      pids =
-          Optional.of(
-              Arrays.stream(childPid.toString().replaceAll("\n", " ").split(" "))
-                  .mapToInt(Integer::parseInt)
-                  .toArray());
+
+      String childPidInfo = childPid.toString();
+      if (!childPidInfo.isEmpty()) {
+        // convert string to array of ints
+        pids =
+            Optional.of(
+                Arrays.stream(childPidInfo.replaceAll("\n", " ").split(" "))
+                    .mapToInt(Integer::parseInt)
+                    .toArray());
+      }
     } catch (IOException | InterruptedException e) {
       LOGGER.error("Error getting child processes for: " + pid, e);
     } catch (NumberFormatException e) {
@@ -257,8 +261,8 @@ public final class ExecUtils {
       int pid = getPidOfProcess(proc).orElse(0);
       final StreamReader stdOut = cp.getSecond();
       final StreamReader stdErr = cp.getThird();
-      proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
-      if (!stdErr.isFinished() || !stdOut.isFinished()) {
+      boolean isFinished = proc.waitFor(durationInSeconds, TimeUnit.SECONDS);
+      if (!isFinished) {
         String platform = determinePlatform();
         if (platform.equals(PLATFORM_LINUX) || platform.equals(PLATFORM_LINUX64)) {
           killLinuxProcessTree(pid);


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Since the Java method `waitFor` returns a boolean to indicate whether the process is finished or not, we should use this boolean rather than using `StreamReader.isFinished()`.  With this change, I no longer have errors like `kill and pgrep calls` and `Error generating thumbnail` locally.

In terms of why `StreamReader.isFinished()` is not working reliably, I think we need to dig into its `run`.