### PR TITLE
Improve SearchPage error handling

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/autotest/OAuthRedirector/public_html/WEB-INF/web.xml" />
+  </component>
   <component name="JavaScriptSettings">
-    <option name="languageLevel" value="JSX" />
+    <option name="languageLevel" value="ES6" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -15,12 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import { ErrorResponse, fromAxiosResponse } from "../api/errors";
-import Axios from "axios";
-import { v4 } from "uuid";
-import { API_BASE_URL } from "../AppConfig";
 import * as OEQ from "@openequella/rest-api-client";
+import Axios from "axios";
+import * as React from "react";
+import { v4 } from "uuid";
+import {
+  ErrorResponse,
+  fromAxiosResponse,
+  generateFromError,
+} from "../api/errors";
+import { API_BASE_URL } from "../AppConfig";
 
 declare global {
   interface Window {
@@ -196,7 +200,11 @@ export const LegacyContent = React.memo(function LegacyContent({
         }
       })
       .catch((error) => {
-        onError({ error: fromAxiosResponse(error.response), fullScreen });
+        const errorResponse: ErrorResponse =
+          error.response !== undefined
+            ? fromAxiosResponse(error.response)
+            : generateFromError(error);
+        onError({ error: errorResponse, fullScreen });
       });
   }
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -191,7 +191,7 @@ export const defaultSearchOptions: SearchOptions = {
 export const defaultPagedSearchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
   start: 0,
   length: 10,
-  available: 10,
+  available: 0,
   results: [],
   highlight: [],
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -163,8 +163,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         ? Promise.resolve(undefined)
         : queryStringParamsToSearchOptions(location),
     ])
-      .then((results) => {
-        const [searchSettings, queryStringSearchOptions] = results;
+      .then(([searchSettings, queryStringSearchOptions]) => {
         setSearchSettings(searchSettings);
         if (queryStringSearchOptions)
           setSearchPageOptions({

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -30,6 +30,11 @@ import { languageStrings } from "../../util/langstrings";
 
 interface CollectionSelectorProps {
   /**
+   * Fires if an error is caught that should be reported up.
+   * @param error the caught error.
+   */
+  onError: (error: Error) => void;
+  /**
    * Fires when collection selections are changed.
    * @param collections Selected collections.
    */
@@ -45,6 +50,7 @@ interface CollectionSelectorProps {
  * The initially selected collections are either provided through props or an empty array.
  */
 export const CollectionSelector = ({
+  onError,
   onSelectionChange,
   value,
 }: CollectionSelectorProps) => {
@@ -53,9 +59,9 @@ export const CollectionSelector = ({
   const [collections, setCollections] = useState<Collection[]>([]);
 
   useEffect(() => {
-    collectionListSummary([
-      OEQ.Acl.ACL_SEARCH_COLLECTION,
-    ]).then((collections: Collection[]) => setCollections(collections));
+    collectionListSummary([OEQ.Acl.ACL_SEARCH_COLLECTION])
+      .then((collections: Collection[]) => setCollections(collections))
+      .catch(onError);
   }, []);
 
   return (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/heartbeat.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/heartbeat.ts
@@ -19,10 +19,17 @@ import Axios from "axios";
 
 export function startHeartbeat() {
   setInterval(function () {
-    Axios.get<string>("api/status/heartbeat").then((resp) => {
-      if (resp.data !== "OK") {
-        console.log(resp.data);
-      }
-    });
+    Axios.get<string>("api/status/heartbeat")
+      .then((resp) => {
+        if (resp.data !== "OK") {
+          throw new Error(
+            `Unexpected heartbeat response from openEQUELLA server: ${resp.data}`
+          );
+        }
+      })
+      .catch((error) => {
+        console.error("Attempt to communicate with openEQUELLA server failed");
+        console.error(error);
+      });
   }, 2 * 60 * 1000);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

A number of possible errors were not being caught. This would result in
spurious console log entries, and lack of feedback to the user that an
issue had occurred.

Most of these are now addressed, by simply shutting down oEQ and then
chasing things popping up in the console log. Or in a few cases, just by
manual code analysis and looking at the user result.

And also snuck in a minor IntelliJ project file update.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
