### PR TITLE
Ensure navigating to ItemSummary page if an Item is saved as a draft

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/SaveDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/SaveDialog.java
@@ -191,6 +191,7 @@ public class SaveDialog extends EquellaDialog<SaveDialog.SaveDialogModel> {
     WorkflowOperation[] ops = new WorkflowOperation[] {};
     boolean doSubmit = type.equals("submit");
     boolean doCheck = type.equals("check");
+    boolean doDraft = type.equals("draft");
 
     if (doSubmit || !state.isInDraft() || doCheck) {
       if (!wizardBodySection.isSaveable(info) && wizardBodySection.goToFirstUnfinished(info)) {
@@ -200,15 +201,15 @@ public class SaveDialog extends EquellaDialog<SaveDialog.SaveDialogModel> {
     if (doCheck) {
       return;
     }
-    boolean stayInWizard = !state.isEntryThroughEdit() && !state.isNewItem();
+    boolean leaveWizard = state.isEntryThroughEdit() || state.isNewItem() || doDraft;
     if (doSubmit) {
       ops = new WorkflowOperation[] {workflowFactory.submit(message)};
-      stayInWizard = false;
+      leaveWizard = true;
     }
 
     wizardService.doSave(state, true, ops);
 
-    if (!stayInWizard) {
+    if (leaveWizard) {
       webWizardService.forwardToViewItem(info, state);
       receiptService.setReceipt(LABEL_SUCCESS_RECEIPT);
     } else {


### PR DESCRIPTION
#1204

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Previously, if users `save and continue` an Item and later save the item as a draft, a 500 error will occur. The reason is New UI failed to stay in the Wizard (I haven't dug into why it failed). But what we want is the page should navigate to ItemSummary page instead of staying in the Wizard if user save an Item as a draft.

So this PR's changes can ensure the navigation happens.