### PR TITLE
Add back missing com.tle.core.connectors.canvas.error.prelim language string

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/com/tle/core/i18n/service/impl/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/com/tle/core/i18n/service/impl/i18n-resource-centre.properties
@@ -400,3 +400,4 @@ institutions.error.readingdetails = Error reading institution details
 institutions.error.pagenotfound = Page not found
 
 institutions.server.settings.name = Server settings
+com.tle.core.connectors.canvas.error.prelim=An error occurred in Canvas\:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
A language string that went missing at some point. Gets used during error handling for the Canvas integration. 
#2601 triggers this missing language string. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
