### PR TITLE
Support navigating to Checkout page after selecting an Item

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -55,7 +55,7 @@ interface ExternalRedirect {
   href: string;
 }
 
-interface ChangeRoute {
+export interface ChangeRoute {
   route: string;
   userUpdated: boolean;
 }
@@ -114,22 +114,24 @@ export interface LegacyContentProps {
   children?: never;
 }
 
-type SubmitResponse = ExternalRedirect | LegacyContentResponse | ChangeRoute;
+export type SubmitResponse =
+  | ExternalRedirect
+  | LegacyContentResponse
+  | ChangeRoute;
 
-function isPageContent(
+export function isPageContent(
   response: SubmitResponse
 ): response is LegacyContentResponse {
   return (response as LegacyContentResponse).html !== undefined;
 }
 
-function isChangeRoute(response: SubmitResponse): response is ChangeRoute {
+export function isChangeRoute(
+  response: SubmitResponse
+): response is ChangeRoute {
   return (response as ChangeRoute).route !== undefined;
 }
 
-export function submitRequest(
-  path: string,
-  vals: StateData
-): Promise<SubmitResponse> {
+function submitRequest(path: string, vals: StateData): Promise<SubmitResponse> {
   return Axios.post<SubmitResponse>(
     "api/content/submit" + encodeURI(path),
     vals

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -18,11 +18,18 @@
 import Axios from "axios";
 import {
   API_BASE_URL,
+  AppConfig,
   getBaseUrl,
   getRenderData,
   SelectionSessionInfo,
 } from "../AppConfig";
-import { LegacyContentResponse } from "../legacycontent/LegacyContent";
+import {
+  ChangeRoute,
+  isChangeRoute,
+  isPageContent,
+  LegacyContentResponse,
+  SubmitResponse,
+} from "../legacycontent/LegacyContent";
 import { routes } from "../mainui/routes";
 
 /**
@@ -272,6 +279,17 @@ const updateSelectionSummary = (legacyContent: LegacyContentResponse) => {
 };
 
 /**
+ * Navigate to Selection Session Checkout page. This function is mostly called
+ * when Selection Session is in 'selectOrAdd'.
+ *
+ * Due to no available React Routes in the context of using new Search UI in
+ * Selection Session, this function concatenates the route with base URL and
+ * then uses 'window.location.href' to achieve the navigation.
+ */
+const navigateToCheckout = ({ route }: ChangeRoute) =>
+  (window.location.href = `${AppConfig.baseUrl}${route}`);
+
+/**
  * Build an object of SelectionSessionPostData for 'structured'.
  */
 export const buildPostDataForStructured = (
@@ -356,11 +374,18 @@ export const selectResourceForNonCourseList = (
     itemKey,
     attachmentUUIDs
   );
+  const callback = (response: SubmitResponse) => {
+    if (isChangeRoute(response)) {
+      navigateToCheckout(response);
+    } else if (isPageContent(response)) {
+      updateSelectionSummary(response);
+    }
+  };
 
-  return submitSelection<LegacyContentResponse>(
+  return submitSelection<SubmitResponse>(
     `${submitBaseUrl}/selectoradd/searching.do`,
     postData,
-    updateSelectionSummary
+    callback
   );
 };
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

When a LMS like Brightspace and Canvas is configured to use 'selectOrAdd', the selection submit response is a `ChangeRoute`, which means the page should navigate based on what route is returned.

Probably in most cases, the page should navigate to the Checkout page.

Here is a [video](https://streamable.com/2e2agl) made with Brightspace.

