### PR TITLE
Add filename to "Error generating thumbnail" log message

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/workflow/thumbnail/service/impl/ThumbingCallable.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/workflow/thumbnail/service/impl/ThumbingCallable.java
@@ -205,7 +205,10 @@ public class ThumbingCallable implements Callable<ThumbingCallableResult> {
     } catch (Throwable ex) {
       final Throwable root = Throwables.getRootCause(ex);
       if (!(root instanceof InterruptedException)) {
-        LOGGER.error("Error generating thumbnail", ex);
+        LOGGER.error(
+            "Error generating thumbnail for "
+                + (thumbnailRequest != null ? thumbnailRequest.getFilename() : "filename unknown"),
+            ex);
       }
     }
     return result;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
When testing the fix for #2527 It came to @PenghaiZhang 's attention that thumbnailing errors do not specify a culprit filename and that it would be a value-add to include. Looking into it I realised it was a quick oneliner to make this happen. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
