### PR TITLE
Fix the 500 error when navigating to Advance search from new search UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -104,8 +104,7 @@ object RenderNewTemplate {
     RunWithDB
       .executeIfInInstitution(UISettings.cachedUISettings)
       .getOrElse(UISettings.defaultSettings)
-      .newUI
-      .newSearch
+      .isNewSearchActive
   }
 
   // Check if New UI is being used, but there is no guarantee that New UI is enabled.

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootSearchSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootSearchSection.java
@@ -38,8 +38,8 @@ import com.tle.web.sections.events.RenderEventContext;
 import com.tle.web.sections.generic.InfoBookmark;
 import com.tle.web.sections.render.Label;
 import com.tle.web.selection.SelectionSession;
-import com.tle.web.settings.UISettingsJava;
 import com.tle.web.template.RenderNewSearchPage;
+import com.tle.web.template.RenderNewTemplate;
 import com.tle.web.template.section.event.BlueBarEvent;
 import com.tle.web.template.section.event.BlueBarEventListener;
 import javax.inject.Inject;
@@ -123,7 +123,7 @@ public class RootSearchSection extends ContextableSearchSection<ContextableSearc
 
   private boolean isNewSearchUIInSelectionSession(SelectionSession selectionSession) {
     if (selectionSession != null) {
-      return UISettingsJava.getUISettings().isNewSearchActive();
+      return RenderNewTemplate.isNewSearchPageEnabled();
     }
     return false;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/selection/SearchSelectable.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/selection/SearchSelectable.java
@@ -28,7 +28,7 @@ import com.tle.web.sections.render.Label;
 import com.tle.web.selection.AbstractSelectionNavAction;
 import com.tle.web.selection.SelectionSession;
 import com.tle.web.selection.section.RootSelectionSection.Layout;
-import com.tle.web.settings.UISettingsJava;
+import com.tle.web.template.RenderNewTemplate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -54,7 +54,7 @@ public class SearchSelectable extends AbstractSelectionNavAction {
 
   @SuppressWarnings("nls")
   protected SectionInfo getSearchTree(SectionInfo info) {
-    if (UISettingsJava.getUISettings().newUI().enabled()) {
+    if (RenderNewTemplate.isNewUIEnabled()) {
       return controller.createForward(info, NEW_FORWARD_PATH);
     }
     return controller.createForward(info, LEGACY_FORWARD_PATH);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/selection/section/SelectionSummarySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/selection/section/SelectionSummarySection.java
@@ -67,7 +67,7 @@ import com.tle.web.selection.SelectionService;
 import com.tle.web.selection.SelectionSession;
 import com.tle.web.selection.event.AttachmentSelectorEvent;
 import com.tle.web.selection.event.AttachmentSelectorEventListener;
-import com.tle.web.settings.UISettingsJava;
+import com.tle.web.template.RenderNewTemplate;
 import com.tle.web.viewable.ViewableItem;
 import com.tle.web.viewable.ViewableItemResolver;
 import javax.inject.Inject;
@@ -127,7 +127,7 @@ public class SelectionSummarySection
     JSHandler unselectHandler =
         // In new search UI, put "unselectAll" in an ajax update function in order not to refresh
         // the page
-        UISettingsJava.getUISettings().isNewSearchActive()
+        RenderNewTemplate.isNewSearchPageEnabled()
             ? new OverrideHandler(getUpdateSelection(tree, events.getEventHandler("unselectAll")))
             : events.getNamedHandler("unselectAll");
     unselectAllLink.setClickHandler(unselectHandler);


### PR DESCRIPTION
#2605 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

So I can reproduce this error by logging in as a normal user such as AutoTest. And this PR's changes can fix this issue although I am not entirely sure what is the matter with ACL for this bug. If I revoke ACL `SEARCH_POWER_SEARCH` then I just simply can't see this advanced search from the list, not to mention to open the advanced search page.

There are a few things worth to mention here.

1. if Advanced Search is open from new Search then the Section used is `RootAdvancedSearchSection`;

2. `RootAdvancedSearchSection` contains the node Section `SelectionSummarySection`;

3. `SelectionSummarySection` needs the UI Settings to determine what callback is used for the `Unselect all` button.

Step 3 is where the error gets caused.