### PR TITLE
Don't show share search button when in a selection session.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -770,4 +770,13 @@ describe("In Selection Session", () => {
       ).toHaveBeenCalledWith(`#${uuid}`, true);
     });
   });
+
+  it("should not show the share search button", async () => {
+    updateMockGetRenderData(basicRenderData);
+    mockSearch.mockResolvedValue(getSearchResult);
+    const copySearchButton = screen.queryByTitle(
+      languageStrings.searchpage.shareSearchHelperText
+    );
+    expect(copySearchButton).not.toBeInTheDocument();
+  });
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -33,6 +33,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import Share from "@material-ui/icons/Share";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
+import { isSelectionSessionOpen } from "../../modules/LegacySelectionSessionModule";
 import { languageStrings } from "../../util/langstrings";
 import SearchOrderSelect, { SearchOrderSelectProps } from "./SearchOrderSelect";
 import { SearchPagination, SearchPaginationProps } from "./SearchPagination";
@@ -94,6 +95,7 @@ export const SearchResultList = ({
 }: SearchResultListProps) => {
   const searchPageStrings = languageStrings.searchpage;
   const classes = useStyles();
+  const inSelectionSession: boolean = isSelectionSessionOpen();
 
   /**
    * A list that consists of search result items. Lower the list's opacity when spinner displays.
@@ -129,13 +131,15 @@ export const SearchResultList = ({
                 </Button>
               </Tooltip>
             </Grid>
-            <Grid item>
-              <Tooltip title={searchPageStrings.shareSearchHelperText}>
-                <IconButton onClick={onCopySearchLink}>
-                  <Share />
-                </IconButton>
-              </Tooltip>
-            </Grid>
+            {!inSelectionSession ? (
+              <Grid item>
+                <Tooltip title={searchPageStrings.shareSearchHelperText}>
+                  <IconButton onClick={onCopySearchLink}>
+                    <Share />
+                  </IconButton>
+                </Tooltip>
+              </Grid>
+            ) : undefined}
           </Grid>
         }
       />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -131,7 +131,7 @@ export const SearchResultList = ({
                 </Button>
               </Tooltip>
             </Grid>
-            {!inSelectionSession ? (
+            {!inSelectionSession && (
               <Grid item>
                 <Tooltip title={searchPageStrings.shareSearchHelperText}>
                   <IconButton onClick={onCopySearchLink}>
@@ -139,7 +139,7 @@ export const SearchResultList = ({
                   </IconButton>
                 </Tooltip>
               </Grid>
-            ) : undefined}
+            )}
           </Grid>
         }
       />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
#1306

There were numerous issues integrating this inside selection session iframes. Plus, it doesn't really make sense for someone to want to share a search in a selections session. So the decision was made (for now at least) to not show the share button in selection sessions

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
