### PR TITLE
Ensure forms submit properly in New UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -215,7 +215,7 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
       formTag.setId(StandardExpressions.FORM_NAME)
       helper.setFormExpression(StandardExpressions.FORM_EXPRESSION)
     }
-    RenderTemplate.formSubmitBinding(formTag)
+    RenderTemplate.addFormSubmitBinding(formTag)
     if (!helper.isSubmitFunctionsSet) {
       helper.setSubmitFunctions(
         new ExternallyDefinedFunction("EQ.event"),

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -215,7 +215,7 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
       formTag.setId(StandardExpressions.FORM_NAME)
       helper.setFormExpression(StandardExpressions.FORM_EXPRESSION)
     }
-
+    RenderTemplate.formSubmitBinding(formTag)
     if (!helper.isSubmitFunctionsSet) {
       helper.setSubmitFunctions(
         new ExternallyDefinedFunction("EQ.event"),

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
@@ -78,7 +78,7 @@ import org.apache.commons.logging.LogFactory;
 @SuppressWarnings("nls")
 public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.RenderTemplateModel>
     implements HtmlRenderer, ForwardEventListener, BeforeEventsListener {
-  private static Log LOGGER = LogFactory.getLog(RenderTemplate.class);
+  private static final Log LOGGER = LogFactory.getLog(RenderTemplate.class);
 
   public static final String XSRF_PARAM = "__xsrf";
 
@@ -301,6 +301,12 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
     return "temp";
   }
 
+  public static void formSubmitBinding(FormTag form) {
+    form.addReadyStatements(
+        new JQueryStatement(
+            form, "bind('submit', function(){if (!g_bSubmitting) return false; })"));
+  }
+
   private TemplateResult selectInnerLayout(RenderContext info, TemplateResult templateResult)
       throws Exception {
     PreRenderContext preRenderer = info.getPreRenderContext();
@@ -315,9 +321,7 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
     }
     preRenderer.preRender(StandardExpressions.SUBMIT_JS);
     FormTag form = info.getRootRenderContext().getForm();
-    form.addReadyStatements(
-        new JQueryStatement(
-            form, "bind('submit', function(){if (!g_bSubmitting) return false; })"));
+    formSubmitBinding(form);
 
     final Decorations decorations = Decorations.getDecorations(info);
     for (LayoutSelector layoutSelector : InnerLayout.getLayoutSelectors(info)) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
@@ -301,7 +301,7 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
     return "temp";
   }
 
-  public static void formSubmitBinding(FormTag form) {
+  public static void addFormSubmitBinding(FormTag form) {
     form.addReadyStatements(
         new JQueryStatement(
             form, "bind('submit', function(){if (!g_bSubmitting) return false; })"));
@@ -321,7 +321,7 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
     }
     preRenderer.preRender(StandardExpressions.SUBMIT_JS);
     FormTag form = info.getRootRenderContext().getForm();
-    formSubmitBinding(form);
+    addFormSubmitBinding(form);
 
     final Decorations decorations = Decorations.getDecorations(info);
     for (LayoutSelector layoutSelector : InnerLayout.getLayoutSelectors(info)) {


### PR DESCRIPTION
#1750 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

In Old UI, pushing Enter on a textfield which is the only input of a form does not submit the form whereas it submits the form in New UI. This is because the Javascript controlling whether to submit a form does not get executed in New UI. 

I have tested two places: the dialog for adding a favourite search and dialog for adding a link attachment. Now let's see if we can have green builds.