### PR TITLE
Address some ESLint react-hooks/exhaustive-deps warnings

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/NavigationGuard.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/NavigationGuard.tsx
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Location } from "history";
 import * as React from "react";
 import { useEffect, useState } from "react";
 import { Prompt, useHistory } from "react-router";
-import ConfirmDialog from "./ConfirmDialog";
-import { Location } from "history";
 import { commonString } from "../util/commonstrings";
 import { languageStrings } from "../util/langstrings";
+import ConfirmDialog from "./ConfirmDialog";
 
 /**
  * Prevent navigations triggered by Browsers' behaviours when this's required.
@@ -62,7 +62,7 @@ export const NavigationGuard = ({ when }: NavigationGuardProps) => {
     if (confirmedNavigation && navigateTo) {
       history.push(navigateTo.pathname);
     }
-  }, [confirmedNavigation, navigateTo]);
+  }, [confirmedNavigation, navigateTo, history]);
 
   /**
    * Handle 'beforeunload' event when preventing navigation is required.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -27,6 +27,7 @@ import {
   collectionListSummary,
 } from "../../modules/CollectionsModule";
 import { languageStrings } from "../../util/langstrings";
+import useError from "../../util/useError";
 
 interface CollectionSelectorProps {
   /**
@@ -57,12 +58,13 @@ export const CollectionSelector = ({
   const collectionSelectorStrings =
     languageStrings.searchpage.collectionSelector;
   const [collections, setCollections] = useState<Collection[]>([]);
+  const handleError = useError(onError);
 
   useEffect(() => {
     collectionListSummary([OEQ.Acl.ACL_SEARCH_COLLECTION])
       .then((collections: Collection[]) => setCollections(collections))
-      .catch(onError);
-  }, []);
+      .catch(handleError);
+  }, [handleError]);
 
   return (
     <Autocomplete

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -25,11 +25,11 @@ import {
   Switch,
   Tooltip,
 } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import SearchIcon from "@material-ui/icons/Search";
 import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
-import SearchIcon from "@material-ui/icons/Search";
 import { languageStrings } from "../../util/langstrings";
-import { makeStyles } from "@material-ui/core/styles";
 
 const ESCAPE_KEY_CODE = 27;
 
@@ -88,8 +88,14 @@ export default function SearchBar({
   const searchStrings = languageStrings.searchpage;
   const [currentQuery, setCurrentQuery] = useState<string>(query);
 
+  // The line below triggers the warning:
+  // > React Hook useCallback received a function whose dependencies are unknown. Pass an inline function instead
+  // It was not obvious how to do this with `debounce`, however attempts were made to manually
+  // validate the dependencies.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedOnQueryChange = useCallback(debounce(onQueryChange, 500), [
     doSearch,
+    onQueryChange,
   ]);
 
   // Update state when search query is cleared.

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
@@ -86,9 +86,11 @@ const FacetDialog = ({
    * Initialise `textfields` values when the dialog is opened.
    */
   useEffect(() => {
-    setName(facet?.name ?? "");
-    setSchemaNode(facet?.schemaNode ?? "");
-    setMaxResults(facet?.maxResults);
+    if (open) {
+      setName(facet?.name ?? "");
+      setSchemaNode(facet?.schemaNode ?? "");
+      setMaxResults(facet?.maxResults);
+    }
   }, [open, facet]);
 
   const onAddOrEdit = () => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
@@ -83,13 +83,13 @@ const FacetDialog = ({
   const isSchemaNodeInvalid = validateFacetFields(schemaNode);
 
   /**
-   * Initialise textfields' values, depending on 'onClose'.
+   * Initialise `textfields` values when the dialog is opened.
    */
   useEffect(() => {
     setName(facet?.name ?? "");
     setSchemaNode(facet?.schemaNode ?? "");
     setMaxResults(facet?.maxResults);
-  }, [onClose]);
+  }, [open, facet]);
 
   const onAddOrEdit = () => {
     addOrEdit(name, schemaNode, maxResults);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/Search/searchfilter/MimeTypeFilterEditingDialog.tsx
@@ -34,6 +34,7 @@ import {
 import { commonString } from "../../../util/commonstrings";
 import { addElement, deleteElement } from "../../../util/ImmutableArrayUtil";
 import { languageStrings } from "../../../util/langstrings";
+import useError from "../../../util/useError";
 import MimeTypeList from "./MimeTypeList";
 
 export interface MimeTypeFilterEditingDialogProps {
@@ -82,25 +83,22 @@ const MimeTypeFilterEditingDialog = ({
     OEQ.MimeType.MimeTypeEntry[]
   >([]);
   // Used to store the name of a MIME type filter.
-  const [filterName, setFilterName] = useState<string>("");
+  const [filterName, setFilterName] = useState<string>(
+    mimeTypeFilter ? mimeTypeFilter.name : ""
+  );
   // Used to store the MIME types of a MIME type filter.
-  const [selectedMimeTypes, setSelectedMimeTypes] = useState<string[]>([]);
+  const [selectedMimeTypes, setSelectedMimeTypes] = useState<string[]>(
+    mimeTypeFilter ? mimeTypeFilter.mimeTypes : []
+  );
+  const setError = useError(handleError);
 
   const isNameValid = validateMimeTypeName(filterName);
 
   useEffect(() => {
     mimeTypeSupplier()
       .then((mimeTypes) => setMimeTypeEntries(mimeTypes))
-      .catch((error) => handleError(error));
-  }, [mimeTypeSupplier]);
-
-  /**
-   * Clean up previously edited filter, depending on 'onClose'.
-   */
-  useEffect(() => {
-    setFilterName(mimeTypeFilter ? mimeTypeFilter.name : "");
-    setSelectedMimeTypes(mimeTypeFilter ? mimeTypeFilter.mimeTypes : []);
-  }, [onClose]);
+      .catch(setError);
+  }, [mimeTypeSupplier, setError]);
 
   /**
    * If a MIME type is selected and it doesn't exist in the collection of selected MIME types,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -15,35 +15,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
 import {
-  Theme,
+  CircularProgress,
   ExpansionPanel,
-  ExpansionPanelSummary,
   ExpansionPanelDetails,
-  Typography,
+  ExpansionPanelSummary,
   List,
   ListItem,
   ListItemText,
-  CircularProgress,
+  Theme,
+  Typography,
 } from "@material-ui/core";
+import MUILink from "@material-ui/core/Link";
+import { makeStyles } from "@material-ui/core/styles";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { ReactElement, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { generateFromError } from "../api/errors";
 import {
   templateDefaults,
   templateError,
   TemplateUpdateProps,
 } from "../mainui/Template";
 import { fetchSettings } from "../modules/GeneralSettingsModule";
-import { languageStrings } from "../util/langstrings";
-import MUILink from "@material-ui/core/Link";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import { Link } from "react-router-dom";
-import { makeStyles } from "@material-ui/core/styles";
 import AdminDownloadDialog from "../settings/AdminDownloadDialog";
-import { ReactElement, useEffect, useState } from "react";
-import UISettingEditor from "./UISettingEditor";
-import { generateFromError } from "../api/errors";
+import { languageStrings } from "../util/langstrings";
 import { groupMap, SettingGroup } from "./SettingGroups";
-import * as OEQ from "@openequella/rest-api-client";
+import UISettingEditor from "./UISettingEditor";
 
 const useStyles = makeStyles((theme: Theme) => {
   return {
@@ -78,16 +78,17 @@ const SettingsPage = ({
   const [adminDialogOpen, setAdminDialogOpen] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [settingGroups, setSettingGroups] = useState<SettingGroup[]>([]);
+  const [error, setError] = useState<Error>();
 
   React.useEffect(() => {
     if (isReloadNeeded) {
       window.location.reload();
     }
-  }, []);
+  }, [isReloadNeeded]);
 
   useEffect(() => {
     updateTemplate(templateDefaults(languageStrings["com.equella.core"].title));
-  }, []);
+  }, [updateTemplate]);
 
   useEffect(() => {
     // Use a flag to prevent setting state when component is being unmounted
@@ -100,7 +101,7 @@ const SettingsPage = ({
         }
       })
       .catch((error) => {
-        handleError(error);
+        setError(error);
         setLoading(false);
       });
 
@@ -109,9 +110,12 @@ const SettingsPage = ({
     };
   }, []);
 
-  const handleError = (error: Error) => {
-    updateTemplate(templateError(generateFromError(error)));
-  };
+  useEffect(() => {
+    if (error) {
+      updateTemplate(templateError(generateFromError(error)));
+      setError(undefined);
+    }
+  }, [error, updateTemplate]);
 
   /**
    * Create the UI content for setting category
@@ -125,7 +129,7 @@ const SettingsPage = ({
   }: SettingGroup): ReactElement => {
     if (category.name === languageStrings.settings.ui.name) {
       return (
-        <UISettingEditor refreshUser={refreshUser} handleError={handleError} />
+        <UISettingEditor refreshUser={refreshUser} handleError={setError} />
       );
     }
     return (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -42,6 +42,7 @@ import {
 import { fetchSettings } from "../modules/GeneralSettingsModule";
 import AdminDownloadDialog from "../settings/AdminDownloadDialog";
 import { languageStrings } from "../util/langstrings";
+import useError from "../util/useError";
 import { groupMap, SettingGroup } from "./SettingGroups";
 import UISettingEditor from "./UISettingEditor";
 
@@ -78,7 +79,9 @@ const SettingsPage = ({
   const [adminDialogOpen, setAdminDialogOpen] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [settingGroups, setSettingGroups] = useState<SettingGroup[]>([]);
-  const [error, setError] = useState<Error>();
+  const setError = useError((error: Error) =>
+    updateTemplate(templateError(generateFromError(error)))
+  );
 
   React.useEffect(() => {
     if (isReloadNeeded) {
@@ -108,14 +111,7 @@ const SettingsPage = ({
     return () => {
       cleanupTriggered = true;
     };
-  }, []);
-
-  useEffect(() => {
-    if (error) {
-      updateTemplate(templateError(generateFromError(error)));
-      setError(undefined);
-    }
-  }, [error, updateTemplate]);
+  }, [setError]);
 
   /**
    * Create the UI content for setting category

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/UISettingEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/UISettingEditor.tsx
@@ -61,6 +61,7 @@ const UISettingEditor = (props: UISettingEditorProps) => {
 
   const [newUIEnabled, setNewUIEnabled] = useState<boolean>(true);
   const [newSearchEnabled, setNewSearchEnabled] = useState<boolean>(false);
+  const [error, setError] = useState<Error>();
 
   useEffect(() => {
     // Use a flag to prevent setting state when component is being unmounted
@@ -74,13 +75,20 @@ const UISettingEditor = (props: UISettingEditorProps) => {
         }
       })
       .catch((error) => {
-        handleError(error);
+        setError(error);
       });
 
     return () => {
       cleanupTriggered = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (error !== undefined) {
+      handleError(error);
+      setError(undefined);
+    }
+  }, [error, handleError]);
 
   const setNewUI = (enabled: boolean) => {
     setNewUIEnabled(enabled);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/UISettingEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/UISettingEditor.tsx
@@ -34,6 +34,7 @@ import { routes } from "../mainui/routes";
 import { languageStrings } from "../util/langstrings";
 import { AppConfig } from "../AppConfig";
 import { useEffect, useState } from "react";
+import useError from "../util/useError";
 
 const useStyles = makeStyles({
   fab: {
@@ -61,7 +62,7 @@ const UISettingEditor = (props: UISettingEditorProps) => {
 
   const [newUIEnabled, setNewUIEnabled] = useState<boolean>(true);
   const [newSearchEnabled, setNewSearchEnabled] = useState<boolean>(false);
-  const [error, setError] = useState<Error>();
+  const setError = useError(handleError);
 
   useEffect(() => {
     // Use a flag to prevent setting state when component is being unmounted
@@ -81,14 +82,7 @@ const UISettingEditor = (props: UISettingEditorProps) => {
     return () => {
       cleanupTriggered = true;
     };
-  }, []);
-
-  useEffect(() => {
-    if (error !== undefined) {
-      handleError(error);
-      setError(undefined);
-    }
-  }, [error, handleError]);
+  }, [setError]);
 
   const setNewUI = (enabled: boolean) => {
     setNewUIEnabled(enabled);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/useError.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/useError.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from "react";
+
+/**
+ * A custom hook to assist with the management of of state (and effect dependencies) for the
+ * displaying of errors within the New UI Template. Ideally long term this will be replaced
+ * possibly through the centralising of this via a Context with `useContent`. Further, the
+ * project will start to make use of Error Boundaries (possibly via `react-error-boundary`).
+ *
+ * But for now, we have this...
+ *
+ * @param onError A function which typically calls out to updateTemplate to trigger the error
+ *                mechanisms, but often passed in via props
+ */
+export const useError = (
+  onError: (error: Error) => void
+): ((error: Error) => void) => {
+  const [error, setError] = useState<Error>();
+
+  useEffect(() => {
+    if (error) {
+      onError(error);
+      setError(undefined);
+    }
+  }, [error, onError]);
+
+  return setError;
+};
+
+export default useError;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] ~tests are included~ checked with existing tests

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This is an initial attempt to address some of the `react-hooks/exhaustive-deps` warnings. There was more than 30, there are now 24.

Because we're just before release, I tried to find the easy ones and flesh out any patterns. (I did start on the `DateRangeSelector` but got a bit more involved - I was almost there, but ran out of time.)

This initial batch resulted in a custom hook being brought in (`useError`) to encapsulate the pattern of how we deal with errors - when we also want to properly specify our dependencies. But as per the comment, I hope this only hangs around for a short time and is ultimately replaced with a Context and Error Boundary (or multiple).

The effort also highlighted the complexity of state we're trying to manage via effects in several places, and I believe we could greatly benefit by bringing in `useReducer` to several components. I also think that this would be the way to tidy up the `SearchPage` and some of the more complex Selectors like the `DateRangeSelector`. (Perhaps the `DateRangeSelector` may be a good starting point.)

Also the effort again drew attention to our pattern with state and effects for making async calls, and reminded me of the value we may gain by bringing in [React Async](https://docs.react-async.com/). It'd just be interesting though to first see how that'd fit with our end point for error handling/messaging.

Another pattern which emerged was the fetching of values from the server from an effect with dependencies for a single run (i.e. `[]`) which relied on a block level function to make the calls - and possibly do the error handling. This block level function would then be re-used after edits were saved and the data needed to be refreshed - or dare I say, reset. The tidy up of dependencies for this case was to move that function (or just the logic) into an effect which was tied to a state flag called `reset` which can then be simply toggled when a refresh is needed. This is possibly the main trigger which emphasised the idea of a move to `useReducer` - with say a 'reset' dispatch action.

While working through I made diligent work of the jest tests after each change, and also undertook manual testing - including tweaking code to throw additional errors and the like. So I believe all is safe.

(And also, I did sort some imports - thanks IntelliJ - as I worked on files.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
