### PR TITLE
Bugfix/search portlet do not support new search UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsconfig.json
+++ b/Source/Plugins/Core/com.equella.core/js/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "CommonJS",
     "esModuleInterop": true,
     "target": "es5",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2020", "dom", "dom.iterable"],
     "inlineSourceMap": true,
     "inlineSources": true,
     "allowJs": true,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -20,7 +20,7 @@ import * as OEQ from "@openequella/rest-api-client";
 import { Location } from "history";
 import { pick } from "lodash";
 import {
-  Array,
+  Array as RuntypeArray,
   Boolean,
   Guard,
   Literal,
@@ -130,13 +130,13 @@ const DehydratedSearchOptionsRunTypes = Partial({
   rowsPerPage: Number,
   currentPage: Number,
   sortOrder: SortOrder,
-  collections: Array(Record({ uuid: String })),
+  collections: RuntypeArray(Record({ uuid: String })),
   rawMode: Boolean,
   lastModifiedDateRange: Record({ start: Guard(isDate), end: Guard(isDate) }),
   owner: Record({ id: String }),
   // Runtypes guard function would not work when defining the type as Array(OEQ.Common.ItemStatuses) or Guard(OEQ.Common.ItemStatuses.guard),
   // So the Union of Literals has been copied from the OEQ.Common module.
-  status: Array(
+  status: RuntypeArray(
     Union(
       Literal("ARCHIVED"),
       Literal("DELETED"),
@@ -149,10 +149,10 @@ const DehydratedSearchOptionsRunTypes = Partial({
       Literal("SUSPENDED")
     )
   ),
-  selectedCategories: Array(
+  selectedCategories: RuntypeArray(
     Record({
       id: Number,
-      categories: Array(String),
+      categories: RuntypeArray(String),
     })
   ),
   searchAttachments: Boolean,
@@ -249,6 +249,11 @@ export const queryStringParamsToSearchOptions = async (
 ): Promise<SearchOptions | undefined> => {
   if (!location.search) return undefined;
   const params = new URLSearchParams(location.search);
+
+  // If no query strings is of type LegacySearchParams, return undefined.
+  if (!Array.from(params.keys()).some((key) => LegacySearchParams.guard(key))) {
+    return undefined;
+  }
 
   if (location.pathname.endsWith("searching.do")) {
     return await legacyQueryStringToSearchOptions(params);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -56,7 +56,6 @@ import {
   SortOrder,
 } from "../modules/SearchSettingsModule";
 import {
-  isSelectionSessionOpen,
   prepareDraggable,
   buildSelectionSessionAdvancedSearchLink,
   buildSelectionSessionRemoteSearchLink,
@@ -158,10 +157,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
     Promise.all([
       getSearchSettingsFromServer(),
-      // Do not convert query string params to search options in Selection Session.
-      isSelectionSessionOpen()
-        ? Promise.resolve(undefined)
-        : queryStringParamsToSearchOptions(location),
+      queryStringParamsToSearchOptions(location),
     ])
       .then(([searchSettings, queryStringSearchOptions]) => {
         setSearchSettings(searchSettings);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -158,7 +158,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
     Promise.all([
       getSearchSettingsFromServer(),
-      // If the search option already exists, don't do query string conversion.
+      // If the search options are available from browser history, ignore those in the query string.
       searchPageHistoryState
         ? Promise.resolve(undefined)
         : queryStringParamsToSearchOptions(location),
@@ -197,8 +197,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   }, [searchPageOptions]);
 
   useEffect(() => {
-    // Don't manipulate the history for the initial search if the search
-    // option is the default one.
+    // If search page is open from a URL which has some query params, updating browser
+    // history for the initial search will produce wrong search option for the second
+    // render. This is because in the second render, we ignore the query param conversion
+    // as the history data has higher priority. So the end result is wrong search options
+    // are displayed in the page.
     if (isInitialSearch && searchPageOptions === defaultSearchPageOptions) {
       return;
     } else {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -158,6 +158,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
     Promise.all([
       getSearchSettingsFromServer(),
+      // If the search option already exists, don't do query string conversion.
       searchPageHistoryState
         ? Promise.resolve(undefined)
         : queryStringParamsToSearchOptions(location),
@@ -196,10 +197,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   }, [searchPageOptions]);
 
   useEffect(() => {
-    history.replace({
-      ...history.location,
-      state: { searchPageOptions, filterExpansion },
-    });
+    // Don't manipulate the history for the initial search if the search
+    // option is the default one.
+    if (isInitialSearch && searchPageOptions === defaultSearchPageOptions) {
+      return;
+    } else {
+      history.replace({
+        ...history.location,
+        state: { searchPageOptions, filterExpansion },
+      });
+    }
   }, [filterExpansion, pagedSearchResult]);
 
   // In Selection Session, once a new search result is returned, make each

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -120,15 +120,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     searchPageOptions: defaultSearchPageOptions,
     filterExpansion: false,
   };
-
+  const searchPageHistoryState: SearchPageHistoryState | undefined = history
+    .location.state as SearchPageHistoryState;
   const [searchPageOptions, setSearchPageOptions] = useState<SearchPageOptions>(
     // If the user has gone 'back' to this page, then use their previous options. Otherwise
     // we start fresh - i.e. if a new navigation to Search Page.
-    (history.location.state as SearchPageHistoryState)?.searchPageOptions ??
+    searchPageHistoryState?.searchPageOptions ??
       defaultSearchPageHistory.searchPageOptions
   );
   const [filterExpansion, setFilterExpansion] = useState(
-    (history.location.state as SearchPageHistoryState)?.filterExpansion ??
+    searchPageHistoryState?.filterExpansion ??
       defaultSearchPageHistory.filterExpansion
   );
   const [pagedSearchResult, setPagedSearchResult] = useState<
@@ -157,7 +158,9 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
     Promise.all([
       getSearchSettingsFromServer(),
-      queryStringParamsToSearchOptions(location),
+      searchPageHistoryState
+        ? Promise.resolve(undefined)
+        : queryStringParamsToSearchOptions(location),
     ])
       .then(([searchSettings, queryStringSearchOptions]) => {
         setSearchSettings(searchSettings);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -204,12 +204,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     // are displayed in the page.
     if (isInitialSearch && searchPageOptions === defaultSearchPageOptions) {
       return;
-    } else {
-      history.replace({
-        ...history.location,
-        state: { searchPageOptions, filterExpansion },
-      });
     }
+    history.replace({
+      ...history.location,
+      state: { searchPageOptions, filterExpansion },
+    });
   }, [filterExpansion, pagedSearchResult]);
 
   // In Selection Session, once a new search result is returned, make each

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/renderer/SearchPortletRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/renderer/SearchPortletRenderer.java
@@ -48,6 +48,8 @@ import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
 import com.tle.web.selection.SelectionService;
 import com.tle.web.selection.SelectionSession;
+import com.tle.web.selection.section.RootSelectionSection.Layout;
+import com.tle.web.template.RenderNewTemplate;
 import javax.inject.Inject;
 
 /** @author aholland */
@@ -118,7 +120,15 @@ public class SearchPortletRenderer extends PortletContentRenderer<Object> {
 
   @EventHandlerMethod
   public void doSearch(SectionInfo info) {
-    SearchQuerySection.basicSearch(info, query.getValue(info));
+    if (RenderNewTemplate.isNewSearchPageEnabled()) {
+      // In Selection Session, the quick search portlet is only available in 'selectOrAdd'.
+      SelectionSession selectionSession = selectionService.getCurrentSession(info);
+      boolean isSelectOrAdd =
+          selectionSession != null && selectionSession.getLayout() == Layout.NORMAL;
+      SearchQuerySection.basicSearchForNewSearch(info, query.getValue(info), isSelectOrAdd);
+    } else {
+      SearchQuerySection.basicSearch(info, query.getValue(info));
+    }
   }
 
   public TextField getQuery() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
@@ -52,6 +52,7 @@ import com.tle.web.searching.OnSearchExtensionHandler;
 import com.tle.web.searching.SearchWhereModel;
 import com.tle.web.searching.SearchWhereModel.WhereEntry;
 import com.tle.web.searching.WithinType;
+import com.tle.web.searching.selection.SearchSelectable;
 import com.tle.web.sections.SectionId;
 import com.tle.web.sections.SectionInfo;
 import com.tle.web.sections.SectionResult;
@@ -81,6 +82,7 @@ import com.tle.web.sections.events.RenderEventContext;
 import com.tle.web.sections.events.SectionEvent;
 import com.tle.web.sections.events.js.EventGenerator;
 import com.tle.web.sections.events.js.JSHandler;
+import com.tle.web.sections.generic.InfoBookmark;
 import com.tle.web.sections.js.JSCallAndReference;
 import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.js.generic.OverrideHandler;
@@ -146,9 +148,9 @@ public class SearchQuerySection
   @PlugKey("query.hint")
   private static Label LABEL_QUERY_HINT;
 
-  private static Label LABEL_SEARCH = new KeyLabel("item.section.query.search");
+  private static final Label LABEL_SEARCH = new KeyLabel("item.section.query.search");
 
-  private static IncludeFile UPDATE_INCLUDE =
+  private static final IncludeFile UPDATE_INCLUDE =
       new IncludeFile(resources.url("scripts/updateinterface.js"));
 
   @EventFactory private EventGenerator events;
@@ -415,9 +417,7 @@ public class SearchQuerySection
 
   public DefaultSearch createDefaultSearch(SectionInfo info, boolean includeQuery) {
     boolean nonLive =
-        getSearchSettings().isSearchingShowNonLiveCheckbox()
-            ? includeNonLive.isChecked(info)
-            : false;
+        getSearchSettings().isSearchingShowNonLiveCheckbox() && includeNonLive.isChecked(info);
     boolean dynamicCollection = false;
 
     String queryText = null;
@@ -621,6 +621,22 @@ public class SearchQuerySection
     collectionList.setSelectedStringValue(info, null);
     changedWhere(info);
     searchResults.startSearch(info);
+  }
+
+  public static void basicSearchForNewSearch(
+      SectionInfo from, String query, boolean inSelectOrAdd) {
+    // In selectOrAdd the endpoint is '/selectoradd/searching.do'.
+    SectionInfo info =
+        inSelectOrAdd
+            ? from.createForward(SearchSelectable.NEW_FORWARD_PATH)
+            : RootSearchSection.createForward(from);
+    String basicUrl = info.getPublicBookmark().getHref();
+
+    String queryString = ((InfoBookmark) info.getPublicBookmark()).getQuery();
+    if (queryString.isEmpty()) {
+      basicUrl = basicUrl + "?";
+    }
+    from.forwardToUrl(basicUrl + "&q=" + query);
   }
 
   public static void basicSearch(SectionInfo from, String query) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/SearchQuerySection.java
@@ -82,7 +82,6 @@ import com.tle.web.sections.events.RenderEventContext;
 import com.tle.web.sections.events.SectionEvent;
 import com.tle.web.sections.events.js.EventGenerator;
 import com.tle.web.sections.events.js.JSHandler;
-import com.tle.web.sections.generic.InfoBookmark;
 import com.tle.web.sections.js.JSCallAndReference;
 import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.js.generic.OverrideHandler;
@@ -111,6 +110,8 @@ import com.tle.web.wizard.page.PageUpdateCallback;
 import com.tle.web.wizard.page.WebWizardPageState;
 import com.tle.web.wizard.page.WizardPage;
 import com.tle.web.wizard.page.WizardPageService;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -630,13 +631,16 @@ public class SearchQuerySection
         inSelectOrAdd
             ? from.createForward(SearchSelectable.NEW_FORWARD_PATH)
             : RootSearchSection.createForward(from);
-    String basicUrl = info.getPublicBookmark().getHref();
 
-    String queryString = ((InfoBookmark) info.getPublicBookmark()).getQuery();
-    if (queryString.isEmpty()) {
-      basicUrl = basicUrl + "?";
+    try {
+      URL basicUrl = new URL(info.getPublicBookmark().getHref());
+      String queryString = basicUrl.getQuery();
+      String queryStringPrefix = queryString == null || queryString.isEmpty() ? "?" : "&";
+      String fullUrl = basicUrl.toString() + queryStringPrefix + "q=" + query;
+      from.forwardToUrl(fullUrl);
+    } catch (MalformedURLException e) {
+      LOGGER.error("Failed to generate a URL for endpoint '/selectoradd/searching.do'. ");
     }
-    from.forwardToUrl(basicUrl + "&q=" + query);
   }
 
   public static void basicSearch(SectionInfo from, String query) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/selection/SearchSelectable.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/selection/SearchSelectable.java
@@ -40,7 +40,7 @@ public class SearchSelectable extends AbstractSelectionNavAction {
   }
 
   private static final String LEGACY_FORWARD_PATH = "/searching.do";
-  private static final String NEW_FORWARD_PATH = "/selectoradd/searching.do";
+  public static final String NEW_FORWARD_PATH = "/selectoradd/searching.do";
 
   @PlugKey("searching.search.title")
   private static Label LABEL_SEARCH;


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Currently, when a search is triggered from quick search in Selection Session, the endpoint is not `selectoradd/searching.do`. This will result in showing the regular page in Selection Session. So we need to change the endpoint.

Also, in order to pass the search query to new search UI, we need to 
1. enable the feature of `converting query strings to search options` in Selection Session;
2. append the query to the URL.

When I was testing,  I noticed that `converting query strings to search options` is not quite compatible with `back to search page`. The issue is if back to a search URL which has query strings, the search option stored in browser history is ignored. 

So overall, this PR fixes above issue and make quick search work fine with new search UI.

[quick search in regular page](https://streamable.com/k6nqul)

[quick search in resource selector](https://streamable.com/0ckvtu)