### PR TITLE
Improve Edit YouTube dialog styles

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -63,7 +63,6 @@ $col2Width: 250px;
 $standardBorderRadius: 4px;
 $roundButtonRadius: 50px;
 $termSelectorHeight: 68px;
-$youtubeSearchOffset: -275px;
 
 @mixin boxShadow {
   box-shadow: $boxShadow;
@@ -543,13 +542,8 @@ select[multiple="multiple"] {
 
 .youTubeHandler {
   @include buttonShadowBorder;
-  //make room for more search results with a negative margin
-  margin-top: $youtubeSearchOffset;
-  .modal_close {
-    margin-top: $youtubeSearchOffset;
-  }
   .modal-content-inner {
-    max-height: 75vh;
+    max-height: 62.5vh;
   }
   .area.float-left.attachment-content {
     background: none;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -551,6 +551,15 @@ select[multiple="multiple"] {
   .modal-content-inner {
     max-height: 75vh;
   }
+  .area.float-left.attachment-content {
+    background: none;
+    box-shadow: none;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none;
+    width: 400px;
+    padding-right: 0;
+    margin-right: 0;
+  }
 }
 
 .modal-search-result li {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
In work on YouTube dialog styling done previously a few issues popped up. The negative margin on the dialog caused parts of the dialog to be cut off the top of the screen. After removing that, I noticed that the edit dialog styles were also broken. This PR fixes both issues. 
Before:
![Peek 2020-12-21 12-35](https://user-images.githubusercontent.com/24543345/102730515-211c1080-4389-11eb-87c4-e03532ea94e3.gif)
After:
![Peek 2020-12-21 12-37](https://user-images.githubusercontent.com/24543345/102730607-56c0f980-4389-11eb-8dbb-c847d194626b.gif)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
