### PR TITLE
Refactor the logic of converting query params to SearchOptions.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -247,18 +247,23 @@ export const generateCategoryWhereQuery = (
 export const queryStringParamsToSearchOptions = async (
   location: Location
 ): Promise<SearchOptions | undefined> => {
-  if (!location.search) return undefined;
-  const params = new URLSearchParams(location.search);
-
-  // If no query strings is of type LegacySearchParams, return undefined.
-  if (!Array.from(params.keys()).some((key) => LegacySearchParams.guard(key))) {
+  if (!location.search) {
     return undefined;
   }
-
-  if (location.pathname.endsWith("searching.do")) {
+  const params = new URLSearchParams(location.search);
+  const searchOptions = params.get("searchOptions");
+  // If SearchOptions is in query string, convert the string to a SearchOptions.
+  // Or, if query string contains 'LegacySearchParams', convert the string
+  // to a SearchOptions.
+  // Otherwise, return undefined.
+  if (searchOptions) {
+    return await newSearchQueryToSearchOptions(searchOptions);
+  } else if (
+    Array.from(params.keys()).some((key) => LegacySearchParams.guard(key))
+  ) {
     return await legacyQueryStringToSearchOptions(params);
   }
-  return await newSearchQueryToSearchOptions(params.get("searchOptions") ?? "");
+  return undefined;
 };
 
 /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -252,10 +252,11 @@ export const queryStringParamsToSearchOptions = async (
   }
   const params = new URLSearchParams(location.search);
   const searchOptions = params.get("searchOptions");
-  // If SearchOptions is in query string, convert the string to a SearchOptions.
-  // Or, if query string contains 'LegacySearchParams', convert the string
-  // to a SearchOptions.
-  // Otherwise, return undefined.
+
+  // If the query params contain `searchOptions` convert to `SearchOptions` with `newSearchQueryToSearchOptions`.
+  // Else if the query params contain params from legacy `searching.do` (i.e. `LegacySearchParams`) then convert to
+  // `searchOptions` with `legacyQueryStringToSearchOptions`.
+  // For all else, return `undefined`.
   if (searchOptions) {
     return await newSearchQueryToSearchOptions(searchOptions);
   } else if (


### PR DESCRIPTION
#2623 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR refactors the logic of how to convert query params to SearchOptions.

The biggest change is: 
 If the new search page is open from `Quick Search`, the location pathname will be `searching.do` rather than `page/search`. This means we should call `newSearchQueryToSearchOptions` instead of `legacyQueryStringToSearchOptions`.

Here is a [video](https://streamable.com/tta47h) for the fix.