### PR TITLE
EBP: Add max-height to folderlist in selection session

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -4958,7 +4958,7 @@ div#sssh_finishedButton {
   @include typography-subtitle-2;
   float: left;
   width: 100%;
-  max-height: 500px;
+  max-height: 60vh;
 }
 
 .foldertree {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -4958,6 +4958,7 @@ div#sssh_finishedButton {
   @include typography-subtitle-2;
   float: left;
   width: 100%;
+  max-height: 500px;
 }
 
 .foldertree {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
In a selection session, when the number of selection destinations exceeds 10, you can't scroll down far enough to see the lowest entries unless you scroll down to the bottom of the openEQUELLA search page. Adding max height to the list means that if it is too long it will have a scroll bar.

Before:
https://user-images.githubusercontent.com/24543345/103978903-aea49080-51d0-11eb-919d-5d0c6caf38aa.mp4

After:
https://user-images.githubusercontent.com/24543345/103978970-ced44f80-51d0-11eb-8325-9411d28ba6d0.mp4


<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
