### PR TITLE
Make sure that the Collection Selector doesn't overlap the Selection Panel in a Selection Session

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -60,6 +60,7 @@ import {
   buildSelectionSessionAdvancedSearchLink,
   buildSelectionSessionRemoteSearchLink,
   isSelectionSessionInStructured,
+  isSelectionSessionOpen,
 } from "../modules/LegacySelectionSessionModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
@@ -498,7 +499,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   return (
     <>
       <Grid container spacing={2}>
-        <Grid item xs={9}>
+        <Grid item xs={isSelectionSessionOpen() ? 8 : 9}>
           <Grid container spacing={2}>
             <Grid item xs={12}>
               <SearchBar
@@ -533,7 +534,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           </Grid>
         </Grid>
 
-        <Grid item xs={3}>
+        <Grid item xs={isSelectionSessionOpen() ? 4 : 3}>
           <Grid container direction="column" spacing={2}>
             <Grid item>
               <RefineSearchPanel

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -60,7 +60,6 @@ import {
   buildSelectionSessionAdvancedSearchLink,
   buildSelectionSessionRemoteSearchLink,
   isSelectionSessionInStructured,
-  isSelectionSessionOpen,
 } from "../modules/LegacySelectionSessionModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
@@ -499,7 +498,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   return (
     <>
       <Grid container spacing={2}>
-        <Grid item xs={isSelectionSessionOpen() ? 8 : 9}>
+        <Grid item xs={8}>
           <Grid container spacing={2}>
             <Grid item xs={12}>
               <SearchBar
@@ -534,7 +533,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           </Grid>
         </Grid>
 
-        <Grid item xs={isSelectionSessionOpen() ? 4 : 3}>
+        <Grid item xs={4}>
           <Grid container direction="column" spacing={2}>
             <Grid item>
               <RefineSearchPanel

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -26,7 +26,6 @@ import {
   Collection,
   collectionListSummary,
 } from "../../modules/CollectionsModule";
-import { isSelectionSessionOpen } from "../../modules/LegacySelectionSessionModule";
 import { languageStrings } from "../../util/langstrings";
 import useError from "../../util/useError";
 
@@ -68,59 +67,54 @@ export const CollectionSelector = ({
   }, [handleError]);
 
   return (
-    <Autocomplete
-      multiple
-      fullWidth
-      limitTags={2}
-      renderTags={
-        /**
-         * If we are in a selection session, limit the max width of the chips
-         * so as to prevent overlapping with the selection panel. 132px is the
-         * widest a chip can be before it starts to increase the width of the
-         * surrounding Autocomplete component.
-         */
-        isSelectionSessionOpen()
-          ? (collections: Collection[], getTagProps: AutocompleteGetTagProps) =>
-              collections.map((collection: Collection, index: number) => (
-                <Tooltip title={collection.name}>
-                  <Chip
-                    style={{ maxWidth: "132px" }}
-                    id={"collectionChip " + collection.uuid}
-                    label={collection.name}
-                    {...getTagProps({ index })}
-                  />
-                </Tooltip>
-              ))
-          : undefined
-      }
-      onChange={(_, value: Collection[]) => {
-        onSelectionChange(value);
-      }}
-      value={value ?? []}
-      options={collections}
-      disableCloseOnSelect
-      getOptionLabel={(collection) => collection.name}
-      getOptionSelected={(collection, selected) =>
-        selected.uuid === collection.uuid
-      }
-      renderOption={(collection, { selected }) => (
-        <>
-          <Checkbox
-            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-            checkedIcon={<CheckBoxIcon fontSize="small" />}
-            checked={selected}
+    <div style={{ width: "100%" }}>
+      <Autocomplete
+        multiple
+        limitTags={2}
+        renderTags={(
+          collections: Collection[],
+          getTagProps: AutocompleteGetTagProps
+        ) =>
+          collections.map((collection: Collection, index: number) => (
+            <Tooltip title={collection.name}>
+              <Chip
+                style={{ maxWidth: "50%" }}
+                id={"collectionChip " + collection.uuid}
+                label={collection.name}
+                {...getTagProps({ index })}
+              />
+            </Tooltip>
+          ))
+        }
+        onChange={(_, value: Collection[]) => {
+          onSelectionChange(value);
+        }}
+        value={value ?? []}
+        options={collections}
+        disableCloseOnSelect
+        getOptionLabel={(collection) => collection.name}
+        getOptionSelected={(collection, selected) =>
+          selected.uuid === collection.uuid
+        }
+        renderOption={(collection, { selected }) => (
+          <>
+            <Checkbox
+              icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+              checkedIcon={<CheckBoxIcon fontSize="small" />}
+              checked={selected}
+            />
+            {collection.name}
+          </>
+        )}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            variant="outlined"
+            label={collectionSelectorStrings.title}
+            placeholder={collectionSelectorStrings.title}
           />
-          {collection.name}
-        </>
-      )}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="outlined"
-          label={collectionSelectorStrings.title}
-          placeholder={collectionSelectorStrings.title}
-        />
-      )}
-    />
+        )}
+      />
+    </div>
   );
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -67,54 +67,52 @@ export const CollectionSelector = ({
   }, [handleError]);
 
   return (
-    <div style={{ width: "100%" }}>
-      <Autocomplete
-        multiple
-        limitTags={2}
-        renderTags={(
-          collections: Collection[],
-          getTagProps: AutocompleteGetTagProps
-        ) =>
-          collections.map((collection: Collection, index: number) => (
-            <Tooltip title={collection.name}>
-              <Chip
-                style={{ maxWidth: "50%" }}
-                id={"collectionChip " + collection.uuid}
-                label={collection.name}
-                {...getTagProps({ index })}
-              />
-            </Tooltip>
-          ))
-        }
-        onChange={(_, value: Collection[]) => {
-          onSelectionChange(value);
-        }}
-        value={value ?? []}
-        options={collections}
-        disableCloseOnSelect
-        getOptionLabel={(collection) => collection.name}
-        getOptionSelected={(collection, selected) =>
-          selected.uuid === collection.uuid
-        }
-        renderOption={(collection, { selected }) => (
-          <>
-            <Checkbox
-              icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-              checkedIcon={<CheckBoxIcon fontSize="small" />}
-              checked={selected}
+    <Autocomplete
+      multiple
+      limitTags={2}
+      renderTags={(
+        collections: Collection[],
+        getTagProps: AutocompleteGetTagProps
+      ) =>
+        collections.map((collection: Collection, index: number) => (
+          <Tooltip title={collection.name}>
+            <Chip
+              style={{ maxWidth: "50%" }}
+              id={"collectionChip " + collection.uuid}
+              label={collection.name}
+              {...getTagProps({ index })}
             />
-            {collection.name}
-          </>
-        )}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            variant="outlined"
-            label={collectionSelectorStrings.title}
-            placeholder={collectionSelectorStrings.title}
+          </Tooltip>
+        ))
+      }
+      onChange={(_, value: Collection[]) => {
+        onSelectionChange(value);
+      }}
+      value={value ?? []}
+      options={collections}
+      disableCloseOnSelect
+      getOptionLabel={(collection) => collection.name}
+      getOptionSelected={(collection, selected) =>
+        selected.uuid === collection.uuid
+      }
+      renderOption={(collection, { selected }) => (
+        <>
+          <Checkbox
+            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+            checkedIcon={<CheckBoxIcon fontSize="small" />}
+            checked={selected}
           />
-        )}
-      />
-    </div>
+          {collection.name}
+        </>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="outlined"
+          label={collectionSelectorStrings.title}
+          placeholder={collectionSelectorStrings.title}
+        />
+      )}
+    />
   );
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -15,10 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Checkbox, TextField } from "@material-ui/core";
+import { Checkbox, Chip, TextField, Tooltip } from "@material-ui/core";
 import CheckBoxIcon from "@material-ui/icons/CheckBox";
 import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
-import { Autocomplete } from "@material-ui/lab";
+import { Autocomplete, AutocompleteGetTagProps } from "@material-ui/lab";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
@@ -26,6 +26,7 @@ import {
   Collection,
   collectionListSummary,
 } from "../../modules/CollectionsModule";
+import { isSelectionSessionOpen } from "../../modules/LegacySelectionSessionModule";
 import { languageStrings } from "../../util/langstrings";
 import useError from "../../util/useError";
 
@@ -71,6 +72,27 @@ export const CollectionSelector = ({
       multiple
       fullWidth
       limitTags={2}
+      renderTags={
+        /**
+         * If we are in a selection session, limit the max width of the chips
+         * so as to prevent overlapping with the selection panel. 132px is the
+         * widest a chip can be before it starts to increase the width of the
+         * surrounding Autocomplete component.
+         */
+        isSelectionSessionOpen()
+          ? (collections: Collection[], getTagProps: AutocompleteGetTagProps) =>
+              collections.map((collection: Collection, index: number) => (
+                <Tooltip title={collection.name}>
+                  <Chip
+                    style={{ maxWidth: "132px" }}
+                    id={"collectionChip " + collection.uuid}
+                    label={collection.name}
+                    {...getTagProps({ index })}
+                  />
+                </Tooltip>
+              ))
+          : undefined
+      }
       onChange={(_, value: Collection[]) => {
         onSelectionChange(value);
       }}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines]
- [x] screenshots are included showing significant UI changes

##### Description of change
When in a selection session (as the selection panel takes up room) or on a small screen (there's less room to begin with), the Refine Search Panel has less width. So the collection selector when getting populated with chips can grow too big and force the panel to widen which can cause overlap with the selection panel or the side of the screen. 

This is addressed in this PR by changing the ratio of search panel width to refine panel width from 9:3 to 8:4. 

This change also limits the width of the chips so they can't take up more than 50 percent of the collection selector's total width.

In order to not lose information with the now truncated collection names, I have added in a tooltip for these chips which displays the full name.

Before: 
https://user-images.githubusercontent.com/24543345/104384442-942e3680-5585-11eb-99b9-f65bd1247fde.mp4

After:
https://user-images.githubusercontent.com/24543345/104986406-14153e80-5a67-11eb-95ff-47af1b393312.mp4




<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
