### PR TITLE
chore(front-end): Rename ExpansionPanelXyz

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   CircularProgress,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
   List,
   ListItem,
   ListItemText,
@@ -119,7 +119,7 @@ const SettingsPage = ({
    * @param settings - settings of the category
    * @returns {ReactElement} Either a List or UISettingEditor, depending on the category
    */
-  const expansionPanelContent = ({
+  const accordionContent = ({
     category,
     settings,
   }: SettingGroup): ReactElement => {
@@ -129,7 +129,7 @@ const SettingsPage = ({
       );
     }
     return (
-      <ExpansionPanelDetails>
+      <AccordionDetails>
         <List>
           {settings.map((setting) => (
             <ListItem key={setting.id}>
@@ -140,7 +140,7 @@ const SettingsPage = ({
             </ListItem>
           ))}
         </List>
-      </ExpansionPanelDetails>
+      </AccordionDetails>
     );
   };
 
@@ -192,15 +192,15 @@ const SettingsPage = ({
           settingGroups.map((group) => {
             const { name, desc } = group.category;
             return (
-              <ExpansionPanel key={name}>
-                <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+              <Accordion key={name}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                   <Typography className={classes.heading}>{name}</Typography>
                   <Typography className={classes.secondaryHeading}>
                     {desc}
                   </Typography>
-                </ExpansionPanelSummary>
-                {expansionPanelContent(group)}
-              </ExpansionPanel>
+                </AccordionSummary>
+                {accordionContent(group)}
+              </Accordion>
             );
           })
         )

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/UISettingEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/UISettingEditor.tsx
@@ -15,25 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  AccordionDetails,
+  Button,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  Switch,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 import * as React from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { AppConfig } from "../AppConfig";
+import { routes } from "../mainui/routes";
 import {
   fetchUISetting,
   saveUISetting,
 } from "../modules/GeneralSettingsModule";
-import {
-  ExpansionPanelDetails,
-  Button,
-  FormControl,
-  FormControlLabel,
-  Switch,
-  Grid,
-} from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
-import { Link } from "react-router-dom";
-import { routes } from "../mainui/routes";
 import { languageStrings } from "../util/langstrings";
-import { AppConfig } from "../AppConfig";
-import { useEffect, useState } from "react";
 import useError from "../util/useError";
 
 const useStyles = makeStyles({
@@ -105,7 +105,7 @@ const UISettingEditor = (props: UISettingEditorProps) => {
   };
 
   return (
-    <ExpansionPanelDetails>
+    <AccordionDetails>
       <Grid container direction="column">
         <Grid item>
           <div className={classes.enableNewUIColumn}>
@@ -148,7 +148,7 @@ const UISettingEditor = (props: UISettingEditorProps) => {
           </Link>
         </Grid>
       </Grid>
-    </ExpansionPanelDetails>
+    </AccordionDetails>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

A ways back MUI renamed ExpansionPanel to Accordion. All still worked
but we'd get hit with extra errors in the console in development builds.
Plus, at some point they'll simply remove ExpansionPanel.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
