### PR TITLE
refactor: convert plain functions to generate JSX into react component functions

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SettingsPage.tsx
@@ -31,7 +31,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
-import { ReactElement, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { generateFromError } from "../api/errors";
 import {
@@ -119,10 +119,7 @@ const SettingsPage = ({
    * @param settings - settings of the category
    * @returns {ReactElement} Either a List or UISettingEditor, depending on the category
    */
-  const accordionContent = ({
-    category,
-    settings,
-  }: SettingGroup): ReactElement => {
+  const AccordionContent = ({ category, settings }: SettingGroup) => {
     if (category.name === languageStrings.settings.ui.name) {
       return (
         <UISettingEditor refreshUser={refreshUser} handleError={setError} />
@@ -134,7 +131,7 @@ const SettingsPage = ({
           {settings.map((setting) => (
             <ListItem key={setting.id}>
               <ListItemText
-                primary={settingLink(setting)}
+                primary={<SettingLink {...setting} />}
                 secondary={setting.description}
               />
             </ListItem>
@@ -149,7 +146,7 @@ const SettingsPage = ({
    * @param {GeneralSetting} setting - A oEQ general setting
    * @returns {ReactElement} A link to the setting's page
    */
-  const settingLink = (setting: OEQ.Settings.GeneralSetting): ReactElement => {
+  const SettingLink = (setting: OEQ.Settings.GeneralSetting) => {
     let link = <div />;
     if (setting.links.route) {
       link = <Link to={setting.links.route}>{setting.name}</Link>;
@@ -199,7 +196,7 @@ const SettingsPage = ({
                     {desc}
                   </Typography>
                 </AccordionSummary>
-                {accordionContent(group)}
+                <AccordionContent {...group} />
               </Accordion>
             );
           })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Converts plain functions to generate JSX into react component functions.
This allows the react dev tools to inspect the props and state of the functions, and brings more consistency to the codebase.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
