### PR TITLE
Further refactor to address react-hooks/exhaustive-deps

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -327,6 +327,11 @@ export const LegacyContent = React.memo(function LegacyContent({
         });
       },
     };
+    // The below is missing `submitCurrentForm` and `stdSubmit` (which depends on
+    // `submitCurrentForm`) from the dependency list. However to add that in would require more
+    // effort than justified - best to rework with a reducer. Long term we aim to not even have the
+    // whole LegacyContent tree, so for now we leave this as is.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
   React.useEffect(() => {
@@ -338,6 +343,10 @@ export const LegacyContent = React.memo(function LegacyContent({
       else urlValues[key] = [val];
     });
     submitCurrentForm(true, true, undefined, urlValues);
+    // The below is missing `submitCurrentForm` from the dependency list. However to add that in
+    // would require more effort than justified - best to rework with a reducer. Long term we aim
+    // to not even have the whole LegacyContent tree, so for now we leave this as is.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname, search, locationKey]);
 
   React.useEffect(
@@ -348,7 +357,7 @@ export const LegacyContent = React.memo(function LegacyContent({
           ? templatePropsForLegacy(content)
           : templateDefaults("Missing content!")),
       })),
-    [content]
+    [content, updateTemplate]
   );
 
   return !updatingContent && content ? (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
@@ -96,9 +96,9 @@ const MainMenu = ({ menuGroups, onClickNavItem }: MainMenuProps) => {
 
   return (
     <div id="menulinks">
-      {menuGroups.map((group, ind) => (
-        <React.Fragment key={ind}>
-          {ind > 0 && <Divider />}
+      {menuGroups.map((group, index) => (
+        <React.Fragment key={index}>
+          {index > 0 && <Divider />}
           <List component="nav">{group.map(navItem)}</List>
         </React.Fragment>
       ))}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
@@ -31,10 +31,22 @@ import { Link } from "react-router-dom";
 import { useStyles } from "./Template";
 
 interface MainMenuProps {
+  /**
+   * Groups of menu items to display in the menu - typically separated by `Divider`s. These groups
+   * are normally computed on the server and based on the current user.
+   */
   menuGroups: Array<Array<OEQ.LegacyContent.MenuItem>>;
+  /**
+   * Event handler for when a menu item is clicked - commonly used to show/hide the drawer which the
+   * menu may be residing in at certain responsive break points.
+   */
   onClickNavItem: () => void;
 }
 
+/**
+ * A component responsible for the menu often found in the left hand side bar (or drawer) of the
+ * main layout.
+ */
 const MainMenu = ({ menuGroups, onClickNavItem }: MainMenuProps) => {
   const classes = useStyles(useTheme());
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
@@ -1,0 +1,97 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Divider,
+  Icon,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+  useTheme,
+} from "@material-ui/core";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { Link } from "react-router-dom";
+import { useStyles } from "./Template";
+
+interface MainMenuProps {
+  menuGroups: Array<Array<OEQ.LegacyContent.MenuItem>>;
+  onClickNavItem: () => void;
+}
+
+const MainMenu = ({ menuGroups, onClickNavItem }: MainMenuProps) => {
+  const classes = useStyles(useTheme());
+
+  const navItem = (item: OEQ.LegacyContent.MenuItem, ind: number) => (
+    <ListItem
+      component={(p) => {
+        const props = {
+          ...p,
+          rel: item.newWindow ? "noopener noreferrer" : undefined,
+          target: item.newWindow ? "_blank" : undefined,
+          onClick: onClickNavItem,
+        };
+        return item.route ? (
+          <Link {...props} to={item.route} />
+        ) : (
+          <a {...props} href={item.href}>
+            {}
+          </a>
+        );
+      }}
+      key={ind}
+      button
+    >
+      <ListItemIcon>
+        {item.iconUrl ? (
+          <img src={item.iconUrl} alt={item.title} />
+        ) : (
+          <Icon color="inherit" className={classes.menuIcon}>
+            {item.systemIcon ? item.systemIcon : "folder"}
+          </Icon>
+        )}
+      </ListItemIcon>
+      <ListItemText
+        disableTypography
+        primary={
+          <Typography
+            variant="subtitle1"
+            className={classes.menuItem}
+            component="div"
+          >
+            {item.title}
+          </Typography>
+        }
+      />
+    </ListItem>
+  );
+
+  return (
+    <div id="menulinks">
+      {menuGroups.map((group, ind) => (
+        <React.Fragment key={ind}>
+          {ind > 0 && <Divider />}
+          <List component="nav">{group.map(navItem)}</List>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default React.memo(MainMenu);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -534,13 +534,13 @@ export const Template = ({
               {badgedLink(
                 <AssignmentIcon />,
                 itemCounts.tasks,
-                routes.TaskList.to,
+                legacyPageUrl(routes.TaskList.to),
                 topBarString.tasks
               )}
               {badgedLink(
                 <NotificationsIcon />,
                 itemCounts.notifications,
-                routes.Notifications.to,
+                legacyPageUrl(routes.Notifications.to),
                 topBarString.notifications
               )}
             </Hidden>
@@ -565,9 +565,17 @@ export const Template = ({
               anchorOrigin={{ vertical: "top", horizontal: "right" }}
               transformOrigin={{ vertical: "top", horizontal: "right" }}
             >
-              {linkItem(routes.Logout.to, true, strings.menu.logout)}
+              {linkItem(
+                legacyPageUrl(routes.Logout.to),
+                true,
+                strings.menu.logout
+              )}
               {currentUser.prefsEditable &&
-                linkItem(routes.UserPreferences.to, false, strings.menu.prefs)}
+                linkItem(
+                  legacyPageUrl(routes.UserPreferences.to),
+                  false,
+                  strings.menu.prefs
+                )}
             </Menu>
           </>
         )}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -19,15 +19,9 @@ import {
   AppBar,
   Badge,
   CssBaseline,
-  Divider,
   Drawer,
   Hidden,
-  Icon,
   IconButton,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Menu,
   MenuItem,
   Toolbar,
@@ -51,7 +45,8 @@ import { ErrorResponse } from "../api/errors";
 import MessageInfo from "../components/MessageInfo";
 import { guestUser, PageContent } from "../legacycontent/LegacyContent";
 import { languageStrings } from "../util/langstrings";
-import { routes } from "./routes";
+import MainMenu from "./MainMenu";
+import { legacyPageUrl, routes } from "./routes";
 import ScreenOptions from "./ScreenOptions";
 
 export type MenuMode = "HIDDEN" | "COLLAPSED" | "FULL";
@@ -354,14 +349,10 @@ export const Template = ({
   }, [title]);
 
   React.useEffect(() => {
-    updateMetaTags(metaTags);
-  }, [metaTags]);
-
-  function updateMetaTags(tags: string | undefined) {
     const head = document.head;
-    if (tags) {
+    if (metaTags) {
       // The meta tags generated on the server side, separated by new line symbols
-      const newMetaTags = tags.split("\n");
+      const newMetaTags = metaTags.split("\n");
       newMetaTags.forEach((newMetaTag) => {
         head.appendChild(
           document.createRange().createContextualFragment(newMetaTag)
@@ -381,7 +372,7 @@ export const Template = ({
         }
       });
     }
-  }
+  }, [metaTags, googleMetaTags]);
 
   function linkItem(
     link: LocationDescriptor,
@@ -429,52 +420,6 @@ export const Template = ({
     );
   }
 
-  function navItem(item: OEQ.LegacyContent.MenuItem, ind: number) {
-    return (
-      <ListItem
-        component={(p) => {
-          const props = {
-            ...p,
-            rel: item.newWindow ? "noopener noreferrer" : undefined,
-            target: item.newWindow ? "_blank" : undefined,
-            onClick: () => setNavMenuOpen(false),
-          };
-          return item.route ? (
-            <Link {...props} to={item.route} />
-          ) : (
-            <a {...props} href={item.href}>
-              {}
-            </a>
-          );
-        }}
-        key={ind}
-        button
-      >
-        <ListItemIcon>
-          {item.iconUrl ? (
-            <img src={item.iconUrl} alt={item.title} />
-          ) : (
-            <Icon color="inherit" className={classes.menuIcon}>
-              {item.systemIcon ? item.systemIcon : "folder"}
-            </Icon>
-          )}
-        </ListItemIcon>
-        <ListItemText
-          disableTypography
-          primary={
-            <Typography
-              variant="subtitle1"
-              className={classes.menuItem}
-              component="div"
-            >
-              {item.title}
-            </Typography>
-          }
-        />
-      </ListItem>
-    );
-  }
-
   const hasMenu = menuMode !== "HIDDEN";
 
   const menuContent = React.useMemo(
@@ -482,18 +427,14 @@ export const Template = ({
       <div className={classes.logo}>
         <img role="presentation" src={logoURL} alt="Logo" />
         {hasMenu && (
-          <div id="menulinks">
-            {currentUser.menuGroups.map((group, ind) => (
-              <React.Fragment key={ind}>
-                {ind > 0 && <Divider />}
-                <List component="nav">{group.map(navItem)}</List>
-              </React.Fragment>
-            ))}
-          </div>
+          <MainMenu
+            menuGroups={currentUser.menuGroups}
+            onClickNavItem={() => setNavMenuOpen(false)}
+          />
         )}
       </div>
     ),
-    [currentUser, hasMenu]
+    [classes.logo, currentUser, hasMenu]
   );
 
   const itemCounts = currentUser.counts

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -48,25 +48,45 @@ export interface BaseOEQRouteComponentProps {
   isReloadNeeded: boolean;
 }
 
-type To = (uuid: string) => string;
-type ToVersion = (uuid: string, version: number) => string;
+type ToFunc = (uuid: string) => string;
+type ToVersionFunc = (uuid: string, version: number) => string;
 
-export interface OEQRoute<T> {
-  component?:
-    | React.ComponentType<BaseOEQRouteComponentProps>
-    | React.ComponentType<T>;
+export interface OEQRouteNewUI {
+  component?: React.ComponentType<BaseOEQRouteComponentProps>;
   render?: (props: BaseOEQRouteComponentProps) => React.ReactNode;
-  path?: string;
-  exact?: boolean;
-  sensitive?: boolean;
-  strict?: boolean;
-  to?: string | To | ToVersion;
+  path: string;
+}
+
+interface OEQRouteTo<T = string | ToFunc | ToVersionFunc> {
+  to: T;
 }
 
 interface Routes {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: OEQRoute<any>;
+  AdvancedSearch: OEQRouteTo<ToFunc>;
+  CloudProviders: OEQRouteNewUI;
+  ContentIndexSettings: OEQRouteNewUI;
+  FacetedSearchSetting: OEQRouteNewUI;
+  LoginNoticeConfig: OEQRouteNewUI;
+  Logout: OEQRouteTo<string>;
+  Notifications: OEQRouteTo<string>;
+  RemoteSearch: OEQRouteTo<ToFunc>;
+  SearchFilterSettings: OEQRouteNewUI;
+  SearchSettings: OEQRouteNewUI;
+  Settings: OEQRouteNewUI & OEQRouteTo<string>;
+  TaskList: OEQRouteTo<string>;
+  ThemeConfig: OEQRouteNewUI;
+  UserPreferences: OEQRouteTo<string>;
+  ViewItem: OEQRouteTo<ToVersionFunc>;
 }
+
+/**
+ * Type guard for when needing to dynamically determine what kind of route is being used.
+ *
+ * @param route the potential route to check
+ */
+export const isNewUIRoute = (route: unknown): route is OEQRouteNewUI =>
+  (route as OEQRouteNewUI).component !== undefined ||
+  (route as OEQRouteNewUI).render !== undefined;
 
 /**
  * Simple validator to allow direct use of an expected to URL route - considering they're hardcoded
@@ -74,7 +94,7 @@ interface Routes {
  *
  * @param to route to validate
  */
-export const legacyPageUrl = (to?: string | To | ToVersion): string => {
+export const legacyPageUrl = (to?: string | ToFunc | ToVersionFunc): string => {
   if (typeof to === "string") {
     return to;
   }
@@ -83,28 +103,12 @@ export const legacyPageUrl = (to?: string | To | ToVersion): string => {
 };
 
 export const routes: Routes = {
-  Settings: {
-    path: "(/access/settings.do|/page/settings)",
-    to: "/page/settings",
-    component: SettingsPage,
-  },
   AdvancedSearch: {
     to: (uuid: string) => `/advanced/searching.do?in=P${uuid}&editquery=true`,
   },
-  RemoteSearch: {
-    // `uc` parameter comes from sections code (AbstractRootSearchSection.Model.java). Setting it to
-    // true clears out the Session State for Remote Repository pages. This replicates the behaviour
-    // for links inside the 'Within' dropdown in the legacy UI.
-    // See com.tle.web.searching.section.SearchQuerySection.forwardToRemote
-    to: (uuid: string) => `/access/z3950.do?.repository=${uuid}&uc=true`,
-  },
-  SearchSettings: {
-    path: "/page/searchsettings",
-    component: SearchPageSettings,
-  },
-  SearchFilterSettings: {
-    path: "/page/searchfiltersettings",
-    component: SearchFilterPage,
+  CloudProviders: {
+    path: "/page/cloudprovider",
+    component: CloudProviderListPage,
   },
   ContentIndexSettings: {
     path: "/page/contentindexsettings",
@@ -114,29 +118,45 @@ export const routes: Routes = {
     path: "/page/facetedsearchsettings",
     component: FacetedSearchSettingsPage,
   },
-  ViewItem: {
-    to: (uuid: string, version: number) => `/items/${uuid}/${version}/`,
-  },
-  ThemeConfig: { path: "/page/themeconfiguration", component: ThemePage },
   LoginNoticeConfig: {
     path: "/page/loginconfiguration",
     component: LoginNoticeConfigPage,
-  },
-  CloudProviders: {
-    path: "/page/cloudprovider",
-    component: CloudProviderListPage,
-  },
-  Notifications: {
-    to: "/access/notifications.do",
-  },
-  TaskList: {
-    to: "/access/tasklist.do",
   },
   Logout: {
     // lack of '/' is significant
     to: "logon.do?logout=true",
   },
+  Notifications: {
+    to: "/access/notifications.do",
+  },
+  RemoteSearch: {
+    // `uc` parameter comes from sections code (AbstractRootSearchSection.Model.java). Setting it to
+    // true clears out the Session State for Remote Repository pages. This replicates the behaviour
+    // for links inside the 'Within' dropdown in the legacy UI.
+    // See com.tle.web.searching.section.SearchQuerySection.forwardToRemote
+    to: (uuid: string) => `/access/z3950.do?.repository=${uuid}&uc=true`,
+  },
+  Settings: {
+    path: "(/access/settings.do|/page/settings)",
+    to: "/page/settings",
+    component: SettingsPage,
+  },
+  SearchFilterSettings: {
+    path: "/page/searchfiltersettings",
+    component: SearchFilterPage,
+  },
+  SearchSettings: {
+    path: "/page/searchsettings",
+    component: SearchPageSettings,
+  },
+  TaskList: {
+    to: "/access/tasklist.do",
+  },
+  ThemeConfig: { path: "/page/themeconfiguration", component: ThemePage },
   UserPreferences: {
     to: "/access/user.do",
+  },
+  ViewItem: {
+    to: (uuid: string, version: number) => `/items/${uuid}/${version}/`,
   },
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/routes.tsx
@@ -63,7 +63,26 @@ export interface OEQRoute<T> {
   to?: string | To | ToVersion;
 }
 
-export const routes = {
+interface Routes {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: OEQRoute<any>;
+}
+
+/**
+ * Simple validator to allow direct use of an expected to URL route - considering they're hardcoded
+ * if an expected one is missing - or of the wrong type - then we have a code issue.
+ *
+ * @param to route to validate
+ */
+export const legacyPageUrl = (to?: string | To | ToVersion): string => {
+  if (typeof to === "string") {
+    return to;
+  }
+
+  throw new TypeError("Expected legacy page URL is undefined");
+};
+
+export const routes: Routes = {
   Settings: {
     path: "(/access/settings.do|/page/settings)",
     to: "/page/settings",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchSettingsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchSettingsModule.ts
@@ -55,7 +55,7 @@ export enum ContentIndex {
 }
 
 export const SEARCH_SETTINGS_URL = "api/settings/search";
-export const CLOUD_SETTINGS_URL = "api/settings/search/cloud";
+export const CLOUD_SETTINGS_URL = `${SEARCH_SETTINGS_URL}/cloud`;
 
 export const getSearchSettingsFromServer = () =>
   new Promise(

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -69,6 +69,13 @@ import {
   determineViewer,
 } from "../../modules/ViewerModule";
 
+const {
+  searchResult: searchResultStrings,
+  comments: commentStrings,
+  starRatings: ratingStrings,
+  selectResource: selectResourceStrings,
+} = languageStrings.searchpage;
+
 const useStyles = makeStyles((theme: Theme) => {
   return {
     inline: {
@@ -172,13 +179,6 @@ export default function SearchResult({
     setAttachmentsWithViewerDetails,
   ] = useState<AttachmentAndViewerDetails[]>([]);
 
-  const {
-    searchResult: searchResultStrings,
-    comments: commentStrings,
-    starRatings: ratingStrings,
-    selectResource: selectResourceStrings,
-  } = languageStrings.searchpage;
-
   // Responsible for determining the MIME type viewer for the provided attachments
   useEffect(() => {
     let mounted = true;
@@ -222,7 +222,7 @@ export default function SearchResult({
       // Short circuit if this component is unmounted before all its comms are done.
       mounted = false;
     };
-  }, [attachments, getViewerDetails]);
+  }, [attachments, getViewerDetails, handleError]);
 
   // In Selection Session, make each attachment draggable.
   useEffect(() => {
@@ -231,7 +231,7 @@ export default function SearchResult({
         prepareDraggable(attachment.id, false);
       });
     }
-  }, [attachmentsWithViewerDetails]);
+  }, [attachmentsWithViewerDetails, inStructured]);
 
   const handleAttachmentPanelClick = (event: SyntheticEvent) => {
     /** prevents the SearchResult onClick from firing when attachment panel is clicked */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaNodeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaNodeSelector.tsx
@@ -89,13 +89,14 @@ export default function SchemaNodeSelector({
   const strings =
     languageStrings.settings.searching.facetedsearchsetting.schemaSelector
       .nodeSelector;
+
   React.useEffect(() => {
     if (tree) {
       setRenderedTree(renderTree(tree));
       setExpanded([]);
       setSelectedNode("");
     }
-  }, [tree]);
+  }, [tree, setSelectedNode]);
 
   return (
     <>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
@@ -40,6 +40,9 @@ interface SchemaSelectorProps {
   setSchemaNode: (node: string) => void;
 }
 
+const strings =
+  languageStrings.settings.searching.facetedsearchsetting.schemaSelector;
+
 /**
  * This component defines a schema selector, for selecting a schema and then a node within.
  * When a schema is selected, it will display that schema within a SchemaNodeSelector.
@@ -52,8 +55,7 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
   const [schema, setSchema] = React.useState<SchemaNode>();
   const [schemaList, setSchemaList] = React.useState<ReactElement[]>([]);
   const [schemaNodePath, setSchemaNodePath] = React.useState<string>("");
-  const strings =
-    languageStrings.settings.searching.facetedsearchsetting.schemaSelector;
+
   React.useEffect(() => {
     schemaListSummary().then((schemas) => {
       const defaultListItem = [[undefined, strings.selectASchema]];
@@ -80,7 +82,7 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
     if (schemaNodePath?.trim()) {
       setSchemaNode(schemaNodePath);
     }
-  }, [schemaNodePath]);
+  }, [schemaNodePath, setSchemaNode]);
 
   return (
     <Grid container direction="column" spacing={0}>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Alright, yet another batch of addressing `react-hooks/exhaustive-deps` ESLint warnings. This leaves us with only 5 which are all focused around `SearchPage` (including `DateModifiedSelector` as that needs `SearchPage` fixed first).

Components addressed:

- `SearchPageSettings`
- `ContentIndexSettings`
- `SchemaSelector`
- `SchemaNodeSelector`
- `SearchResult`
- `IndexPage`
- `Template`
- `LegacyContent`

In `LegacyContent` I took a pragmatic approach and resorted to suppressing the 2/3 warnings. This is because the amount of effort was not justified when: 1. we plan to get rid of this long term; and 2. a ton of effort has just been expended on it to get it in better shape. (It feels like it would require treatment similar to what will be needed for `SearchPage`.)

I did observe other oddities - like error handling/wrapping in `SearchPageSettings`/`ContentIndexSettings` however these are planned to be addressed later. So overall, I stayed pretty close to task of just refactoring to address hook dependency issues - even when moving code around I tried to mostly leave as is - e.g. code in the new `MainMenu.tsx`.

While this is up for review, I'll now branch off branch and start work on `SearchPage`. I believe it's state and complexity is well past the point where a reducer should be employed, and now that we're at the start of the release it should be a good time to try. This will also ease the management of the dependency and attempted flow of effects. If successful, then that'll bring us to 0 warnings and we can swap this over to an error on failure.

That work will be in a future PR - combing here I think would've made things unmanageable.

I have done some manual testing, as well as executing the core Jest test suite and things have looked good. But I look forward to seeing what CI thinks.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
