### PR TITLE
Refactor of SearchPage to useReducer to address last set of ESLint react-hooks/exhaustive-deps

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import { makeStyles } from "@material-ui/core/styles";
+import LuxonUtils from "@date-io/luxon";
 import {
   FormControl,
   Grid,
@@ -24,16 +23,17 @@ import {
   MenuItem,
   Select,
 } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 import {
   KeyboardDatePicker,
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
-import type { DateRange } from "../modules/SearchModule";
-import SettingsToggleSwitch from "./SettingsToggleSwitch";
-import { ReactNode, useEffect, useRef, useState } from "react";
-import { languageStrings } from "../util/langstrings";
-import LuxonUtils from "@date-io/luxon";
 import { DateTime } from "luxon";
+import * as React from "react";
+import { ReactNode, useEffect, useState } from "react";
+import type { DateRange } from "../modules/SearchModule";
+import { languageStrings } from "../util/langstrings";
+import SettingsToggleSwitch from "./SettingsToggleSwitch";
 
 interface DatePickerProps {
   /**
@@ -128,18 +128,13 @@ export const DateRangeSelector = ({
   );
   const [showCalenderIcon, setShowCalenderIcon] = useState<boolean>(false);
 
-  const isInitialRender = useRef(true);
+  // Only when prop dateRange is cleared, clear stateDateRange as well.
   useEffect(() => {
-    if (isInitialRender.current) {
-      isInitialRender.current = false;
-      return;
-    }
-    // When state is cleared, do not proceed to avoid duplicated search.
-    if (!stateDateRange) {
-      return;
-    }
-    const start = stateDateRange?.start;
-    const end = stateDateRange?.end;
+    setStateDateRange(dateRange);
+  }, [dateRange]);
+
+  const handleDateRangeChange = (range: DateRange): void => {
+    const { start, end } = range;
     const isStartValid = start && DateTime.fromJSDate(start).isValid;
     const isEndValid = end && DateTime.fromJSDate(end).isValid;
 
@@ -154,15 +149,9 @@ export const DateRangeSelector = ({
       start && end ? isStartValid && isEndValid && start <= end : false;
     // Call onDateRangeChange for above four cases.
     if (openStart || openEnd || openRange || closedRange) {
-      onDateRangeChange(stateDateRange);
+      onDateRangeChange(range);
     }
-  }, [stateDateRange]);
-
-  // Only when prop dateRange is cleared, clear stateDateRange as well.
-  useEffect(() => {
-    setStateDateRange(dateRange);
-  }, [dateRange]);
-
+  };
   /**
    * Provide labels and values for options of pre-defined date ranges.
    */
@@ -238,6 +227,7 @@ export const DateRangeSelector = ({
   const handleQuickDateOptionChange = (option: string): void => {
     const dateRange = dateOptionToDateRangeConverter(option);
     setStateDateRange(dateRange);
+    handleDateRangeChange(dateRange);
   };
 
   const quickOptionSelector: ReactNode = (
@@ -304,12 +294,14 @@ export const DateRangeSelector = ({
             label={label}
             // When value is undefined use null instead so nothing is displayed in the TextField.
             value={value ?? null}
-            onChange={(newDate, _) =>
-              setStateDateRange({
+            onChange={(newDate, _) => {
+              const newRange = {
                 ...stateDateRange,
                 [field]: newDate?.toJSDate(),
-              })
-            }
+              };
+              setStateDateRange(newRange);
+              handleDateRangeChange(newRange);
+            }}
           />
         </Grid>
       );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -290,7 +290,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
   // In Selection Session, once a new search result is returned, make each
   // new search result Item draggable. Could probably merge into 'searching'
-  // effect, however this is only required while selections sessions still
+  // effect, however this is only required while selection sessions still
   // involve legacy content.
   useEffect(() => {
     if (state.status === "success" && isSelectionSessionInStructured()) {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -79,7 +79,7 @@ import {
 import StatusSelector from "./components/StatusSelector";
 
 // destructure strings import
-const searchStrings = languageStrings.searchpage;
+const { searchpage: searchStrings } = languageStrings;
 const {
   title: dateModifiedSelectorTitle,
   quickOptionDropdown,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -538,32 +538,41 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     },
   ];
 
-  const renderClassifications = () => {
-    if (
-      state.status === "success" &&
-      state.classifications.length > 0 &&
-      state.classifications.some((c) => c.categories.length > 0)
-    ) {
-      return (
-        <Grid item>
-          <Card>
-            <CardContent>
-              <Typography variant="h5">
-                {languageStrings.searchpage.categorySelector.title}
-              </Typography>
-              <CategorySelector
-                classifications={state.classifications}
-                onSelectedCategoriesChange={handleSelectedCategoriesChange}
-                selectedCategories={searchPageOptions.selectedCategories}
-              />
-            </CardContent>
-          </Card>
-        </Grid>
-      );
-    }
+  const Classifications = ({
+    classifications,
+    onChange,
+    currentSelections,
+  }: {
+    classifications: Classification[];
+    onChange: (selectedCategories: SelectedCategories[]) => void;
+    currentSelections?: SelectedCategories[];
+  }) => (
+    <Grid item>
+      <Card>
+        <CardContent>
+          <Typography variant="h5">
+            {languageStrings.searchpage.categorySelector.title}
+          </Typography>
+          <CategorySelector
+            classifications={classifications}
+            onSelectedCategoriesChange={onChange}
+            selectedCategories={currentSelections}
+          />
+        </CardContent>
+      </Card>
+    </Grid>
+  );
 
-    return null;
-  };
+  const renderClassifications = () =>
+    state.status === "success" &&
+    state.classifications.length > 0 &&
+    state.classifications.some((c) => c.categories.length > 0) ? (
+      <Classifications
+        classifications={state.classifications}
+        onChange={handleSelectedCategoriesChange}
+        currentSelections={searchPageOptions.selectedCategories}
+      />
+    ) : null;
 
   const {
     available: totalCount,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -20,7 +20,7 @@ import * as OEQ from "@openequella/rest-api-client";
 
 import { isEqual, pick } from "lodash";
 import * as React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import { useHistory, useLocation } from "react-router";
 import { Static } from "runtypes";
 import { generateFromError } from "../api/errors";
@@ -35,6 +35,12 @@ import {
 } from "../mainui/Template";
 import { getAdvancedSearchesFromServer } from "../modules/AdvancedSearchModule";
 import type { Collection } from "../modules/CollectionsModule";
+import {
+  buildSelectionSessionAdvancedSearchLink,
+  buildSelectionSessionRemoteSearchLink,
+  isSelectionSessionInStructured,
+  prepareDraggable,
+} from "../modules/LegacySelectionSessionModule";
 import { getRemoteSearchesFromServer } from "../modules/RemoteSearchModule";
 import {
   Classification,
@@ -55,12 +61,6 @@ import {
   SearchSettings,
   SortOrder,
 } from "../modules/SearchSettingsModule";
-import {
-  prepareDraggable,
-  buildSelectionSessionAdvancedSearchLink,
-  buildSelectionSessionRemoteSearchLink,
-  isSelectionSessionInStructured,
-} from "../modules/LegacySelectionSessionModule";
 import SearchBar from "../search/components/SearchBar";
 import { languageStrings } from "../util/langstrings";
 import { AuxiliarySearchSelector } from "./components/AuxiliarySearchSelector";
@@ -77,6 +77,14 @@ import {
   SearchResultList,
 } from "./components/SearchResultList";
 import StatusSelector from "./components/StatusSelector";
+
+// destructure strings import
+const searchStrings = languageStrings.searchpage;
+const {
+  title: dateModifiedSelectorTitle,
+  quickOptionDropdown,
+} = searchStrings.lastModifiedDateSelector;
+const { title: collectionSelectorTitle } = searchStrings.collectionSelector;
 
 /**
  * Type of search options that are specific to Search page presentation layer.
@@ -102,15 +110,50 @@ interface SearchPageHistoryState {
   filterExpansion: boolean;
 }
 
-const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
-  const searchStrings = languageStrings.searchpage;
-  const {
-    title: dateModifiedSelectorTitle,
-    quickOptionDropdown,
-  } = searchStrings.lastModifiedDateSelector;
-  const { title: collectionSelectorTitle } = searchStrings.collectionSelector;
+type Action =
+  | { type: "init" }
+  | { type: "search"; options: SearchPageOptions }
+  | {
+      type: "search-complete";
+      result: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>;
+      classifications: Classification[];
+    }
+  | { type: "error"; cause: Error };
 
+type State =
+  | { status: "initialising" }
+  | { status: "searching"; options: SearchPageOptions }
+  | {
+      status: "success";
+      result: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>;
+      classifications: Classification[];
+    }
+  | { status: "failure"; cause: Error };
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "init":
+      return { status: "initialising" };
+    case "search":
+      return { status: "searching", options: action.options };
+    case "search-complete":
+      return {
+        status: "success",
+        result: action.result,
+        classifications: action.classifications,
+      };
+    case "error":
+      return { status: "failure", cause: action.cause };
+    default:
+      throw new TypeError("Unexpected action passed to reducer!");
+  }
+};
+
+const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const history = useHistory();
+  const location = useLocation();
+
+  const [state, dispatch] = useReducer(reducer, { status: "initialising" });
   const defaultSearchPageOptions: SearchPageOptions = {
     ...defaultSearchOptions,
     dateRangeQuickModeEnabled: true,
@@ -132,124 +175,136 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     searchPageHistoryState?.filterExpansion ??
       defaultSearchPageHistory.filterExpansion
   );
-  const [pagedSearchResult, setPagedSearchResult] = useState<
-    OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>
-  >(defaultPagedSearchResult);
-  const [showSpinner, setShowSpinner] = useState<boolean>(false);
-  const [showSnackBar, setShowSnackBar] = useState<boolean>(false);
+  const [
+    showSearchCopiedSnackBar,
+    setShowSearchCopiedSnackBar,
+  ] = useState<boolean>(false);
   const [searchSettings, setSearchSettings] = useState<SearchSettings>();
-  const [classifications, setClassifications] = useState<Classification[]>([]);
 
-  const location = useLocation();
+  const handleError = useCallback(
+    (error: Error) => {
+      dispatch({ type: "error", cause: error });
+    },
+    [dispatch]
+  );
 
-  const handleError = (error: Error) => {
-    updateTemplate(templateError(generateFromError(error)));
-  };
+  const search = useCallback(
+    (searchPageOptions: SearchPageOptions): void =>
+      dispatch({ type: "search", options: { ...searchPageOptions } }),
+    [dispatch]
+  );
 
   /**
-   * Update the page title and retrieve Search settings.
+   * Error display -> similar to onError hook, however in the context of reducer need to do manually.
    */
   useEffect(() => {
+    if (state.status === "failure") {
+      updateTemplate(templateError(generateFromError(state.cause)));
+    }
+  }, [state, updateTemplate]);
+
+  /**
+   * Page initialisation -> Update the page title, retrieve Search settings and trigger first
+   * search.
+   */
+  useEffect(() => {
+    if (state.status !== "initialising") {
+      return;
+    }
+
     updateTemplate((tp) => ({
       ...templateDefaults(searchStrings.title)(tp),
     }));
-    // Show spinner before calling API to retrieve Search settings.
-    setShowSpinner(true);
 
     Promise.all([
       getSearchSettingsFromServer(),
       // If the search options are available from browser history, ignore those in the query string.
-      searchPageHistoryState
+      (location.state as SearchPageHistoryState)
         ? Promise.resolve(undefined)
         : queryStringParamsToSearchOptions(location),
     ])
       .then(([searchSettings, queryStringSearchOptions]) => {
         setSearchSettings(searchSettings);
-        if (queryStringSearchOptions)
-          setSearchPageOptions({
-            ...queryStringSearchOptions,
-            dateRangeQuickModeEnabled: false,
-            sortOrder:
-              queryStringSearchOptions.sortOrder ??
-              searchSettings.defaultSearchSort,
-          });
-        else
-          setSearchPageOptions({
-            ...searchPageOptions,
-            sortOrder:
-              searchPageOptions.sortOrder ?? searchSettings.defaultSearchSort,
-          });
+        search(
+          queryStringSearchOptions
+            ? {
+                ...queryStringSearchOptions,
+                dateRangeQuickModeEnabled: false,
+                sortOrder:
+                  queryStringSearchOptions.sortOrder ??
+                  searchSettings.defaultSearchSort,
+              }
+            : {
+                ...searchPageOptions,
+                sortOrder:
+                  searchPageOptions.sortOrder ??
+                  searchSettings.defaultSearchSort,
+              }
+        );
       })
       .catch((e) => {
-        setShowSpinner(false);
         handleError(e);
       });
-  }, []);
+  }, [
+    dispatch,
+    handleError,
+    location,
+    search,
+    searchPageOptions,
+    state.status,
+    updateTemplate,
+  ]);
 
-  const isInitialSearch = useRef(true);
-  // Trigger a search when Search options get changed, but skip the initial values.
+  /**
+   * Searching -> Executing the search (including for classifications) and returning the results.
+   */
   useEffect(() => {
-    if (isInitialSearch.current) {
-      isInitialSearch.current = false;
-    } else {
-      search();
+    if (state.status === "searching") {
+      setSearchPageOptions(state.options);
+      Promise.all([
+        searchItems(state.options),
+        listClassifications(state.options),
+      ])
+        .then(
+          ([result, classifications]: [
+            OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>,
+            Classification[]
+          ]) => {
+            dispatch({
+              type: "search-complete",
+              result: { ...result },
+              classifications: [...classifications],
+            });
+            // Update history
+            history.replace({
+              ...history.location,
+              state: { searchPageOptions: state.options, filterExpansion },
+            });
+            // scroll back up to the top of the page
+            window.scrollTo(0, 0);
+          }
+        )
+        .catch(handleError);
     }
-  }, [searchPageOptions]);
-
-  useEffect(() => {
-    // If search page is open from a URL which has some query params, updating browser
-    // history for the initial search will produce wrong search option for the second
-    // render. This is because in the second render, we ignore the query param conversion
-    // as the history data has higher priority. So the end result is wrong search options
-    // are displayed in the page.
-    if (isInitialSearch && searchPageOptions === defaultSearchPageOptions) {
-      return;
-    }
-    history.replace({
-      ...history.location,
-      state: { searchPageOptions, filterExpansion },
-    });
-  }, [filterExpansion, pagedSearchResult]);
+  }, [dispatch, filterExpansion, handleError, history, state]);
 
   // In Selection Session, once a new search result is returned, make each
-  // new search result Item draggable.
+  // new search result Item draggable. Could probably merge into 'searching'
+  // effect, however this is only required while selections sessions still
+  // involve legacy content.
   useEffect(() => {
-    if (isSelectionSessionInStructured()) {
-      pagedSearchResult.results.forEach(({ uuid }) => {
+    if (state.status === "success" && isSelectionSessionInStructured()) {
+      state.result.results.forEach(({ uuid }) => {
         prepareDraggable(uuid);
       });
     }
-  }, [pagedSearchResult]);
-
-  // When Search options get changed, also update the Classification list.
-  useEffect(() => {
-    if (!isInitialSearch.current) {
-      listClassifications(searchPageOptions)
-        .then((classifications) => setClassifications(classifications))
-        .catch(handleError);
-    }
-  }, [searchPageOptions]);
-
-  /**
-   * Search items with specified search criteria and show a spinner when the search is in progress.
-   */
-  const search = (): void => {
-    setShowSpinner(true);
-    searchItems(searchPageOptions)
-      .then((items: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>) => {
-        setPagedSearchResult(items);
-        // scroll back up to the top of the page
-        window.scrollTo(0, 0);
-      })
-      .catch(handleError)
-      .finally(() => setShowSpinner(false));
-  };
+  }, [state]);
 
   const handleSortOrderChanged = (order: Static<typeof SortOrder>) =>
-    setSearchPageOptions({ ...searchPageOptions, sortOrder: order });
+    search({ ...searchPageOptions, sortOrder: order });
 
   const handleQueryChanged = (query: string) =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       query: query,
       currentPage: 0,
@@ -257,7 +312,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     });
 
   const handleCollectionSelectionChanged = (collections: Collection[]) => {
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       collections: collections,
       currentPage: 0,
@@ -288,23 +343,23 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   };
 
   const handlePageChanged = (page: number) =>
-    setSearchPageOptions({ ...searchPageOptions, currentPage: page });
+    search({ ...searchPageOptions, currentPage: page });
 
   const handleRowsPerPageChanged = (rowsPerPage: number) =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       currentPage: 0,
       rowsPerPage: rowsPerPage,
     });
 
   const handleRawModeChanged = (rawMode: boolean) =>
-    setSearchPageOptions({ ...searchPageOptions, rawMode: rawMode });
+    search({ ...searchPageOptions, rawMode: rawMode });
 
   const handleQuickDateRangeModeChange = (
     quickDateRangeMode: boolean,
     dateRange?: DateRange
   ) =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       dateRangeQuickModeEnabled: quickDateRangeMode,
       // When the mode is changed, the date range may also need to be updated.
@@ -314,28 +369,19 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     });
 
   const handleLastModifiedDateRangeChange = (dateRange?: DateRange) =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       lastModifiedDateRange: dateRange,
       selectedCategories: undefined,
     });
 
   const handleClearSearchOptions = () => {
-    setSearchPageOptions({
+    search({
       ...defaultSearchPageOptions,
       sortOrder: searchSettings?.defaultSearchSort,
     });
     setFilterExpansion(false);
   };
-
-  const copySearchInfoSnackbar = (
-    <MessageInfo
-      open={showSnackBar}
-      onClose={() => setShowSnackBar(false)}
-      title={searchStrings.shareSearchConfirmationText}
-      variant="success"
-    />
-  );
 
   const handleCopySearch = () => {
     //base institution urls have a trailing / that we need to get rid of
@@ -347,34 +393,34 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     navigator.clipboard
       .writeText(searchUrl)
       .then(() => {
-        setShowSnackBar(true);
+        setShowSearchCopiedSnackBar(true);
       })
       .catch(() => handleError);
   };
 
   const handleOwnerChange = (owner: OEQ.UserQuery.UserDetails) =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       owner: { ...owner },
       selectedCategories: undefined,
     });
 
   const handleOwnerClear = () =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       owner: undefined,
       selectedCategories: undefined,
     });
 
   const handleStatusChange = (status: OEQ.Common.ItemStatus[]) =>
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       status: [...status],
       selectedCategories: undefined,
     });
 
   const handleSearchAttachmentsChange = (searchAttachments: boolean) => {
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       searchAttachments: searchAttachments,
     });
@@ -384,14 +430,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     selectedCategories: SelectedCategories[]
   ) => {
     const getSchemaNode = (id: number) => {
-      const node = classifications.find((c) => c.id === id)?.schemaNode;
+      const node =
+        state.status === "success" &&
+        state.classifications.find((c) => c.id === id)?.schemaNode;
       if (!node) {
         throw new Error(`Unable to find schema node for classification ${id}.`);
       }
       return node;
     };
 
-    setSearchPageOptions({
+    search({
       ...searchPageOptions,
       selectedCategories: selectedCategories.map((c) => ({
         ...c,
@@ -490,11 +538,38 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     },
   ];
 
+  const renderClassifications = () => {
+    if (
+      state.status === "success" &&
+      state.classifications.length > 0 &&
+      state.classifications.some((c) => c.categories.length > 0)
+    ) {
+      return (
+        <Grid item>
+          <Card>
+            <CardContent>
+              <Typography variant="h5">
+                {languageStrings.searchpage.categorySelector.title}
+              </Typography>
+              <CategorySelector
+                classifications={state.classifications}
+                onSelectedCategoriesChange={handleSelectedCategoriesChange}
+                selectedCategories={searchPageOptions.selectedCategories}
+              />
+            </CardContent>
+          </Card>
+        </Grid>
+      );
+    }
+
+    return null;
+  };
+
   const {
     available: totalCount,
     highlight: highlights,
     results: searchResults,
-  } = pagedSearchResult;
+  } = state.status === "success" ? state.result : defaultPagedSearchResult;
   return (
     <>
       <Grid container spacing={2}>
@@ -506,12 +581,15 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
                 rawMode={searchPageOptions.rawMode}
                 onQueryChange={handleQueryChanged}
                 onRawModeChange={handleRawModeChanged}
-                doSearch={search}
+                doSearch={() => search(searchPageOptions)}
               />
             </Grid>
             <Grid item xs={12}>
               <SearchResultList
-                showSpinner={showSpinner}
+                showSpinner={
+                  state.status === "initialising" ||
+                  state.status === "searching"
+                }
                 paginationProps={{
                   count: totalCount,
                   currentPage: searchPageOptions.currentPage,
@@ -543,31 +621,16 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
                 showFilterIcon={areCollapsibleFiltersSet()}
               />
             </Grid>
-            {classifications.length > 0 &&
-              classifications.some((c) => c.categories.length > 0) && (
-                <Grid item>
-                  <Card>
-                    <CardContent>
-                      <Typography variant="h5">
-                        {languageStrings.searchpage.categorySelector.title}
-                      </Typography>
-                      <CategorySelector
-                        classifications={classifications}
-                        onSelectedCategoriesChange={
-                          handleSelectedCategoriesChange
-                        }
-                        selectedCategories={
-                          searchPageOptions.selectedCategories
-                        }
-                      />
-                    </CardContent>
-                  </Card>
-                </Grid>
-              )}
+            {renderClassifications()}
           </Grid>
         </Grid>
       </Grid>
-      {copySearchInfoSnackbar}
+      <MessageInfo
+        open={showSearchCopiedSnackBar}
+        onClose={() => setShowSearchCopiedSnackBar(false)}
+        title={searchStrings.shareSearchConfirmationText}
+        variant="success"
+      />
     </>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included - covered by existing tests

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Well, there we have it. This PR brings the count of `react-hooks/exhaustive-deps` warnings to _zero_!! :tada: 

To achieve that I've done two things:

1. Refactored `SearchPage` to `useReducer` for it's main state relating to searching; and
2. Removed a superfluous effect from `DateRangeSelector`.

**SearchPage**

Towards the conclusion of 2020.2 the amount of state and effects the `SearchPage` was looking after had made the component's function somewhat opaque, however there wasn't time for significant refactor. This PR now does that refactor with a pivot to `useReducer`.

Doing so has improved readability of the code, and  made it more explicit as to when searches are occurring - rather than depending on the chain of effects and their dependencies. I think it has also addressed a few cases of extraneous API calls.

In doing this I have also tried to balance which state to still manage with `useState` (such as `SearchPageOptions`) vs what to put in the state managed with `useReducer`. I left `SearchPageOptions` in `useState` as they also govern the surrounding/general state, and I also left the `SearchSettings` in `useState` as these are really a one off query from the server at the start.

Mostly, this all works just like it did before. However, there is one UX change which is when a new search is occurring the old results are removed - i.e. the spinner is not just overlayed a faded out set of previous results, they all go and an empty list is shown behind the spinner. This comes about from explicit specification of the state where I saw there can only be result items if the current state is `success` - i.e. don't show results when in `failed` state or `initialising` state. Maybe this is too logical though, and when in `searching` state the previous results (if any) should be kept. I'll leave that open for debate.

**DateRangeSelector**

All that occurred here was to move what is in the effect into an explicit handler. All still works as it used to, but arguably a bit better - as the missing effect dependency was indeed indicating an issue.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
