### PR TITLE
Feature - Search2 MIME type filtering support

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -65,8 +65,7 @@ object SearchHelper {
     search.setUseServerTimeZone(true)
     search.setQuery(params.query)
     search.setOwner(params.owner)
-    search.setMimeTypes(
-      (if (params.mimeTypes.isEmpty) None else Some(params.mimeTypes.toList.asJava)).orNull)
+    search.setMimeTypes(params.mimeTypes.toList.asJava)
 
     val orderType =
       DefaultSearch.getOrderType(Option(params.order).map(_.toLowerCase).orNull, params.query)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -18,10 +18,6 @@
 
 package com.tle.web.api.search
 
-import java.time.format.DateTimeParseException
-import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId}
-import java.util.Date
-
 import com.dytech.edge.exceptions.BadRequestException
 import com.tle.beans.entity.DynaCollection
 import com.tle.beans.item.{Comment, ItemIdKey}
@@ -41,6 +37,9 @@ import com.tle.web.api.item.equella.interfaces.beans.{
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
 import com.tle.web.api.search.model.{SearchParam, SearchResultAttachment, SearchResultItem}
 
+import java.time.format.DateTimeParseException
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId}
+import java.util.Date
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -66,6 +65,8 @@ object SearchHelper {
     search.setUseServerTimeZone(true)
     search.setQuery(params.query)
     search.setOwner(params.owner)
+    search.setMimeTypes(
+      (if (params.mimeTypes.isEmpty) None else Some(params.mimeTypes.toList.asJava)).orNull)
 
     val orderType =
       DefaultSearch.getOrderType(Option(params.order).map(_.toLowerCase).orNull, params.query)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -86,4 +86,8 @@ class SearchParam {
   @ApiParam("Single dynamic collection uuid (:virtualized value)")
   @QueryParam("dynaCollection")
   var dynaCollection: String = _
+
+  @ApiParam("List of MIME types to filter by")
+  @QueryParam("mimeTypes")
+  var mimeTypes: Array[String] = _
 }

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -134,6 +134,8 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   public void selectStatus(boolean allStatus) {
     String buttonText = allStatus ? "All" : "Live";
     WebElement statusSelector = getRefineControl("StatusSelector");
+    // Normally hidden in the collapsed section of the Refine Panel
+    waiter.until(ExpectedConditions.visibilityOf(statusSelector));
     selectFromButtonGroup(statusSelector, buttonText);
   }
 
@@ -145,6 +147,8 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   public void selectSearchAttachments(boolean search) {
     String buttonText = search ? "Yes" : "No";
     WebElement searchAttachmentsSelector = getRefineControl("SearchAttachmentsSelector");
+    // Normally hidden in the collapsed section of the Refine Panel
+    waiter.until(ExpectedConditions.visibilityOf(searchAttachmentsSelector));
     selectFromButtonGroup(searchAttachmentsSelector, buttonText);
   }
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -157,6 +157,19 @@ public class Search2ApiTest extends AbstractRestApiTest {
     assertEquals(getAvailable(result), expectNumber);
   }
 
+  @Test(description = "Search for a known MIME type")
+  public void validMimeTypeSearch() throws IOException {
+    JsonNode result = doSearch(200, null, new NameValuePair("mimeTypes", "text/plain"));
+    assertEquals(getAvailable(result), 6);
+  }
+
+  @Test(description = "Search for a known MIME type with has no items")
+  public void absentMimeTypeSearch() throws IOException {
+    JsonNode result =
+        doSearch(200, null, new NameValuePair("mimeTypes", "application/illustrator"));
+    assertEquals(getAvailable(result), 0);
+  }
+
   private JsonNode doSearch(int expectedCode, String query, NameValuePair... queryVals)
       throws IOException {
     final HttpMethod method = new GetMethod(SEARCH_API_ENDPOINT);

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -80,6 +80,10 @@ export interface SearchParams {
    * A flag indicating whether to search attachments or not.
    */
   searchAttachments?: boolean;
+  /**
+   * List of MIME types to filter by.
+   */
+  mimeTypes?: string[];
 }
 
 /**

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -69,6 +69,13 @@ describe('Search for items', () => {
     expect(findItemByStatus(STATUS_LIVE)).toBeTruthy();
     expect(findItemByStatus(STATUS_PERSONAL)).toBeTruthy();
   });
+
+  it('should return results which match one of multiple MIME types', async () => {
+    const searchResult = await doSearch({
+      mimeTypes: ['text/plain', 'application/pdf'],
+    });
+    expect(searchResult.results).toHaveLength(7);
+  });
 });
 
 describe('Search for attachments', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [x] documentation is changed or added (apidocs)

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Adds support for filtering by a list of MIME types. We need this for a few things, but my immediate concern is the image gallery.

![image](https://user-images.githubusercontent.com/43919233/107318118-20356e80-6af0-11eb-8a23-e55e566b5740.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
