### PR TITLE
New search page responsiveness

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -15,6 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createMuiTheme, MuiThemeProvider } from "@material-ui/core";
+import type { Theme } from "@material-ui/core/styles";
 import * as OEQ from "@openequella/rest-api-client";
 import "@testing-library/jest-dom/extend-expect";
 import {
@@ -75,6 +77,7 @@ import {
   queryStatusSelector,
 } from "./SearchPageHelper";
 
+const defaultTheme = createMuiTheme();
 const mockCollections = jest.spyOn(CollectionsModule, "collectionListSummary");
 const mockListUsers = jest.spyOn(UserModule, "listUsers");
 const mockListClassification = jest.spyOn(
@@ -148,7 +151,8 @@ const waitForSearch = async () =>
  * @returns The RenderResult from the `render` of the `<SearchPage>`
  */
 const renderSearchPage = async (
-  queryString?: string
+  queryString?: string,
+  theme: Theme = defaultTheme
 ): Promise<RenderResult> => {
   window.history.replaceState({}, "Clean history state");
   const history = createMemoryHistory();
@@ -156,9 +160,11 @@ const renderSearchPage = async (
   history.push({});
 
   const page = render(
-    <Router history={history}>
-      <SearchPage updateTemplate={jest.fn()} />{" "}
-    </Router>
+    <MuiThemeProvider theme={theme}>
+      <Router history={history}>
+        <SearchPage updateTemplate={jest.fn()} />
+      </Router>
+    </MuiThemeProvider>
   );
   // Wait for the first completion of initial search
   await waitForSearch();
@@ -371,7 +377,9 @@ describe("Collapsible refine filter section", () => {
   });
 
   it("Should contain the correct controls", async () => {
-    const refineSearchPanel = page.getByText("Refine search").closest("div");
+    const refineSearchPanel = page
+      .getByText(languageStrings.searchpage.refineSearchPanel.title)
+      .closest("div");
     if (!refineSearchPanel) {
       throw new Error("Unable to find refine search panel");
     }
@@ -719,7 +727,7 @@ describe("<SearchPage/>", () => {
       1
     );
     expect(mockClipboard).toHaveBeenCalledWith(
-      "/?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RANK%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D"
+      "/?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RANK%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D"
     );
     expect(
       screen.getByText(languageStrings.searchpage.shareSearchConfirmationText)
@@ -778,5 +786,45 @@ describe("In Selection Session", () => {
       languageStrings.searchpage.shareSearchHelperText
     );
     expect(copySearchButton).not.toBeInTheDocument();
+  });
+});
+
+describe("Responsiveness", () => {
+  const getSidePanel = (page: RenderResult) =>
+    page.queryByTitle(languageStrings.searchpage.sidePanel.title);
+  let page: RenderResult;
+
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(async () => {
+    page = await renderSearchPage();
+  });
+
+  it("should hide the side panel in small screens", async () => {
+    expect(getSidePanel(page)).not.toBeInTheDocument();
+  });
+
+  it("should display the button controlling the side panel visibility", async () => {
+    const refineSearchButton = page.queryByTitle(
+      languageStrings.searchpage.refineSearchPanel.title
+    );
+    expect(refineSearchButton).toBeInTheDocument();
+
+    userEvent.click(refineSearchButton!); // It's safe to add a '!' now.
+    expect(getSidePanel(page)).toBeInTheDocument();
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -782,7 +782,9 @@ describe("In Selection Session", () => {
   it("should not show the share search button", async () => {
     updateMockGetRenderData(basicRenderData);
     mockSearch.mockResolvedValue(getSearchResult);
-    const copySearchButton = screen.queryByTitle(
+    const { queryByTitle } = await renderSearchPage();
+
+    const copySearchButton = queryByTitle(
       languageStrings.searchpage.shareSearchHelperText
     );
     expect(copySearchButton).not.toBeInTheDocument();
@@ -823,8 +825,11 @@ describe("Responsiveness", () => {
       languageStrings.searchpage.refineSearchPanel.title
     );
     expect(refineSearchButton).toBeInTheDocument();
-
-    userEvent.click(refineSearchButton!); // It's safe to add a '!' now.
+    userEvent.click(refineSearchButton!);
+    await act(async () => {
+      // Put this click in an act because it will update some components' state.
+      await userEvent.click(refineSearchButton!); // It's safe to add a '!' now.
+    });
     expect(getSidePanel(page)).toBeInTheDocument();
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -792,8 +792,9 @@ describe("In Selection Session", () => {
 });
 
 describe("Responsiveness", () => {
-  const getSidePanel = (page: RenderResult) =>
-    page.queryByTitle(languageStrings.searchpage.sidePanel.title);
+  // We can query the Refine Search Panel as it always exists in the Side Panel.
+  const querySidePanel = (page: RenderResult) =>
+    page.queryByText(languageStrings.searchpage.refineSearchPanel.title);
   let page: RenderResult;
 
   beforeAll(() => {
@@ -817,7 +818,7 @@ describe("Responsiveness", () => {
   });
 
   it("should hide the side panel in small screens", async () => {
-    expect(getSidePanel(page)).not.toBeInTheDocument();
+    expect(querySidePanel(page)).not.toBeInTheDocument();
   });
 
   it("should display the button controlling the side panel visibility", async () => {
@@ -825,11 +826,10 @@ describe("Responsiveness", () => {
       languageStrings.searchpage.refineSearchPanel.title
     );
     expect(refineSearchButton).toBeInTheDocument();
-    userEvent.click(refineSearchButton!);
     await act(async () => {
       // Put this click in an act because it will update some components' state.
       await userEvent.click(refineSearchButton!); // It's safe to add a '!' now.
     });
-    expect(getSidePanel(page)).toBeInTheDocument();
+    expect(querySidePanel(page)).toBeInTheDocument();
   });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -77,7 +77,9 @@ import {
   queryStatusSelector,
 } from "./SearchPageHelper";
 
-const defaultTheme = createMuiTheme();
+const defaultTheme = createMuiTheme({
+  props: { MuiWithWidth: { initialWidth: "md" } },
+});
 const mockCollections = jest.spyOn(CollectionsModule, "collectionListSummary");
 const mockListUsers = jest.spyOn(UserModule, "listUsers");
 const mockListClassification = jest.spyOn(
@@ -792,29 +794,17 @@ describe("In Selection Session", () => {
 });
 
 describe("Responsiveness", () => {
+  const theme = createMuiTheme({
+    props: { MuiWithWidth: { initialWidth: "sm" } },
+  });
+
   // We can query the Refine Search Panel as it always exists in the Side Panel.
   const querySidePanel = (page: RenderResult) =>
     page.queryByText(languageStrings.searchpage.refineSearchPanel.title);
   let page: RenderResult;
 
-  beforeAll(() => {
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: true,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-  });
-
   beforeEach(async () => {
-    page = await renderSearchPage();
+    page = await renderSearchPage(undefined, theme);
   });
 
   it("should hide the side panel in small screens", async () => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/DateRangeSelector.tsx
@@ -149,7 +149,7 @@ export const DateRangeSelector = ({
       start && end ? isStartValid && isEndValid && start <= end : false;
     // Call onDateRangeChange for above four cases.
     if (openStart || openEnd || openRange || closedRange) {
-      onDateRangeChange(range);
+      onDateRangeChange({ start: range.start, end: range.end });
     }
   };
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -185,6 +185,10 @@ export const defaultSearchOptions: SearchOptions = {
   rawMode: false,
   status: liveStatuses,
   searchAttachments: true,
+  query: "",
+  collections: [],
+  lastModifiedDateRange: { start: undefined, end: undefined },
+  owner: undefined,
 };
 
 export const defaultPagedSearchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
@@ -484,3 +488,13 @@ export const legacyQueryStringToSearchOptions = async (
   };
   return searchOptions;
 };
+
+/**
+ * Call this function to get partial SearchOptions.
+ * @param options An object of SearchOptions
+ * @param fields What fields of SearchOptions to get
+ */
+export const getPartialSearchOptions = (
+  options: SearchOptions,
+  fields: string[]
+) => pick(options, fields);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -91,6 +91,11 @@ export interface SearchOptions {
 }
 
 /**
+ * The type representing fields of SearchOptions.
+ */
+export type SearchOptionsFields = keyof SearchOptions;
+
+/**
  * Represent a date range which has an optional start and end.
  */
 export interface DateRange {
@@ -496,5 +501,5 @@ export const legacyQueryStringToSearchOptions = async (
  */
 export const getPartialSearchOptions = (
   options: SearchOptions,
-  fields: string[]
+  fields: SearchOptionsFields[]
 ) => pick(options, fields);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Drawer, Grid, useMediaQuery } from "@material-ui/core";
-import type { Theme } from "@material-ui/core/styles";
+import { Drawer, Grid, Hidden } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
 
 import { isEqual } from "lodash";
@@ -164,11 +163,6 @@ const reducer = (state: State, action: Action): State => {
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const history = useHistory();
   const location = useLocation();
-  // True when the current screen width is <= MUI breakpoint 'sm'.
-  const isInSmallScreen: boolean = useMediaQuery(
-    (theme: Theme) => theme.breakpoints.down("sm"),
-    { noSsr: true } // Set 'noSsr' to true as we only do client-side rendering.
-  );
 
   const [state, dispatch] = useReducer(reducer, { status: "initialising" });
   const defaultSearchPageOptions: SearchPageOptions = {
@@ -676,7 +670,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
                   onChange: handleSortOrderChanged,
                 }}
                 refineSearchProps={{
-                  isInSmallScreen: isInSmallScreen,
                   showRefinePanel: () => setShowRefinePanel(true),
                   isCriteriaSet: isCriteriaSet(),
                 }}
@@ -689,14 +682,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
             </Grid>
           </Grid>
         </Grid>
-        {
-          // Only show the right-hand side panels when NOT in small screen.
-          !isInSmallScreen && (
-            <Grid item md={4}>
-              {renderSidePanel()}
-            </Grid>
-          )
-        }
+        <Hidden smDown>
+          <Grid item md={4}>
+            {renderSidePanel()}
+          </Grid>
+        </Hidden>
       </Grid>
       <MessageInfo
         open={showSearchCopiedSnackBar}
@@ -704,7 +694,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         title={searchStrings.shareSearchConfirmationText}
         variant="success"
       />
-      {isInSmallScreen && (
+      <Hidden mdUp>
         <Drawer
           open={showRefinePanel}
           anchor="right"
@@ -712,7 +702,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         >
           {renderSidePanel()}
         </Drawer>
-      )}
+      </Hidden>
     </>
   );
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -349,37 +349,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     setFilterExpansion(!filterExpansion);
   };
 
-  /**
-   * Determines if any collapsible filters have been modified from their defaults
-   */
-  const areCollapsibleFiltersSet = (): boolean => {
-    const fields = [
-      "lastModifiedDateRange",
-      "owner",
-      "status",
-      "searchAttachments",
-    ];
-    return !isEqual(
-      getPartialSearchOptions(defaultSearchOptions, fields),
-      getPartialSearchOptions(searchPageOptions, fields)
-    );
-  };
-
-  const isCriteriaSet = (): boolean => {
-    const fields = [
-      "lastModifiedDateRange",
-      "owner",
-      "status",
-      "searchAttachments",
-      "query",
-      "collections",
-    ];
-    return !isEqual(
-      getPartialSearchOptions(defaultSearchOptions, fields),
-      getPartialSearchOptions(searchPageOptions, fields)
-    );
-  };
-
   const handlePageChanged = (page: number) =>
     search({ ...searchPageOptions, currentPage: page });
 
@@ -487,6 +456,47 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         schemaNode: getSchemaNode(c.id),
       })),
     });
+  };
+
+  /**
+   * Determines if any collapsible filters have been modified from their defaults
+   */
+  const areCollapsibleFiltersSet = (): boolean => {
+    const fields = [
+      "lastModifiedDateRange",
+      "owner",
+      "status",
+      "searchAttachments",
+    ];
+    return !isEqual(
+      getPartialSearchOptions(defaultSearchOptions, fields),
+      getPartialSearchOptions(searchPageOptions, fields)
+    );
+  };
+
+  const isCriteriaSet = (): boolean => {
+    const fields = [
+      "lastModifiedDateRange",
+      "owner",
+      "status",
+      "searchAttachments",
+      "query",
+      "collections",
+    ];
+
+    // Field 'selectedCategories' is a bit different. Once a classification is selected, the category will persist in searchPageOptions.
+    // What we really care is if we have got any category that has any classification selected.
+    const isClassificationSelected: boolean =
+      searchPageOptions.selectedCategories?.some(
+        ({ categories }: SelectedCategories) => categories.length > 0
+      ) ?? false;
+
+    return (
+      !isEqual(
+        getPartialSearchOptions(defaultSearchOptions, fields),
+        getPartialSearchOptions(searchPageOptions, fields)
+      ) || isClassificationSelected
+    );
   };
 
   const refinePanelControls: RefinePanelControl[] = [

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -55,6 +55,7 @@ import {
   queryStringParamsToSearchOptions,
   searchItems,
   SearchOptions,
+  SearchOptionsFields,
 } from "../modules/SearchModule";
 import { getSearchSettingsFromServer } from "../modules/SearchSettingsModule";
 import SearchBar from "../search/components/SearchBar";
@@ -457,7 +458,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
    * Determines if any collapsible filters have been modified from their defaults
    */
   const areCollapsibleFiltersSet = (): boolean => {
-    const fields = [
+    const fields: SearchOptionsFields[] = [
       "lastModifiedDateRange",
       "owner",
       "status",
@@ -473,12 +474,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
    * Determines if any search criteria has been set, including classifications, query and all filters.
    */
   const isCriteriaSet = (): boolean => {
-    const fields = [
+    const fields: SearchOptionsFields[] = [
       "lastModifiedDateRange",
       "owner",
       "status",
       "searchAttachments",
-      "query",
       "collections",
     ];
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -165,8 +165,9 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const history = useHistory();
   const location = useLocation();
   // True when the current screen width is <= MUI breakpoint 'sm'.
-  const isInSmallScreen: boolean = useMediaQuery((theme: Theme) =>
-    theme.breakpoints.down("sm")
+  const isInSmallScreen: boolean = useMediaQuery(
+    (theme: Theme) => theme.breakpoints.down("sm"),
+    { noSsr: true } // Set 'noSsr' to true as we only do client-side rendering.
   );
 
   const [state, dispatch] = useReducer(reducer, { status: "initialising" });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/AuxiliarySearchSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/AuxiliarySearchSelector.tsx
@@ -79,6 +79,7 @@ export const AuxiliarySearchSelector = ({
       <OeqLink
         routeLinkUrlProvider={() => urlGeneratorForRouteLink(summary.uuid)}
         muiLinkUrlProvider={() => urlGeneratorForMuiLink(summary.uuid)}
+        key={summary.uuid}
       >
         {getLinkContent(summary)}
       </OeqLink>
@@ -86,7 +87,7 @@ export const AuxiliarySearchSelector = ({
 
   return (
     <FormControl variant="outlined" fullWidth>
-      <Select>{buildSearchMenuItems()}</Select>
+      <Select value="">{buildSearchMenuItems()}</Select>
     </FormControl>
   );
 };

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CategorySelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CategorySelector.tsx
@@ -209,11 +209,7 @@ export const CategorySelector = ({
   }: CategoryListItemProps) => {
     const { term } = category;
     return (
-      <ListItem
-        key={`${classificationID}:${term}`}
-        disableGutters
-        className={classes.classificationListItem}
-      >
+      <ListItem disableGutters className={classes.classificationListItem}>
         <FormControlLabel
           style={{ alignItems: "flex-start" }}
           control={
@@ -296,7 +292,11 @@ export const CategorySelector = ({
   }: ListCategoryProps) => (
     <>
       {categories.slice(0, expanded ? undefined : maxDisplay).map((facet) => (
-        <CategoryListItem classificationID={id} category={facet} />
+        <CategoryListItem
+          classificationID={id}
+          category={facet}
+          key={`${id}:${facet.term}`}
+        />
       ))}
     </>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ClassificationsPanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ClassificationsPanel.tsx
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, Typography } from "@material-ui/core";
+import * as React from "react";
+import { languageStrings } from "../../util/langstrings";
+import { CategorySelector, CategorySelectorProps } from "./CategorySelector";
+
+/**
+ * Provide a MUI Card which display CategorySelector and the title.
+ */
+export const ClassificationsPanel = ({
+  classifications,
+  onSelectedCategoriesChange,
+  selectedCategories,
+}: CategorySelectorProps) => (
+  <Card>
+    <CardContent>
+      <Typography variant="h5">
+        {languageStrings.searchpage.categorySelector.title}
+      </Typography>
+      <CategorySelector
+        classifications={classifications}
+        onSelectedCategoriesChange={onSelectedCategoriesChange}
+        selectedCategories={selectedCategories}
+      />
+    </CardContent>
+  </Card>
+);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ClassificationsPanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ClassificationsPanel.tsx
@@ -21,23 +21,16 @@ import { languageStrings } from "../../util/langstrings";
 import { CategorySelector, CategorySelectorProps } from "./CategorySelector";
 
 /**
- * Provide a MUI Card which display CategorySelector and the title.
+ * Lays out `CategorySelector` in a MUI `Card` with appropriate title. As a result, props
+ * are simply passed through to `CategorySelector`.
  */
-export const ClassificationsPanel = ({
-  classifications,
-  onSelectedCategoriesChange,
-  selectedCategories,
-}: CategorySelectorProps) => (
+export const ClassificationsPanel = (props: CategorySelectorProps) => (
   <Card>
     <CardContent>
       <Typography variant="h5">
         {languageStrings.searchpage.categorySelector.title}
       </Typography>
-      <CategorySelector
-        classifications={classifications}
-        onSelectedCategoriesChange={onSelectedCategoriesChange}
-        selectedCategories={selectedCategories}
-      />
+      <CategorySelector {...props} />
     </CardContent>
   </Card>
 );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/CollectionSelector.tsx
@@ -75,7 +75,7 @@ export const CollectionSelector = ({
         getTagProps: AutocompleteGetTagProps
       ) =>
         collections.map((collection: Collection, index: number) => (
-          <Tooltip title={collection.name}>
+          <Tooltip title={collection.name} key={collection.uuid}>
             <Chip
               style={{ maxWidth: "50%" }}
               id={"collectionChip " + collection.uuid}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/RefineSearchPanel.tsx
@@ -54,7 +54,7 @@ export interface RefinePanelControl {
   alwaysVisible?: boolean;
 }
 
-interface RefinePanelProps {
+export interface RefinePanelProps {
   /**
    * Child components rendered inside this panel.
    */

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -29,6 +29,7 @@ import {
   Tooltip,
   Typography,
 } from "@material-ui/core";
+import FilterListIcon from "@material-ui/icons/FilterList";
 import { makeStyles } from "@material-ui/core/styles";
 import Share from "@material-ui/icons/Share";
 import * as OEQ from "@openequella/rest-api-client";
@@ -48,6 +49,21 @@ const useStyles = makeStyles({
     position: "fixed",
   },
 });
+
+interface RefineSearchProps {
+  /**
+   * True when current screen width is <= MUI breakpoint 'sm'
+   */
+  isInSmallScreen: boolean;
+  /**
+   * True when any search criteria has been set
+   */
+  isCriteriaSet: boolean;
+  /**
+   * Function fired to show Refine Search panel.
+   */
+  showRefinePanel: () => void;
+}
 
 /**
  * Props required by component SearchResultList.
@@ -77,6 +93,10 @@ export interface SearchResultListProps {
    * Fired when the copy search button is clicked.
    */
   onCopySearchLink: () => void;
+  /**
+   * Props for the Icon button that controls whether show Refine panel in small screens
+   */
+  refineSearchProps: RefineSearchProps;
 }
 
 /**
@@ -88,8 +108,15 @@ export interface SearchResultListProps {
 export const SearchResultList = ({
   children,
   showSpinner,
-  orderSelectProps,
-  paginationProps,
+  orderSelectProps: { value, onChange: onOrderChange },
+  paginationProps: {
+    count,
+    currentPage,
+    rowsPerPage,
+    onPageChange,
+    onRowsPerPageChange,
+  },
+  refineSearchProps: { isCriteriaSet, isInSmallScreen, showRefinePanel },
   onClearSearchOptions,
   onCopySearchLink,
 }: SearchResultListProps) => {
@@ -115,14 +142,11 @@ export const SearchResultList = ({
   return (
     <Card>
       <CardHeader
-        title={searchPageStrings.subtitle + ` (${paginationProps.count})`}
+        title={searchPageStrings.subtitle + ` (${count})`}
         action={
           <Grid container spacing={1} alignItems="center">
             <Grid item>
-              <SearchOrderSelect
-                value={orderSelectProps.value}
-                onChange={orderSelectProps.onChange}
-              />
+              <SearchOrderSelect value={value} onChange={onOrderChange} />
             </Grid>
             <Grid item>
               <Tooltip title={searchPageStrings.newSearchHelperText}>
@@ -131,6 +155,16 @@ export const SearchResultList = ({
                 </Button>
               </Tooltip>
             </Grid>
+            {isInSmallScreen && (
+              <Grid item>
+                <IconButton
+                  onClick={showRefinePanel}
+                  color={isCriteriaSet ? "secondary" : "primary"}
+                >
+                  <FilterListIcon />
+                </IconButton>
+              </Grid>
+            )}
             {!inSelectionSession && (
               <Grid item>
                 <Tooltip title={searchPageStrings.shareSearchHelperText}>
@@ -157,14 +191,12 @@ export const SearchResultList = ({
         <Grid container justify="center">
           <Grid item>
             <SearchPagination
-              count={paginationProps.count}
-              currentPage={paginationProps.currentPage}
-              rowsPerPage={paginationProps.rowsPerPage}
-              onPageChange={(page: number) =>
-                paginationProps.onPageChange(page)
-              }
+              count={count}
+              currentPage={currentPage}
+              rowsPerPage={rowsPerPage}
+              onPageChange={(page: number) => onPageChange(page)}
               onRowsPerPageChange={(rowsPerPage: number) =>
-                paginationProps.onRowsPerPageChange(rowsPerPage)
+                onRowsPerPageChange(rowsPerPage)
               }
             />
           </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -23,6 +23,7 @@ import {
   CardHeader,
   CircularProgress,
   Grid,
+  Hidden,
   IconButton,
   List,
   ListItem,
@@ -51,10 +52,6 @@ const useStyles = makeStyles({
 });
 
 interface RefineSearchProps {
-  /**
-   * True when current screen width is <= MUI breakpoint 'sm'
-   */
-  isInSmallScreen: boolean;
   /**
    * True when any search criteria has been set
    */
@@ -118,7 +115,7 @@ export const SearchResultList = ({
     onPageChange,
     onRowsPerPageChange,
   },
-  refineSearchProps: { isCriteriaSet, isInSmallScreen, showRefinePanel },
+  refineSearchProps: { isCriteriaSet, showRefinePanel },
   onClearSearchOptions,
   onCopySearchLink,
 }: SearchResultListProps) => {
@@ -156,7 +153,7 @@ export const SearchResultList = ({
                 </Button>
               </Tooltip>
             </Grid>
-            {isInSmallScreen && (
+            <Hidden mdUp>
               <Grid item>
                 <Tooltip title={searchPageStrings.refineSearchPanel.title}>
                   <IconButton
@@ -167,7 +164,7 @@ export const SearchResultList = ({
                   </IconButton>
                 </Tooltip>
               </Grid>
-            )}
+            </Hidden>
             {!inSelectionSession && (
               <Grid item>
                 <Tooltip title={searchPageStrings.shareSearchHelperText}>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -99,6 +99,8 @@ export interface SearchResultListProps {
   refineSearchProps: RefineSearchProps;
 }
 
+const searchPageStrings = languageStrings.searchpage;
+
 /**
  * This component is basically a Card which includes a list of search results and a few search controls.
  * The sort order select is displayed in CardHeader.
@@ -120,7 +122,6 @@ export const SearchResultList = ({
   onClearSearchOptions,
   onCopySearchLink,
 }: SearchResultListProps) => {
-  const searchPageStrings = languageStrings.searchpage;
   const classes = useStyles();
   const inSelectionSession: boolean = isSelectionSessionOpen();
 
@@ -157,12 +158,14 @@ export const SearchResultList = ({
             </Grid>
             {isInSmallScreen && (
               <Grid item>
-                <IconButton
-                  onClick={showRefinePanel}
-                  color={isCriteriaSet ? "secondary" : "primary"}
-                >
-                  <FilterListIcon />
-                </IconButton>
+                <Tooltip title={searchPageStrings.refineSearchPanel.title}>
+                  <IconButton
+                    onClick={showRefinePanel}
+                    color={isCriteriaSet ? "secondary" : "primary"}
+                  >
+                    <FilterListIcon />
+                  </IconButton>
+                </Tooltip>
               </Grid>
             )}
             {!inSelectionSession && (

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SidePanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SidePanel.tsx
@@ -17,7 +17,6 @@
  */
 import { Grid } from "@material-ui/core";
 import * as React from "react";
-import { languageStrings } from "../../util/langstrings";
 import { CategorySelectorProps } from "./CategorySelector";
 
 import { ClassificationsPanel } from "./ClassificationsPanel";
@@ -38,39 +37,16 @@ interface SidePanelProps {
  * Right-hand side panel which includes Refine Search panel and Classifications panel.
  */
 export const SidePanel = ({
-  refinePanelProps: {
-    controls,
-    onChangeExpansion,
-    panelExpanded,
-    showFilterIcon,
-  },
-  classificationsPanelProps: {
-    classifications,
-    onSelectedCategoriesChange,
-    selectedCategories,
-  },
+  refinePanelProps,
+  classificationsPanelProps,
 }: SidePanelProps) => (
-  <Grid
-    container
-    direction="column"
-    spacing={2}
-    title={languageStrings.searchpage.sidePanel.title}
-  >
+  <Grid container direction="column" spacing={2}>
     <Grid item>
-      <RefineSearchPanel
-        controls={controls}
-        onChangeExpansion={onChangeExpansion}
-        panelExpanded={panelExpanded}
-        showFilterIcon={showFilterIcon}
-      />
+      <RefineSearchPanel {...refinePanelProps} />
     </Grid>
-    {classifications.length > 0 && (
+    {classificationsPanelProps.classifications.length > 0 && (
       <Grid item>
-        <ClassificationsPanel
-          classifications={classifications}
-          onSelectedCategoriesChange={onSelectedCategoriesChange}
-          selectedCategories={selectedCategories}
-        />
+        <ClassificationsPanel {...classificationsPanelProps} />
       </Grid>
     )}
   </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SidePanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SidePanel.tsx
@@ -1,0 +1,71 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Grid } from "@material-ui/core";
+import * as React from "react";
+import { CategorySelectorProps } from "./CategorySelector";
+
+import { ClassificationsPanel } from "./ClassificationsPanel";
+import { RefinePanelProps, RefineSearchPanel } from "./RefineSearchPanel";
+
+interface SidePanelProps {
+  /**
+   * Props passed to Refine Search panel
+   */
+  refinePanelProps: RefinePanelProps;
+  /**
+   * Props passed to Classifications Panel
+   */
+  classificationsPanelProps: CategorySelectorProps;
+}
+
+/**
+ * Right-hand side panel which includes Refine Search panel and Classifications panel.
+ */
+export const SidePanel = ({
+  refinePanelProps: {
+    controls,
+    onChangeExpansion,
+    panelExpanded,
+    showFilterIcon,
+  },
+  classificationsPanelProps: {
+    classifications,
+    onSelectedCategoriesChange,
+    selectedCategories,
+  },
+}: SidePanelProps) => (
+  <Grid container direction="column" spacing={2}>
+    <Grid item>
+      <RefineSearchPanel
+        controls={controls}
+        onChangeExpansion={onChangeExpansion}
+        panelExpanded={panelExpanded}
+        showFilterIcon={showFilterIcon}
+      />
+    </Grid>
+    {classifications.length > 0 && (
+      <Grid item>
+        <ClassificationsPanel
+          classifications={classifications}
+          onSelectedCategoriesChange={onSelectedCategoriesChange}
+          selectedCategories={selectedCategories}
+        />
+      </Grid>
+    )}
+  </Grid>
+);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SidePanel.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SidePanel.tsx
@@ -17,6 +17,7 @@
  */
 import { Grid } from "@material-ui/core";
 import * as React from "react";
+import { languageStrings } from "../../util/langstrings";
 import { CategorySelectorProps } from "./CategorySelector";
 
 import { ClassificationsPanel } from "./ClassificationsPanel";
@@ -49,7 +50,12 @@ export const SidePanel = ({
     selectedCategories,
   },
 }: SidePanelProps) => (
-  <Grid container direction="column" spacing={2}>
+  <Grid
+    container
+    direction="column"
+    spacing={2}
+    title={languageStrings.searchpage.sidePanel.title}
+  >
     <Grid item>
       <RefineSearchPanel
         controls={controls}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/settings/SchemaSelector.tsx
@@ -86,39 +86,37 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
 
   return (
     <Grid container direction="column" spacing={0}>
-      <>
-        <Grid item>
-          {schemaList && (
-            <>
-              <Select
-                fullWidth
-                label={
-                  <InputLabel shrink id="select-label">
-                    {strings.schema}
-                  </InputLabel>
-                }
-                value={selectedSchema}
-                displayEmpty
-                onChange={(event) => {
-                  setSelectedSchema(event.target.value as string | undefined);
-                }}
-              >
-                {schemaList}
-              </Select>
-              <FormHelperText>{strings.permissionsHelperText}</FormHelperText>
-            </>
-          )}
-        </Grid>
-        <Grid item>
-          {schema && (
-            <SchemaNodeSelector
-              expandControls
-              tree={schema}
-              setSelectedNode={setSchemaNodePath}
-            />
-          )}
-        </Grid>
-      </>
+      <Grid item>
+        {schemaList && (
+          <>
+            <Select
+              fullWidth
+              label={
+                <InputLabel shrink id="select-label">
+                  {strings.schema}
+                </InputLabel>
+              }
+              value={selectedSchema ?? ""}
+              displayEmpty
+              onChange={(event) => {
+                setSelectedSchema(event.target.value as string | undefined);
+              }}
+            >
+              {schemaList}
+            </Select>
+            <FormHelperText>{strings.permissionsHelperText}</FormHelperText>
+          </>
+        )}
+      </Grid>
+      <Grid item>
+        {schema && (
+          <SchemaNodeSelector
+            expandControls
+            tree={schema}
+            setSelectedNode={setSchemaNodePath}
+          />
+        )}
+      </Grid>
     </Grid>
   );
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -397,6 +397,9 @@ export const languageStrings = {
           "Failed to get attachment viewer details",
       },
     },
+    sidePanel: {
+      title: "Side panel",
+    },
     statusSelector: {
       all: "All",
       live: "Live",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -397,9 +397,6 @@ export const languageStrings = {
           "Failed to get attachment viewer details",
       },
     },
-    sidePanel: {
-      title: "Side panel",
-    },
     statusSelector: {
       all: "All",
       live: "Live",


### PR DESCRIPTION
#2559 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This is the second PR for the Skinny Selection Session, which includes changes:

1. Improve the user experience in small screens - the side panel is displayed in a `Drawer` which is controlled by an icon button. This is achieved by using MUI hook `useMediaQuery`.

2. Add two new components: `SidePanel` and `ClassificationsPanel`.

3. Modify the default search option to include more fields with default values.

4. Tests for above changes.

While working on writing Jest tests, I also tried to fix lots of warnings. Now there is one remaining warning about determining attachment viewer which is what we expect to see.


https://user-images.githubusercontent.com/47203811/107449054-fbe09d00-6b96-11eb-823f-2caaa806a010.mp4

![image](https://user-images.githubusercontent.com/47203811/107450141-d6549300-6b98-11eb-8d32-6cfd6d36ff1c.png)

