### PR TITLE
Ensure full page errors in new UI integration selection session are not swallowed by "Already Rendered!" error

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/com/tle/core/i18n/service/impl/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/com/tle/core/i18n/service/impl/i18n-resource-centre.properties
@@ -401,3 +401,4 @@ institutions.error.pagenotfound = Page not found
 
 institutions.server.settings.name = Server settings
 com.tle.core.connectors.canvas.error.prelim=An error occurred in Canvas\:
+com.tle.core.connectors.canvas.error.apache=An error occurred in Canvas that was returned from Apache. Cleared cookie cache.

--- a/Source/Plugins/Core/com.equella.core/resources/com/tle/core/i18n/service/impl/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/com/tle/core/i18n/service/impl/i18n-resource-centre.properties
@@ -401,4 +401,4 @@ institutions.error.pagenotfound = Page not found
 
 institutions.server.settings.name = Server settings
 com.tle.core.connectors.canvas.error.prelim=An error occurred in Canvas\:
-com.tle.core.connectors.canvas.error.apache=An error occurred in Canvas that was returned from Apache. Cleared cookie cache.
+com.tle.core.connectors.canvas.error.apache=An error occurred in Canvas. Canvas session has been reset.

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5604,3 +5604,7 @@ button:focus {
     display: none;
   }
 }
+
+#selection-page .area.error {
+  width: 100%;
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/canvas/service/CanvasConnectorService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/canvas/service/CanvasConnectorService.java
@@ -796,7 +796,7 @@ public class CanvasConnectorService extends AbstractIntegrationConnectorResposit
           }
           if (response.getCode() == 400 && response.getBody().contains("Apache")) {
             // Invalidating cookie cache, as this is a known source of these errors
-            httpService.clearCookieCache(request.getUrl());
+            httpService.clearCookieCache();
             LOGGER.debug("Error response from Canvas's Apache");
             LOGGER.debug(response.getCode());
             LOGGER.debug(response.getMessage());

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/canvas/service/CanvasConnectorService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/canvas/service/CanvasConnectorService.java
@@ -793,6 +793,16 @@ public class CanvasConnectorService extends AbstractIntegrationConnectorResposit
           if (response.getCode() == 401) {
             throw new CanvasAuthException(
                 CurrentLocale.get("com.tle.core.connectors.canvas.error.unauthorized"));
+          }
+          if (response.getCode() == 400 && response.getBody().contains("Apache")) {
+            // Invalidating cookie cache, as this is a known source of these errors
+            httpService.clearCookieCache(request.getUrl());
+            LOGGER.debug("Error response from Canvas's Apache");
+            LOGGER.debug(response.getCode());
+            LOGGER.debug(response.getMessage());
+            LOGGER.debug(response.getBody());
+            throw new CanvasApacheException(
+                CurrentLocale.get("com.tle.core.connectors.canvas.error.apache"));
           } else {
             final String body = response.getBody();
             throw new RuntimeException(
@@ -988,6 +998,12 @@ public class CanvasConnectorService extends AbstractIntegrationConnectorResposit
 
   private static class CanvasAuthException extends RuntimeException {
     public CanvasAuthException(String message) {
+      super(message);
+    }
+  }
+
+  public static class CanvasApacheException extends RuntimeException {
+    public CanvasApacheException(String message) {
       super(message);
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/HttpService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/HttpService.java
@@ -62,8 +62,9 @@ public interface HttpService {
   /** Encodes a URL parameter value */
   String urlParamEncode(String value);
 
-  /** Invalidates a cookie cache for a given URL (URLs are used as cache keys) */
-  void clearCookieCache(String url);
+  /** Invalidates cookie cache */
+  void clearCookieCache();
+
   /**
    * Checks the code of the response for error codes (404, 500 etc)
    *

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/HttpService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/HttpService.java
@@ -62,7 +62,7 @@ public interface HttpService {
   /** Encodes a URL parameter value */
   String urlParamEncode(String value);
 
-  /** Invalidates a cookie cache for a given URL (URLs are used as cache keys) * */
+  /** Invalidates a cookie cache for a given URL (URLs are used as cache keys) */
   void clearCookieCache(String url);
   /**
    * Checks the code of the response for error codes (404, 500 etc)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/HttpService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/HttpService.java
@@ -62,6 +62,8 @@ public interface HttpService {
   /** Encodes a URL parameter value */
   String urlParamEncode(String value);
 
+  /** Invalidates a cookie cache for a given URL (URLs are used as cache keys) * */
+  void clearCookieCache(String url);
   /**
    * Checks the code of the response for error codes (404, 500 etc)
    *

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
@@ -223,6 +223,7 @@ public class HttpServiceImpl implements HttpService {
 
   public void clearCookieCache(String url) {
     COOKIE_CACHE.invalidate(toCacheKey(url));
+    COOKIE_CACHE.cleanUp();
   }
 
   private DefaultHttpClient createClient(boolean https) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
@@ -221,7 +221,7 @@ public class HttpServiceImpl implements HttpService {
     return /* req.getSession().getId() */ "FIXME" + ':' + url;
   }
 
-  public void clearCookieCache(String url) {
+  public void clearCookieCache() {
     COOKIE_CACHE.invalidateAll();
     COOKIE_CACHE.cleanUp();
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
@@ -203,7 +203,7 @@ public class HttpServiceImpl implements HttpService {
       }
 
       // TODO: see fixme about cookie cache
-      final String cacheKey = /* req.getSession().getId() */ "FIXME" + ':' + url;
+      final String cacheKey = toCacheKey(url);
       Cookies cookies = COOKIE_CACHE.getIfPresent(cacheKey);
       if (cookies == null) {
         cookies = new Cookies();
@@ -215,6 +215,14 @@ public class HttpServiceImpl implements HttpService {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public String toCacheKey(String url) {
+    return /* req.getSession().getId() */ "FIXME" + ':' + url;
+  }
+
+  public void clearCookieCache(String url) {
+    COOKIE_CACHE.invalidate(toCacheKey(url));
   }
 
   private DefaultHttpClient createClient(boolean https) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/HttpServiceImpl.java
@@ -222,7 +222,7 @@ public class HttpServiceImpl implements HttpService {
   }
 
   public void clearCookieCache(String url) {
-    COOKIE_CACHE.invalidate(toCacheKey(url));
+    COOKIE_CACHE.invalidateAll();
     COOKIE_CACHE.cleanUp();
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/integration/IntegrationExceptionHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/integration/IntegrationExceptionHandler.java
@@ -22,9 +22,11 @@ import com.tle.core.guice.Bind;
 import com.tle.web.errors.DefaultExceptionHandler;
 import com.tle.web.integration.service.IntegrationService;
 import com.tle.web.sections.SectionInfo;
+import com.tle.web.sections.SectionUtils;
 import com.tle.web.sections.SectionsController;
 import com.tle.web.sections.events.SectionEvent;
 import com.tle.web.template.Decorations;
+import com.tle.web.template.RenderNewTemplate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -44,9 +46,14 @@ public class IntegrationExceptionHandler extends DefaultExceptionHandler {
   @Override
   public void handle(
       Throwable exception, SectionInfo info, SectionsController controller, SectionEvent<?> event) {
+    if (RenderNewTemplate.isNewUIEnabled()) {
+      SectionUtils.throwRuntime(exception);
+    }
+
     if (checkRendered(info)) {
       return;
     }
+    markHandled(info);
     SectionInfo newInfo = createNewInfo(exception, info, controller);
     Decorations.getDecorations(newInfo).clearAllDecorations();
     controller.execute(newInfo);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
This is a fix for two related issues. 
**Issue 1:** Errors that occur within an integration selection session are "swallowed" by another error that reads "Already Rendered!" rather than showing the correct message. This is because the IntegrationExceptionHandler doesn't rethrow like the DefaultExceptionHandler does, causing the error page to be rendered but not served up. Then when it tries to render the actual page to serve up, it triggers the "Already Rendered!" error. 

In the old UI it appears to use the Default handler anyway, and so things work properly. 

I was able to edit the IntegrationExceptionHandler so that if in the new UI the error gets properly rethrown as a RuntimeException, rather than swallowed up.

**Issue 2:** An error that was hidden by this was a known bug in the Canvas integration, in which if you rapidly click the Save button in a selection session it messes up the cookie cache for that particular call by adding in cookies repeatedly, as the cookie cache is URL specific but not request specific. This cookie cache is then used to populate a request to Canvas, but ends up being too long for Canvas's Apache to understand. Canvas' Apache spits back an error message (annoyingly as a HTML page).  

In the old UI this is impossible to do, as there is a JS error message that pops up with "This request is already being submitted", and so you can't send them fast enough to make the cookie cache get swamped.

The problem with this is, if the cookie cache gets into a malformed state like this, it will continue to occur with further saves, even after a refresh. So I've made sure to catch this error, and invalidate the cache when it occurs. This at least ensures that you can simply try again. 

**TL;DR**
- Stopped "Already Rendered!" message from getting in the way of actual error messages within Integration Selection Sessions
- Made sure that if the Canvas Integration cookie cache gets swamped it can clean itself up
- Small bit of CSS to make the error message display nicely

**Note:** I haven't fixed the cookie cache, I.E prevented it from getting swamped in the first place. All I've done is ensure that if it does get swamped, it can invalidate itself. 

**Screengrab clips**

*New UI Before fix:*

Trigger the Canvas cookie cache problem via spamming the Save button and see Already Rendered. Refresh and see that it happens from then on.
https://user-images.githubusercontent.com/24543345/107714795-fd8a9c00-6d21-11eb-9b73-410b2161f079.mp4

With SEARCH_PAGE ACL disabled, attempt to open the search page in a selection session and see Already Rendered
https://user-images.githubusercontent.com/24543345/107714891-2d39a400-6d22-11eb-9ff6-1af54a7eebd2.mp4

*New UI After fix:*

With SEARCH_PAGE ACL disabled, attempt to open the search page in a selection session and see the error that we should see.
https://user-images.githubusercontent.com/24543345/107714939-480c1880-6d22-11eb-8825-ba86169fa24d.mp4

Trigger the Canvas cookie cache problem via spamming the Save button, see the new error message. Refresh and see that the cache has been invalidated and the bug no longer happens.
https://user-images.githubusercontent.com/24543345/107715017-7984e400-6d22-11eb-8a46-ac371d41dc56.mp4

*Old UI Before and After fix:* 

Note that it is impossible to spam click the Save button in the old UI, so the canvas bug cannot occur. Appears identical before and after fix.
https://user-images.githubusercontent.com/24543345/107715240-ec8e5a80-6d22-11eb-95df-7738a22086b1.mp4

Old UI - Shows what the SEARCH PAGE ACL error message looks like. Appears identical before and after fix. 
https://user-images.githubusercontent.com/24543345/107715251-f748ef80-6d22-11eb-9efd-a0947a81a1fd.mp4







<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
