### PR TITLE
New Search UI: allow attachments contributed via Resource Selector to use the correct viewer on the search page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/ViewerModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/ViewerModule.ts
@@ -40,7 +40,7 @@ export const determineViewer = (
 ): ViewerDefinition => {
   const simpleLinkView: ViewerDefinition = ["link", viewUrl];
 
-  if (attachmentType !== "file") {
+  if (attachmentType !== "file" && attachmentType !== "custom/resource") {
     // For non-file attachments, we currently just defer to the link provided by the server
     return simpleLinkView;
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -36,6 +36,7 @@ import com.tle.web.api.item.equella.interfaces.beans.{
 }
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
 import com.tle.web.api.search.model.{SearchParam, SearchResultAttachment, SearchResultItem}
+import com.tle.web.controls.resource.ResourceAttachmentBean
 
 import java.time.format.DateTimeParseException
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId}
@@ -258,6 +259,9 @@ object SearchHelper {
     bean match {
       case file: AbstractFileAttachmentBean =>
         Some(LegacyGuice.mimeTypeService.getMimeTypeForFilename(file.getFilename))
+      case resourceAttachmentBean: ResourceAttachmentBean =>
+        Some(
+          LegacyGuice.mimeTypeService.getMimeTypeForResourceAttachmentBean(resourceAttachmentBean))
       case _ => None
     }
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/AttachmentDao.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/AttachmentDao.java
@@ -36,4 +36,8 @@ public interface AttachmentDao extends GenericDao<Attachment, Long> {
 
   List<CustomAttachment> findResourceAttachmentsByQuery(
       String query, boolean liveOnly, String sortHql);
+
+  Attachment findByUuid(String uuid);
+
+  List<Attachment> findAllByUuid(String uuid);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
@@ -125,4 +125,30 @@ public class AttachmentDaoImpl extends GenericDaoImpl<Attachment, Long> implemen
     // it's possible that value1 could be
     return attachments;
   }
+
+  @Override
+  public List<Attachment> findAllByUuid(String uuid) {
+    String[] names = new String[] {"institution", "uuid"};
+    Object[] values = new Object[] {CurrentInstitution.get(), uuid};
+    List<String> nameList = new ArrayList<String>(Arrays.asList(names));
+    List<Object> valueList = new ArrayList<Object>(Arrays.asList(values));
+
+    StringBuilder query = new StringBuilder();
+    query.append(
+        "SELECT a FROM Item i LEFT JOIN i.attachments a WHERE i.institution = :institution");
+    query.append(" AND a.uuid = :uuid");
+    List<Attachment> attachments =
+        (List<Attachment>)
+            getHibernateTemplate()
+                .findByNamedParam(
+                    query.toString(),
+                    nameList.toArray(new String[nameList.size()]),
+                    valueList.toArray());
+
+    return attachments;
+  }
+
+  public Attachment findByUuid(String uuid) {
+    return findAllByUuid(uuid).get(0);
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
@@ -140,11 +140,11 @@ public class AttachmentDaoImpl extends GenericDaoImpl<Attachment, Long> implemen
 
   @Override
   public List<Attachment> findAllByUuid(String uuid) {
-    return (List<Attachment>) findByDetachedCriteria(Criteria::list, criteriaByUuid(uuid));
+    return (List<Attachment>) findByDetachedCriteria(criteriaByUuid(uuid), Criteria::list);
   }
 
   @Override
   public Attachment findByUuid(String uuid) {
-    return (Attachment) findByDetachedCriteria(Criteria::uniqueResult, criteriaByUuid(uuid));
+    return (Attachment) findByDetachedCriteria(criteriaByUuid(uuid), Criteria::uniqueResult);
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/AttachmentDaoImpl.java
@@ -129,7 +129,7 @@ public class AttachmentDaoImpl extends GenericDaoImpl<Attachment, Long> implemen
     return attachments;
   }
 
-  // Criteria for checking an attachments against institution of the item and uuid of the
+  // Criteria for checking attachments against institution of the item and UUID of the
   // attachment. Detached so that we don't need to create a Hibernate session until one is required.
   private DetachedCriteria criteriaByUuid(String uuid) {
     return DetachedCriteria.forClass(Attachment.class)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
@@ -23,6 +23,7 @@ import com.tle.annotation.Nullable;
 import com.tle.beans.item.attachments.Attachment;
 import com.tle.beans.mime.MimeEntry;
 import com.tle.core.TextExtracterExtension;
+import com.tle.web.controls.resource.ResourceAttachmentBean;
 import java.util.Collection;
 import java.util.List;
 
@@ -36,6 +37,10 @@ public interface MimeTypeService {
    * @return If the extension is not known then application/octet-stream is returned
    */
   String getMimeTypeForFilename(String filename);
+
+  String getMimeTypeForAttachmentUuid(String attachmentUuid);
+
+  String getMimeTypeForResourceAttachmentBean(ResourceAttachmentBean resourceAttachmentBean);
 
   @Nullable
   MimeEntry getEntryForMimeType(String mimeType);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -467,7 +467,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
     if (attachType == AttachmentType.CUSTOM) {
       type += '/' + ((CustomAttachment) attachment).getType().toLowerCase();
     }
-    if (type.equals("custom/resource") && attachment.getData("type").equals('a')) {
+    if (type.equals("custom/resource") && attachment.getData("type").equals("a")) {
       // Recurse to drill into the linked attachment, so we can use the correct viewer
       return getMimeEntryForAttachment(
           attachmentDao.findByCriteria(Restrictions.eq("uuid", attachment.getUrl())));

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -467,7 +467,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
     if (attachType == AttachmentType.CUSTOM) {
       type += '/' + ((CustomAttachment) attachment).getType().toLowerCase();
     }
-    if (type.equals("custom/resource")) {
+    if (type.equals("custom/resource") && attachment.getData("type").equals('a')) {
       // Recurse to drill into the linked attachment, so we can use the correct viewer
       return getMimeEntryForAttachment(
           attachmentDao.findByCriteria(Restrictions.eq("uuid", attachment.getUrl())));

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -18,6 +18,8 @@
 
 package com.tle.core.mimetypes;
 
+import static com.tle.core.mimetypes.MimeTypeConstants.MIME_ITEM;
+
 import com.google.common.cache.CacheLoader;
 import com.tle.annotation.Nullable;
 import com.tle.beans.Institution;
@@ -184,9 +186,9 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
       case SelectedResource.TYPE_ATTACHMENT:
         return getMimeTypeForAttachmentUuid(resourceAttachmentBean.getAttachmentUuid());
       case SelectedResource.TYPE_PATH:
-        return "equella/item";
+        return MIME_ITEM;
       default:
-        return DEFAULT_MIMETYPE;
+        return resourceAttachmentBean.getRawAttachmentType();
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -62,8 +62,6 @@ import javax.inject.Singleton;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.hibernate.Hibernate;
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
 import org.java.plugin.registry.Extension;
 import org.java.plugin.registry.Extension.Parameter;
 import org.springframework.transaction.annotation.Propagation;
@@ -177,7 +175,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
   }
 
   public String getMimeTypeForAttachmentUuid(String attachmentUuid) {
-    Attachment attachment = attachmentDao.findByCriteria(Restrictions.eq("uuid", attachmentUuid));
+    Attachment attachment = attachmentDao.findByUuid(attachmentUuid);
     return getMimeEntryForAttachment(attachment);
   }
 
@@ -479,8 +477,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
       // Recurse to drill into the linked attachment, so we can use the correct viewer.
       // If more than one attachment has the linked uuid,
       // this is a zip or scorm package and we can let it fall through.
-      Criterion uuidEqualsAttachmentUrl = Restrictions.eq("uuid", attachment.getUrl());
-      List<Attachment> attachmentList = attachmentDao.findAllByCriteria(uuidEqualsAttachmentUrl);
+      List<Attachment> attachmentList = attachmentDao.findAllByUuid(attachment.getUrl());
       if (attachmentList.size() == 1) {
         return getMimeEntryForAttachment(attachmentList.get(0));
       }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -19,6 +19,7 @@
 package com.tle.core.mimetypes;
 
 import static com.tle.core.mimetypes.MimeTypeConstants.MIME_ITEM;
+import static com.tle.web.controls.resource.ResourceAttachmentBean.TYPE_ID;
 
 import com.google.common.cache.CacheLoader;
 import com.tle.annotation.Nullable;
@@ -471,7 +472,7 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
     if (attachType == AttachmentType.CUSTOM) {
       type += '/' + ((CustomAttachment) attachment).getType().toLowerCase();
     }
-    if (type.equals("custom/resource")
+    if (type.equals(TYPE_ID)
         && attachment
             .getData("type")
             .equals(Character.toString(SelectedResource.TYPE_ATTACHMENT))) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -45,6 +45,7 @@ import com.tle.core.plugins.PluginTracker.ExtensionParamComparator;
 import com.tle.core.security.impl.RequiresPrivilege;
 import com.tle.exceptions.AccessDeniedException;
 import com.tle.web.controls.resource.ResourceAttachmentBean;
+import com.tle.web.selection.SelectedResource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -180,9 +181,9 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
   public String getMimeTypeForResourceAttachmentBean(
       ResourceAttachmentBean resourceAttachmentBean) {
     switch (resourceAttachmentBean.getResourceType()) {
-      case 'a':
+      case SelectedResource.TYPE_ATTACHMENT:
         return getMimeTypeForAttachmentUuid(resourceAttachmentBean.getAttachmentUuid());
-      case 'p':
+      case SelectedResource.TYPE_PATH:
         return "equella/item";
       default:
         return DEFAULT_MIMETYPE;
@@ -468,7 +469,8 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
     if (attachType == AttachmentType.CUSTOM) {
       type += '/' + ((CustomAttachment) attachment).getType().toLowerCase();
     }
-    if (type.equals("custom/resource") && attachment.getData("type").equals("a")) {
+    if (type.equals("custom/resource")
+        && attachment.getData("type").equals(SelectedResource.TYPE_ATTACHMENT)) {
       // Recurse to drill into the linked attachment, so we can use the correct viewer.
       // If more than one attachment has the linked uuid,
       // this is a zip or scorm package and we can let it fall through.

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -472,7 +472,9 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
       type += '/' + ((CustomAttachment) attachment).getType().toLowerCase();
     }
     if (type.equals("custom/resource")
-        && attachment.getData("type").equals(SelectedResource.TYPE_ATTACHMENT)) {
+        && attachment
+            .getData("type")
+            .equals(Character.toString(SelectedResource.TYPE_ATTACHMENT))) {
       // Recurse to drill into the linked attachment, so we can use the correct viewer.
       // If more than one attachment has the linked uuid,
       // this is a zip or scorm package and we can let it fall through.

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/resource/ResourceAttachmentBean.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/resource/ResourceAttachmentBean.java
@@ -22,6 +22,8 @@ import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
 
 @SuppressWarnings("nls")
 public class ResourceAttachmentBean extends EquellaAttachmentBean {
+  public static final String TYPE_ID = "custom/resource";
+
   private String itemUuid;
   private int itemVersion;
   private char resourceType;
@@ -70,6 +72,6 @@ public class ResourceAttachmentBean extends EquellaAttachmentBean {
 
   @Override
   public String getRawAttachmentType() {
-    return "custom/resource";
+    return TYPE_ID;
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDao.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDao.java
@@ -67,7 +67,7 @@ public interface GenericDao<T, ID extends Serializable> {
   List<T> findAllByCriteria(Criterion... criterion);
 
   Object findByDetachedCriteria(
-      final Function<Criteria, Object> process, DetachedCriteria criteria);
+      DetachedCriteria criteria, final Function<Criteria, Object> process);
   /**
    * @param order can be null if no order is required
    * @param maxResults can be -1 to retrieve all results.

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDao.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDao.java
@@ -22,6 +22,8 @@ import com.tle.annotation.NonNullByDefault;
 import com.tle.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
+import java.util.function.Function;
+import org.hibernate.Criteria;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
@@ -64,6 +66,8 @@ public interface GenericDao<T, ID extends Serializable> {
 
   List<T> findAllByCriteria(Criterion... criterion);
 
+  Object findByDetachedCriteria(
+      final Function<Criteria, Object> process, DetachedCriteria criteria);
   /**
    * @param order can be null if no order is required
    * @param maxResults can be -1 to retrieve all results.

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
@@ -22,6 +22,7 @@ import com.tle.annotation.NonNullByDefault;
 import com.tle.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
+import java.util.function.Function;
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
@@ -228,6 +229,24 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
     return findAllByCriteria(null, -1, criterion);
   }
 
+  /**
+   * Allows for passing a DetachedCriteria to run Hibernate query.
+   *
+   * @param process Function from Criteria class used to determine what to do with the output of the query. This also specifies the return type.
+   * @param criteria Detached query that is attached to a new session.
+   */
+  public Object findByDetachedCriteria(
+      final Function<Criteria, Object> process, DetachedCriteria criteria) {
+    return getHibernateTemplate()
+        .execute(
+            new TLEHibernateCallback() {
+
+              @Override
+              public Object doInHibernate(Session session) throws HibernateException {
+                return process.apply(criteria.getExecutableCriteria(session));
+              }
+            });
+  }
   /*
    * (non-Javadoc)
    * @see

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
@@ -232,12 +232,12 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
   /**
    * Allows for passing a DetachedCriteria to run Hibernate query.
    *
+   * @param criteria Detached query that is attached to a new session.
    * @param process Function from Criteria class used to determine what to do with the output of the
    *     query. This also specifies the return type.
-   * @param criteria Detached query that is attached to a new session.
    */
   public Object findByDetachedCriteria(
-      final Function<Criteria, Object> process, DetachedCriteria criteria) {
+      DetachedCriteria criteria, final Function<Criteria, Object> process) {
     return getHibernateTemplate()
         .execute(
             new TLEHibernateCallback() {

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
@@ -232,7 +232,8 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
   /**
    * Allows for passing a DetachedCriteria to run Hibernate query.
    *
-   * @param process Function from Criteria class used to determine what to do with the output of the query. This also specifies the return type.
+   * @param process Function from Criteria class used to determine what to do with the output of the
+   *     query. This also specifies the return type.
    * @param criteria Detached query that is attached to a new session.
    */
   public Object findByDetachedCriteria(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change
When clicking attachment previews from the search page, if the attachment came from a non-integration selection session (Resource Attachment) then it wouldn't resolve the mimetype, and so the viewer would treat is as a default MIME type attachment and simply open in a new tab rather than a lightbox. 
To fix this, I added a case on the backend to handle mimetypes for resource attachments rather than just for file attachments. 
Since it is possible to select a resource attachment which points to a resource attachment which points to a resource attachment infinitely, we required a bit of recursion to drill down to the original attachment and get its mime type. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
