### PR TITLE
Do not re-render FavouriteItemDialog when it's about to close

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -207,8 +207,9 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     setFavouriteDialogProps,
   ] = useState<FavouriteItemDialogProps>({
     ...defaultFavouriteItemDialogProps,
-    closeDialog: () =>
-      setFavouriteDialogProps({ ...favouriteDialogProps, open: false }),
+    closeDialog: () => {
+      setFavouriteDialogProps({ ...favouriteDialogProps, open: false });
+    },
   });
 
   // A function passed to SearchResult to help build props of FavouriteItemDialog.
@@ -730,7 +731,9 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           {renderSidePanel()}
         </Drawer>
       </Hidden>
-      <FavouriteItemDialog {...favouriteDialogProps} />
+      {favouriteDialogProps.open && (
+        <FavouriteItemDialog {...favouriteDialogProps} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This dialog flickers with different dialog content when it's about to close. This can be fixed by excluding it from the react virtual DOM tree when the visibility flag is false.

