### PR TITLE
Update ci.yaml to use postgres 13.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:13.2
         env:
           POSTGRES_USER: equellatests
           POSTGRES_PASSWORD: password

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,7 +314,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:latest
         env:
           POSTGRES_USER: equellatests
           POSTGRES_PASSWORD: password

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,11 +184,15 @@ jobs:
     strategy:
       matrix:
         newui: [true, false]
+        pgsql-image: [latest, 9.6]
+        exclude:
+          - newui: false
+            pgsql-image: latest
       fail-fast: false
 
     services:
       postgres:
-        image: postgres:13.2
+        image: postgres:${{ matrix.pgsql-image }}
         env:
           POSTGRES_USER: equellatests
           POSTGRES_PASSWORD: password


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
This PR is just to test how GHA goes running the test suite against PostgreSQL 13.2 (current latest version). Recently when working on something else, I installed openEQUELLA with this version and it seemed to work. 
If this  goes well, I can take it out of draft and we can have GHA test against latest postgres from now on. If it doesn't go well, then we know that there are changes that need to be made to support this version. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
