### PR TITLE
Support adding a favourite search

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/favourite/FavouriteResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/favourite/FavouriteResource.scala
@@ -33,18 +33,24 @@ import javax.ws.rs.{DELETE, POST, Path, PathParam, Produces, QueryParam}
 import scala.collection.JavaConverters._
 
 /**
-  * Provide basic information of a favourite Item.
+  * Model class for Items to be saved to user's favourites.
   * @param keywords Tags of this Favourite Item
   * @param isAlwaysLatest Whether this Favourite Item uses latest Item version
   * @param itemID ID of the Item
   * @param bookmarkID ID of the related Bookmark
   */
-case class FavouriteItem(itemID: String,
-                         keywords: Array[String],
-                         isAlwaysLatest: Boolean,
-                         bookmarkID: Long)
+case class FavouriteItemModel(itemID: String,
+                              keywords: Array[String],
+                              isAlwaysLatest: Boolean,
+                              bookmarkID: Long)
 
-case class FavouriteSearchInfo(name: String, url: String)
+/**
+  * Model class for search definitions to be saved to user's favourites.
+  * @param id ID of a search definition. The value is None before the search definition persists to DB.
+  * @param name Name of a search definition.
+  * @param url Path to new Search UI, including all query strings.
+  */
+case class FavouriteSearchModel(id: Option[Long], name: String, url: String)
 
 @Path("favourite")
 @Produces(Array("application/json"))
@@ -57,8 +63,8 @@ class FavouriteResource {
   @Path("/item")
   @ApiOperation(value = "Add one Item to user's favourites",
                 notes = "This operation is essentially adding a new bookmark.",
-                response = classOf[FavouriteItem])
-  def addFavouriteItem(favouriteItem: FavouriteItem): Response = {
+                response = classOf[FavouriteItemModel])
+  def addFavouriteItem(favouriteItem: FavouriteItemModel): Response = {
     // ItemNotFoundException will be thrown by itemService if there is no Item matching this
     // item ID so we don't validate item ID here again.
     val item = itemService.get(new ItemId(favouriteItem.itemID))
@@ -67,7 +73,7 @@ class FavouriteResource {
     Response
       .status(Status.CREATED)
       .entity(
-        FavouriteItem(
+        FavouriteItemModel(
           newBookmark.getItem.getItemId.toString,
           newBookmark.getKeywords.asScala.toArray,
           newBookmark.isAlwaysLatest,
@@ -97,8 +103,8 @@ class FavouriteResource {
   @POST
   @Path("/search")
   @ApiOperation(value = "Add a search definition to user's search favourites",
-                response = classOf[FavouriteSearchInfo])
-  def addFavouriteSearch(searchInfo: FavouriteSearchInfo): Response = {
+                response = classOf[FavouriteSearchModel])
+  def addFavouriteSearch(searchInfo: FavouriteSearchModel): Response = {
     val favouriteSearch = new FavouriteSearch
     favouriteSearch.setName(searchInfo.name)
     favouriteSearch.setUrl(searchInfo.url)
@@ -109,7 +115,10 @@ class FavouriteResource {
 
     Response
       .status(Status.CREATED)
-      .entity(FavouriteSearchInfo(newFavouriteSearch.getName, newFavouriteSearch.getUrl))
+      .entity(
+        FavouriteSearchModel(Option(newFavouriteSearch.getId),
+                             newFavouriteSearch.getName,
+                             newFavouriteSearch.getUrl))
       .build()
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/favourite/FavouriteResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/favourite/FavouriteResource.scala
@@ -19,6 +19,10 @@
 package com.tle.web.api.favourite
 
 import com.tle.beans.item.ItemId
+import com.tle.common.institution.CurrentInstitution
+import com.tle.common.usermanagement.user.CurrentUser
+import com.tle.core.favourites.bean.FavouriteSearch
+import java.util.Date
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.ApiErrorResponse
 import io.swagger.annotations.{Api, ApiOperation, ApiParam}
@@ -48,6 +52,7 @@ class FavouriteResource {
   private val itemService     = LegacyGuice.itemService
 
   @POST
+  @Path("/item")
   @ApiOperation(value = "Add one Item to user's favourites",
                 notes = "This operation is essentially adding a new bookmark.",
                 response = classOf[FavouriteItem])
@@ -71,7 +76,7 @@ class FavouriteResource {
   }
 
   @DELETE
-  @Path("/{id}")
+  @Path("/item/{id}")
   @ApiOperation(
     value = "Delete one Item from user's favourites",
     notes = "This operation is essentially deleting a bookmark.",
@@ -85,5 +90,16 @@ class FavouriteResource {
         ApiErrorResponse
           .resourceNotFound(s"No Bookmark matching ID: ${id}")
     }
+  }
+
+  @POST
+  @Path("/search")
+  @ApiOperation(value = "Add one search to user's favourites", response = classOf[FavouriteSearch])
+  def addFavouriteSearch(favouriteSearch: FavouriteSearch): Response = {
+    favouriteSearch.setInstitution(CurrentInstitution.get())
+    favouriteSearch.setDateModified(new Date())
+    favouriteSearch.setOwner(CurrentUser.getUserID)
+    val newFavouriteSearch = LegacyGuice.favouriteSearchService.save(favouriteSearch)
+    Response.status(Status.CREATED).entity(newFavouriteSearch).build()
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/favourite/FavouriteResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/favourite/FavouriteResource.scala
@@ -44,6 +44,8 @@ case class FavouriteItem(itemID: String,
                          isAlwaysLatest: Boolean,
                          bookmarkID: Long)
 
+case class FavouriteSearchInfo(name: String, url: String)
+
 @Path("favourite")
 @Produces(Array("application/json"))
 @Api("Favourite")
@@ -94,12 +96,20 @@ class FavouriteResource {
 
   @POST
   @Path("/search")
-  @ApiOperation(value = "Add one search to user's favourites", response = classOf[FavouriteSearch])
-  def addFavouriteSearch(favouriteSearch: FavouriteSearch): Response = {
+  @ApiOperation(value = "Add a search definition to user's search favourites",
+                response = classOf[FavouriteSearchInfo])
+  def addFavouriteSearch(searchInfo: FavouriteSearchInfo): Response = {
+    val favouriteSearch = new FavouriteSearch
+    favouriteSearch.setName(searchInfo.name)
+    favouriteSearch.setUrl(searchInfo.url)
     favouriteSearch.setInstitution(CurrentInstitution.get())
     favouriteSearch.setDateModified(new Date())
     favouriteSearch.setOwner(CurrentUser.getUserID)
     val newFavouriteSearch = LegacyGuice.favouriteSearchService.save(favouriteSearch)
-    Response.status(Status.CREATED).entity(newFavouriteSearch).build()
+
+    Response
+      .status(Status.CREATED)
+      .entity(FavouriteSearchInfo(newFavouriteSearch.getName, newFavouriteSearch.getUrl))
+      .build()
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchService.java
@@ -25,7 +25,7 @@ import com.tle.web.sections.SectionInfo;
 import java.util.List;
 
 public interface FavouriteSearchService {
-  void save(FavouriteSearch search);
+  FavouriteSearch save(FavouriteSearch search);
 
   SearchFavouritesSearchResults search(Search search, int offset, int perPage);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchService.java
@@ -25,6 +25,13 @@ import com.tle.web.sections.SectionInfo;
 import java.util.List;
 
 public interface FavouriteSearchService {
+
+  /**
+   * Save a search definition to user's search favourites.
+   *
+   * @param search A search definition to be saved to database.
+   * @return A FavouriteSearch instance of the new entry.
+   */
   FavouriteSearch save(FavouriteSearch search);
 
   SearchFavouritesSearchResults search(Search search, int offset, int perPage);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -53,8 +53,9 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
 
   @Override
   @Transactional
-  public void save(FavouriteSearch search) {
+  public FavouriteSearch save(FavouriteSearch search) {
     dao.save(search);
+    return search;
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -34,6 +34,7 @@ import com.tle.core.favourites.bean.FavouriteSearch;
 import com.tle.core.favourites.dao.FavouriteSearchDao;
 import com.tle.core.guice.Bind;
 import com.tle.web.sections.SectionInfo;
+import com.tle.web.template.RenderNewTemplate;
 import java.util.Date;
 import java.util.List;
 import javax.inject.Inject;
@@ -72,6 +73,13 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
     FavouriteSearch search = dao.getById(id);
     if (search != null) {
       String url = search.getUrl();
+      if (url != null && RenderNewTemplate.isNewSearchPageEnabled()) {
+        // Remove the last '/' from 'CurrentInstitution.get().getUrl()' and then construct a full
+        // path.
+        String fullPath = StringUtils.removeEnd(CurrentInstitution.get().getUrl(), "/") + url;
+        info.forwardToUrl(fullPath);
+        return;
+      }
       // When user favourites a normal search, cloud search or hierarchy search,
       // the value of 'url' starts with '/access' if the fav search is added in old oEQ versions,
       // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -38,6 +38,7 @@ import com.tle.web.sections.SectionsRuntimeException;
 import com.tle.web.template.RenderNewTemplate;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.lang.StringUtils;
@@ -71,42 +72,43 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
 
   @Override
   public void executeSearch(SectionInfo info, long id) {
-    FavouriteSearch search = dao.getById(id);
-    if (search != null) {
-      String url = search.getUrl();
-      // If new Search UI is enabled then navigate to it by calling 'forwardToUrl'.
-      // If new Search UI is disabled but the search was added from new Search UI, throw an error.
-      // Else do however it used to do.
-      if (url != null) {
-        if (RenderNewTemplate.isNewSearchPageEnabled()) {
-          // Remove the last '/' from 'CurrentInstitution.get().getUrl()' and then construct a full
-          // path.
-          String fullPath = StringUtils.removeEnd(CurrentInstitution.get().getUrl(), "/") + url;
-          info.forwardToUrl(fullPath);
-          return;
-        } else if (url.contains("/page/search")) {
-          throw new SectionsRuntimeException(
-              "This favourite search is only available in new Search Page");
-        }
-      }
-      // When user favourites a normal search, cloud search or hierarchy search,
-      // the value of 'url' starts with '/access' if the fav search is added in old oEQ versions,
-      // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
-      if (url != null
-          && url.startsWith(WebConstants.ACCESS_PATH)
-          && StringUtils.indexOfAny(
-                  url,
-                  new String[] {
-                    WebConstants.SEARCHING_PAGE,
-                    WebConstants.HIERARCHY_PAGE,
-                    WebConstants.CLOUDSEARCH_PAGE
-                  })
-              > -1) {
-        url = "/" + url.replaceFirst(WebConstants.ACCESS_PATH, "");
-      }
-      SectionInfo forward = info.createForwardForUri(url);
-      info.forwardAsBookmark(forward);
+    Optional<FavouriteSearch> search = Optional.ofNullable(dao.getById(id));
+    Optional<String> url = search.map(FavouriteSearch::getUrl);
+    if (!search.isPresent() || !url.isPresent() || url.get().isEmpty()) {
+      throw new SectionsRuntimeException("Favourite search with id " + id + " is invalid.");
     }
+
+    String path = url.get();
+    // If new Search UI is enabled then navigate to it by calling 'forwardToUrl'.
+    // If new Search UI is disabled but the search was added from new Search UI, throw an error.
+    // Else do however it used to do.
+    if (RenderNewTemplate.isNewSearchPageEnabled()) {
+      // Remove the last '/' from 'CurrentInstitution.get().getUrl()' and then construct a full
+      // path.
+      String fullPath = StringUtils.removeEnd(CurrentInstitution.get().getUrl(), "/") + path;
+      info.forwardToUrl(fullPath);
+      return;
+    } else if (path.contains("/page/search")) {
+      throw new SectionsRuntimeException(
+          "This favourite search is only available in new Search Page");
+    }
+
+    // When user favourites a normal search, cloud search or hierarchy search,
+    // the value of 'url' starts with '/access' if the fav search is added in old oEQ versions,
+    // which results in "no tree for xxx" error. Hence, remove "/access" if it exists.
+    if (path.startsWith(WebConstants.ACCESS_PATH)
+        && StringUtils.indexOfAny(
+                path,
+                new String[] {
+                  WebConstants.SEARCHING_PAGE,
+                  WebConstants.HIERARCHY_PAGE,
+                  WebConstants.CLOUDSEARCH_PAGE
+                })
+            > -1) {
+      path = "/" + path.replaceFirst(WebConstants.ACCESS_PATH, "");
+    }
+    SectionInfo forward = info.createForwardForUri(path);
+    info.forwardAsBookmark(forward);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -55,8 +55,8 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
   @Override
   @Transactional
   public FavouriteSearch save(FavouriteSearch search) {
-    dao.save(search);
-    return search;
+    Long id = dao.save(search);
+    return dao.getById(id);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -89,8 +89,7 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
       info.forwardToUrl(fullPath);
       return;
     } else if (path.contains("/page/search")) {
-      throw new SectionsRuntimeException(
-          "This favourite search is only available in new Search Page");
+      throw new SectionsRuntimeException("This favourite search is only available in New UI mode.");
     }
 
     // When user favourites a normal search, cloud search or hierarchy search,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/favourites/service/FavouriteSearchServiceImpl.java
@@ -34,6 +34,7 @@ import com.tle.core.favourites.bean.FavouriteSearch;
 import com.tle.core.favourites.dao.FavouriteSearchDao;
 import com.tle.core.guice.Bind;
 import com.tle.web.sections.SectionInfo;
+import com.tle.web.sections.SectionsRuntimeException;
 import com.tle.web.template.RenderNewTemplate;
 import java.util.Date;
 import java.util.List;
@@ -73,12 +74,20 @@ public class FavouriteSearchServiceImpl implements FavouriteSearchService, UserC
     FavouriteSearch search = dao.getById(id);
     if (search != null) {
       String url = search.getUrl();
-      if (url != null && RenderNewTemplate.isNewSearchPageEnabled()) {
-        // Remove the last '/' from 'CurrentInstitution.get().getUrl()' and then construct a full
-        // path.
-        String fullPath = StringUtils.removeEnd(CurrentInstitution.get().getUrl(), "/") + url;
-        info.forwardToUrl(fullPath);
-        return;
+      // If new Search UI is enabled then navigate to it by calling 'forwardToUrl'.
+      // If new Search UI is disabled but the search was added from new Search UI, throw an error.
+      // Else do however it used to do.
+      if (url != null) {
+        if (RenderNewTemplate.isNewSearchPageEnabled()) {
+          // Remove the last '/' from 'CurrentInstitution.get().getUrl()' and then construct a full
+          // path.
+          String fullPath = StringUtils.removeEnd(CurrentInstitution.get().getUrl(), "/") + url;
+          info.forwardToUrl(fullPath);
+          return;
+        } else if (url.contains("/page/search")) {
+          throw new SectionsRuntimeException(
+              "This favourite search is only available in new Search Page");
+        }
       }
       // When user favourites a normal search, cloud search or hierarchy search,
       // the value of 'url' starts with '/access' if the fav search is added in old oEQ versions,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -31,6 +31,7 @@ import com.tle.core.encryption.EncryptionService;
 import com.tle.core.events.services.EventService;
 import com.tle.core.facetedsearch.service.FacetedSearchClassificationService;
 import com.tle.core.favourites.service.BookmarkService;
+import com.tle.core.favourites.service.FavouriteSearchService;
 import com.tle.core.fedsearch.FederatedSearchService;
 import com.tle.core.freetext.service.FreeTextService;
 import com.tle.core.i18n.BundleCache;
@@ -136,6 +137,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static EventService eventService;
 
   @Inject public static FacetedSearchClassificationService facetedSearchClassificationService;
+
+  @Inject public static FavouriteSearchService favouriteSearchService;
 
   @Inject public static FederatedSearchService federatedSearchService;
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/FavouriteApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/FavouriteApiTest.java
@@ -16,14 +16,16 @@ import org.codehaus.jackson.node.ObjectNode;
 import org.testng.annotations.Test;
 
 public class FavouriteApiTest extends AbstractRestApiTest {
-  private final String FAVOURITE_API_ENDPOINT =
-      getTestConfig().getInstitutionUrl() + "api/favourite";
+  private final String FAVOURITE_ITEM_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/favourite/item";
+  private final String FAVOURITE_SEARCH_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/favourite/search";
   private final String ITEM_KEY = "8a9ea41c-e28d-45de-b0a5-d75bca48d701/1";
   private long bookmarkId = 0L;
 
   @Test
-  public void testAddFavourite() throws IOException {
-    final PostMethod method = new PostMethod(FAVOURITE_API_ENDPOINT);
+  public void testAddFavouriteItem() throws IOException {
+    final PostMethod method = new PostMethod(FAVOURITE_ITEM_API_ENDPOINT);
     final String[] tags = {"a", "b"};
     ObjectNode body = mapper.createObjectNode();
     body.put("itemID", ITEM_KEY);
@@ -41,11 +43,32 @@ public class FavouriteApiTest extends AbstractRestApiTest {
     bookmarkId = response.get("bookmarkID").asLong();
   }
 
-  @Test(dependsOnMethods = "testAddFavourite")
-  public void testRemoveFavourite() throws IOException {
-    final HttpMethod method = new DeleteMethod(FAVOURITE_API_ENDPOINT + "/" + bookmarkId);
+  @Test(dependsOnMethods = "testAddFavouriteItem")
+  public void testRemoveFavouriteItem() throws IOException {
+    final HttpMethod method = new DeleteMethod(FAVOURITE_ITEM_API_ENDPOINT + "/" + bookmarkId);
     assertEquals(HttpStatus.SC_NO_CONTENT, makeClientRequest(method));
     // Try to delete again and the response code should be 404 as the bookmark is already deleted.
     assertEquals(HttpStatus.SC_NOT_FOUND, makeClientRequest(method));
+  }
+
+  @Test
+  public void testAddFavouriteSearch() throws IOException {
+    String searchName = "testFavouriteSearch";
+    String searchPath =
+        "/page/search?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RANK%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22mimeTypeFilters%22%3A%5B%5D%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D";
+    final PostMethod method = new PostMethod(FAVOURITE_SEARCH_API_ENDPOINT);
+    ObjectNode body = mapper.createObjectNode();
+    body.put("name", searchName);
+    body.put("url", searchPath);
+    method.setRequestEntity(new StringRequestEntity(body.toString(), "application/json", "UTF-8"));
+
+    assertEquals(HttpStatus.SC_CREATED, makeClientRequest(method));
+    JsonNode response = mapper.readTree(method.getResponseBody());
+    assertNotNull(response.get("id"));
+    assertNotNull(response.get("owner"));
+    assertNotNull(response.get("dateModified"));
+    assertNotNull(response.get("institution"));
+    assertEquals(searchName, response.get("name").asText());
+    assertEquals(searchPath, response.get("url").asText());
   }
 }

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/FavouriteApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/FavouriteApiTest.java
@@ -64,10 +64,6 @@ public class FavouriteApiTest extends AbstractRestApiTest {
 
     assertEquals(HttpStatus.SC_CREATED, makeClientRequest(method));
     JsonNode response = mapper.readTree(method.getResponseBody());
-    assertNotNull(response.get("id"));
-    assertNotNull(response.get("owner"));
-    assertNotNull(response.get("dateModified"));
-    assertNotNull(response.get("institution"));
     assertEquals(searchName, response.get("name").asText());
     assertEquals(searchPath, response.get("url").asText());
   }

--- a/oeq-ts-rest-api/src/Favourite.ts
+++ b/oeq-ts-rest-api/src/Favourite.ts
@@ -80,6 +80,20 @@ export interface FavouriteSearch {
   criteria?: string;
 }
 
+/**
+ * Data structure for adding a search definition to user's favourite search
+ */
+export interface FavouriteSearchInfo {
+  /**
+   * Name of a search definition
+   */
+  name: string;
+  /**
+   * Relative path to the new Search UI, including all query params.
+   */
+  url: string;
+}
+
 const FAVOURITE_ITEM_PATH = '/favourite/item';
 const FAVOURITE_SEARCH_PATH = '/favourite/search';
 
@@ -112,19 +126,14 @@ export const deleteFavouriteItem = (
 /**
  * Add a search to user's favourites.
  * @param apiBasePath Base URI to the oEQ institution and API
- * @param favouriteSearchName Name of a favourite search
- * @param favouriteSearchURL Relative path to the new Search UI including query strings (e.g. `/page/search?searchOptions=xxxxx`)
+ * @param searchInfo required information for adding a favourite search
  */
 export const addFavouriteSearch = (
   apiBasePath: string,
-  favouriteSearchName: string,
-  favouriteSearchURL: string
-): Promise<FavouriteSearch> =>
+  searchInfo: FavouriteSearchInfo
+): Promise<FavouriteSearchInfo> =>
   POST(
     apiBasePath + FAVOURITE_SEARCH_PATH,
-    (data): data is FavouriteSearch => is<FavouriteSearch>(data),
-    {
-      name: favouriteSearchName,
-      url: favouriteSearchURL,
-    }
+    (data): data is FavouriteSearchInfo => is<FavouriteSearchInfo>(data),
+    searchInfo
   );

--- a/oeq-ts-rest-api/src/Favourite.ts
+++ b/oeq-ts-rest-api/src/Favourite.ts
@@ -83,7 +83,11 @@ export interface FavouriteSearch {
 /**
  * Data structure for adding a search definition to user's favourite search
  */
-export interface FavouriteSearchInfo {
+export interface FavouriteSearchModel {
+  /**
+   * ID of a favourite search. The value is null when the search doesn't persist to DB.
+   */
+  id?: number;
   /**
    * Name of a search definition
    */
@@ -130,10 +134,10 @@ export const deleteFavouriteItem = (
  */
 export const addFavouriteSearch = (
   apiBasePath: string,
-  searchInfo: FavouriteSearchInfo
-): Promise<FavouriteSearchInfo> =>
+  searchInfo: FavouriteSearchModel
+): Promise<FavouriteSearchModel> =>
   POST(
     apiBasePath + FAVOURITE_SEARCH_PATH,
-    (data): data is FavouriteSearchInfo => is<FavouriteSearchInfo>(data),
+    (data): data is FavouriteSearchModel => is<FavouriteSearchModel>(data),
     searchInfo
   );

--- a/oeq-ts-rest-api/src/Favourite.ts
+++ b/oeq-ts-rest-api/src/Favourite.ts
@@ -40,7 +40,48 @@ export interface FavouriteItem {
   bookmarkID?: number;
 }
 
-const FAVOURITE_PATH = '/favourite';
+/**
+ * Type matching server-side model FavouriteSearch
+ */
+export interface FavouriteSearch {
+  /**
+   * Unique ID of a favourite search
+   */
+  id: number;
+  /**
+   * Name of a favourite search
+   */
+  name: string;
+  /**
+   * Relative path to the new Search UI including query strings
+   * If the search is added from new Search UI, the URL will be `/page/search?searchOptions=xxxxx`.
+   * If it's added from old UI, the URL will be `searching.do?xxx=yyy`.
+   */
+  url: string;
+  /**
+   * Owner of a favourite search
+   */
+  owner: string;
+  /**
+   * Last modified date
+   */
+  dateModified: string;
+  /**
+   * Name of selected Collection
+   */
+  within?: string;
+  /**
+   * Search query
+   */
+  query?: string;
+  /**
+   * Advanced search criteria
+   */
+  criteria?: string;
+}
+
+const FAVOURITE_ITEM_PATH = '/favourite/item';
+const FAVOURITE_SEARCH_PATH = '/favourite/search';
 
 /**
  * Add an Item to user's favourites.
@@ -52,7 +93,7 @@ export const addFavouriteItem = (
   favouriteItem: FavouriteItem
 ): Promise<FavouriteItem> =>
   POST(
-    apiBasePath + FAVOURITE_PATH,
+    apiBasePath + FAVOURITE_ITEM_PATH,
     (data): data is FavouriteItem => is<FavouriteItem>(data),
     favouriteItem
   );
@@ -66,4 +107,24 @@ export const deleteFavouriteItem = (
   apiBasePath: string,
   bookmarkID: number
 ): Promise<void> =>
-  DELETE<void>(`${apiBasePath}${FAVOURITE_PATH}/${bookmarkID}`);
+  DELETE<void>(`${apiBasePath}${FAVOURITE_ITEM_PATH}/${bookmarkID}`);
+
+/**
+ * Add a search to user's favourites.
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param favouriteSearchName Name of a favourite search
+ * @param favouriteSearchURL Relative path to the new Search UI including query strings (e.g. `/page/search?searchOptions=xxxxx`)
+ */
+export const addFavouriteSearch = (
+  apiBasePath: string,
+  favouriteSearchName: string,
+  favouriteSearchURL: string
+): Promise<FavouriteSearch> =>
+  POST(
+    apiBasePath + FAVOURITE_SEARCH_PATH,
+    (data): data is FavouriteSearch => is<FavouriteSearch>(data),
+    {
+      name: favouriteSearchName,
+      url: favouriteSearchURL,
+    }
+  );

--- a/oeq-ts-rest-api/test/Favourite.test.ts
+++ b/oeq-ts-rest-api/test/Favourite.test.ts
@@ -57,12 +57,11 @@ describe('FavouriteItem', () => {
 
 describe('FavouriteSearch', () => {
   it('should be possible to add a favourite search', async () => {
-    const newFavouriteSearch = await addFavouriteSearch(
-      TC.API_PATH,
-      'test',
-      '/page/search?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RATING%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22crab%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22mimeTypeFilters%22%3A%5B%5D%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D'
-    );
+    const newFavouriteSearch = await addFavouriteSearch(TC.API_PATH, {
+      name: 'test',
+      url:
+        '/page/search?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RATING%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22crab%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22mimeTypeFilters%22%3A%5B%5D%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D',
+    });
     expect(newFavouriteSearch).toBeTruthy();
-    expect(newFavouriteSearch.id).toBeTruthy();
   });
 });

--- a/oeq-ts-rest-api/test/Favourite.test.ts
+++ b/oeq-ts-rest-api/test/Favourite.test.ts
@@ -18,6 +18,7 @@
 import * as OEQ from '../src';
 import {
   addFavouriteItem,
+  addFavouriteSearch,
   deleteFavouriteItem,
   FavouriteItem,
 } from '../src/Favourite';
@@ -51,5 +52,17 @@ describe('FavouriteItem', () => {
     await expect(
       deleteFavouriteItem(TC.API_PATH, newBookmarkID)
     ).resolves.not.toThrow();
+  });
+});
+
+describe('FavouriteSearch', () => {
+  it('should be possible to add a favourite search', async () => {
+    const newFavouriteSearch = await addFavouriteSearch(
+      TC.API_PATH,
+      'test',
+      '/page/search?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RATING%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22crab%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22mimeTypeFilters%22%3A%5B%5D%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D'
+    );
+    expect(newFavouriteSearch).toBeTruthy();
+    expect(newFavouriteSearch.id).toBeTruthy();
   });
 });


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR, I added a new REST endpoint to support adding a favourite search. I also updated the endpoint for favourite item (from `favourite` to `favourite/item`). Then, I added the support to the REST Module for the new endpoint.

During testing, I encountered the issue of viewing a favourite search in new Search UI. Since the fix seems easy to implement, I added the fix in this PR.