### PR TITLE
Support restricted attachments properly in the new Search UI

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/item/interfaces/beans/AttachmentBean.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/item/interfaces/beans/AttachmentBean.java
@@ -31,6 +31,7 @@ public abstract class AttachmentBean extends AbstractExtendableBean {
   private String viewer;
   private boolean preview;
   private boolean erroredIndexing;
+  private boolean restricted;
 
   public String getUuid() {
     return uuid;
@@ -65,6 +66,14 @@ public abstract class AttachmentBean extends AbstractExtendableBean {
 
   public void setPreview(boolean preview) {
     this.preview = preview;
+  }
+
+  public void setRestricted(boolean restricted) {
+    this.restricted = restricted;
+  }
+
+  public boolean isRestricted() {
+    return restricted;
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/ItemAttachmentLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/ItemAttachmentLink.tsx
@@ -19,6 +19,7 @@ import { Link } from "@material-ui/core";
 import * as React from "react";
 import { SyntheticEvent, useState } from "react";
 import { ViewerDefinition } from "../modules/ViewerModule";
+import { languageStrings } from "../util/langstrings";
 import Lightbox from "./Lightbox";
 
 export interface ItemAttachmentLinkProps {
@@ -57,6 +58,7 @@ const ItemAttachmentLink = ({
   viewerDetails: [viewer, url],
 }: ItemAttachmentLinkProps) => {
   const [showLightbox, setShowLightbox] = useState<boolean>(false);
+  const { attachmentLink } = languageStrings.searchpage.searchResult;
 
   const buildLightboxLink = (): JSX.Element => {
     if (!mimeType) {
@@ -68,7 +70,7 @@ const ItemAttachmentLink = ({
     return (
       <>
         <Link
-          aria-label="Attachment link"
+          aria-label={`${attachmentLink} ${description}`}
           component="button"
           onClick={(event: SyntheticEvent) => {
             setShowLightbox(!showLightbox);
@@ -95,7 +97,7 @@ const ItemAttachmentLink = ({
   ) : (
     // Lightbox viewer not specified, so go with the default of a simple link.
     <Link
-      aria-label="Attachment link"
+      aria-label={`${attachmentLink} ${description}`}
       href={url}
       target="_blank"
       rel="noreferrer"

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/ItemAttachmentLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/ItemAttachmentLink.tsx
@@ -68,6 +68,7 @@ const ItemAttachmentLink = ({
     return (
       <>
         <Link
+          aria-label="Attachment link"
           component="button"
           onClick={(event: SyntheticEvent) => {
             setShowLightbox(!showLightbox);
@@ -93,7 +94,12 @@ const ItemAttachmentLink = ({
     buildLightboxLink()
   ) : (
     // Lightbox viewer not specified, so go with the default of a simple link.
-    <Link href={url} target="_blank" rel="noreferrer">
+    <Link
+      aria-label="Attachment link"
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+    >
       {children}
     </Link>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -433,11 +433,7 @@ export default function SearchResult({
                 viewerDetails?.viewerId
               )}
             >
-              <ListItemText
-                title={description}
-                color="primary"
-                primary={description}
-              />
+              <ListItemText color="primary" primary={description} />
             </ItemAttachmentLink>
             {inSelectionSession && (
               <ListItemSecondaryAction>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -433,7 +433,11 @@ export default function SearchResult({
                 viewerDetails?.viewerId
               )}
             >
-              <ListItemText color="primary" primary={description} />
+              <ListItemText
+                title={description}
+                color="primary"
+                primary={description}
+              />
             </ItemAttachmentLink>
             {inSelectionSession && (
               <ListItemSecondaryAction>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -412,6 +412,7 @@ export const languageStrings = {
     searchResult: {
       attachments: "Attachments",
       dateModified: "Modified",
+      attachmentLink: "Attachment link",
       keywordFoundInAttachment: "Search term found in attachment content",
       errors: {
         getAttachmentViewerDetailsFailure:

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -20,9 +20,10 @@ package com.tle.web.api.search
 
 import com.dytech.edge.exceptions.BadRequestException
 import com.tle.beans.entity.DynaCollection
-import com.tle.beans.item.{Bookmark, Comment, ItemIdKey}
+import com.tle.beans.item.{Comment, ItemIdKey}
 import com.tle.common.Check
 import com.tle.common.beans.exception.NotFoundException
+import com.tle.common.collection.AttachmentConfigConstants
 import com.tle.common.search.DefaultSearch
 import com.tle.common.search.whereparser.WhereParser
 import com.tle.core.freetext.queries.FreeTextBooleanQuery
@@ -217,6 +218,12 @@ object SearchHelper {
     */
   def convertToAttachment(attachmentBeans: java.util.List[AttachmentBean],
                           itemKey: ItemIdKey): Option[List[SearchResultAttachment]] = {
+    // Filter out restricted attachments if user doesn't have permission to view them
+    if (LegacyGuice.aclManager
+          .filterNonGrantedPrivileges(AttachmentConfigConstants.VIEW_RESTRICTED_ATTACHMENTS)
+          .isEmpty) {
+      attachmentBeans.removeIf(a => a.isRestricted)
+    }
     Option(attachmentBeans).map(
       beans =>
         beans.asScala

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -219,15 +219,15 @@ object SearchHelper {
     */
   def convertToAttachment(attachmentBeans: java.util.List[AttachmentBean],
                           itemKey: ItemIdKey): Option[List[SearchResultAttachment]] = {
-    // Filter out restricted attachments if user doesn't have permission to view them
-    if (CollectionUtils.isNotEmpty(attachmentBeans) && LegacyGuice.aclManager
-          .filterNonGrantedPrivileges(AttachmentConfigConstants.VIEW_RESTRICTED_ATTACHMENTS)
-          .isEmpty) {
-      attachmentBeans.removeIf(a => a.isRestricted)
-    }
     Option(attachmentBeans).map(
       beans =>
         beans.asScala
+        // Filter out restricted attachments if the user does not have permissions to view them
+          .filter(
+            a =>
+              !a.isRestricted || !LegacyGuice.aclManager
+                .filterNonGrantedPrivileges(AttachmentConfigConstants.VIEW_RESTRICTED_ATTACHMENTS)
+                .isEmpty)
           .map(att =>
             SearchResultAttachment(
               attachmentType = att.getRawAttachmentType,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -38,6 +38,7 @@ import com.tle.web.api.item.equella.interfaces.beans.{
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
 import com.tle.web.api.search.model.{SearchParam, SearchResultAttachment, SearchResultItem}
 import com.tle.web.controls.resource.ResourceAttachmentBean
+import org.apache.commons.collections.CollectionUtils
 
 import java.time.format.DateTimeParseException
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId}
@@ -219,7 +220,7 @@ object SearchHelper {
   def convertToAttachment(attachmentBeans: java.util.List[AttachmentBean],
                           itemKey: ItemIdKey): Option[List[SearchResultAttachment]] = {
     // Filter out restricted attachments if user doesn't have permission to view them
-    if (LegacyGuice.aclManager
+    if (CollectionUtils.isNotEmpty(attachmentBeans) && LegacyGuice.aclManager
           .filterNonGrantedPrivileges(AttachmentConfigConstants.VIEW_RESTRICTED_ATTACHMENTS)
           .isEmpty) {
       attachmentBeans.removeIf(a => a.isRestricted)

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -198,9 +198,7 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    */
   private By xPathForAttachmentText(String attachmentText) {
     return By.xpath(
-        String.format(
-            "//ul[contains(@class,'attachmentListItem')]//div[contains(@title,'%s')]",
-            attachmentText));
+        String.format("//*[@aria-label='Attachment link']//span[text()='%s']", attachmentText));
   }
 
   /**

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -189,6 +189,43 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   }
 
   /**
+   * Returns a By for the title attribute of an attachment in a search result given the attachment
+   * title.
+   *
+   * @param attachmentText The text to search against to find the name of the attachment within
+   *     search results.
+   * @return a By for the attachmentText.
+   */
+  private By xPathForAttachmentText(String attachmentText) {
+    return By.xpath(
+        String.format(
+            "//ul[contains(@class,'attachmentListItem')]//div[contains(@title,'%s')]",
+            attachmentText));
+  }
+
+  /**
+   * Waits until the search results contain an Attachment with a name that matches the given text.
+   *
+   * @param attachmentText the attachment name to be present in the search.
+   */
+  public void verifyAttachmentDisplayed(String attachmentText) {
+    waiter.until(
+        ExpectedConditions.presenceOfElementLocated(xPathForAttachmentText(attachmentText)));
+  }
+
+  /**
+   * Waits until the search results contain no attachments with a name that matches the given text.
+   * Uses numberOfElementsToBe(path, 0), as there is no non-presence condition in
+   * ExpectedConditions.
+   *
+   * @param attachmentText the attachment name not to be present in the search.
+   */
+  public void verifyAttachmentNotDisplayed(String attachmentText) {
+    waiter.until(
+        ExpectedConditions.numberOfElementsToBe(xPathForAttachmentText(attachmentText), 0));
+  }
+
+  /**
    * Get one Refine Search control by ID.
    *
    * @param id The ID of a Refine Search control, excluding its prefix.

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -189,8 +189,8 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   }
 
   /**
-   * Returns a By for the title attribute of an attachment in a search result given the attachment
-   * title.
+   * Returns a By for the aria-label attribute of an attachment link in a search result, given the
+   * attachment title.
    *
    * @param attachmentText The text to search against to find the name of the attachment within
    *     search results.

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -197,8 +197,8 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    * @return a By for the attachmentText.
    */
   private By xPathForAttachmentText(String attachmentText) {
-    return By.xpath(
-        String.format("//*[@aria-label='Attachment link']//span[text()='%s']", attachmentText));
+
+    return By.xpath(String.format("//*[@aria-label='Attachment link %s']", attachmentText));
   }
 
   /**

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -192,13 +192,12 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    * Returns a By for the aria-label attribute of an attachment link in a search result, given the
    * attachment title.
    *
-   * @param attachmentText The text to search against to find the name of the attachment within
-   *     search results.
-   * @return a By for the attachmentText.
+   * @param text The text to search against to find the name of the attachment within search
+   *     results.
+   * @return a By for the text.
    */
-  private By xPathForAttachmentText(String attachmentText) {
-
-    return By.xpath(String.format("//*[@aria-label='Attachment link %s']", attachmentText));
+  private By attachmentLinkByText(String text) {
+    return By.xpath(String.format("//*[@aria-label='Attachment link %s']", text));
   }
 
   /**
@@ -207,8 +206,7 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    * @param attachmentText the attachment name to be present in the search.
    */
   public void verifyAttachmentDisplayed(String attachmentText) {
-    waiter.until(
-        ExpectedConditions.presenceOfElementLocated(xPathForAttachmentText(attachmentText)));
+    waiter.until(ExpectedConditions.presenceOfElementLocated(attachmentLinkByText(attachmentText)));
   }
 
   /**
@@ -219,8 +217,7 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    * @param attachmentText the attachment name not to be present in the search.
    */
   public void verifyAttachmentNotDisplayed(String attachmentText) {
-    waiter.until(
-        ExpectedConditions.numberOfElementsToBe(xPathForAttachmentText(attachmentText), 0));
+    waiter.until(ExpectedConditions.numberOfElementsToBe(attachmentLinkByText(attachmentText), 0));
   }
 
   /**

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -90,7 +90,8 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(
-      description = "Search with two differently privileged users when there is a restricted attachment",
+      description =
+          "Search with two differently privileged users when there is a restricted attachment",
       dependsOnMethods = "searchWithLessACLS")
   @NewUIOnly
   public void searchWithRestrictedAttachments() {

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -90,7 +90,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(
-      description = "Search with a low privileged user when there are restricted attachments",
+      description = "Search with two differently privileged users when there are restricted attachments",
       dependsOnMethods = "searchWithLessACLS")
   @NewUIOnly
   public void searchWithRestrictedAttachments() {

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -90,7 +90,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
   }
 
   @Test(
-      description = "Search with two differently privileged users when there are restricted attachments",
+      description = "Search with two differently privileged users when there is a restricted attachment",
       dependsOnMethods = "searchWithLessACLS")
   @NewUIOnly
   public void searchWithRestrictedAttachments() {

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -88,4 +88,32 @@ public class NewSearchPageTest extends AbstractSessionTest {
     searchPage.selectCollection("Hardware");
     searchPage.waitForSearchCompleted(7);
   }
+
+  @Test(
+      description = "Search with a low privileged user when there are restricted attachments",
+      dependsOnMethods = "searchWithLessACLS")
+  @NewUIOnly
+  public void searchWithRestrictedAttachments() {
+    String attachmentTitle = "https://en.wikipedia.org/wiki/Itanium";
+    String searchTerm = "Itanium";
+    // The Item 'Itanium' has been set with a restricted attachment.
+
+    // To test, logon as TLE_ADMINISTRATOR (who inherently has VIEW_RESTRICTED_ATTACHMENTS)
+    logon("TLE_ADMINISTRATOR", testConfig.getAdminPassword());
+    searchPage = new NewSearchPage(context).load();
+
+    // and verify the attachment appears when the item appears in a search.
+    searchPage.changeQuery(searchTerm);
+    searchPage.waitForSearchCompleted(1);
+    searchPage.verifyAttachmentDisplayed(attachmentTitle);
+
+    // Then, logon as AutoTest (who doesn't have VIEW_RESTRICTED_ATTACHMENTS)
+    logon(AUTOTEST_LOGON, AUTOTEST_PASSWD);
+    searchPage = new NewSearchPage(context).load();
+
+    // and verify that the attachment doesn't show when the item appears in a search.
+    searchPage.changeQuery(searchTerm);
+    searchPage.waitForSearchCompleted(1);
+    searchPage.verifyAttachmentNotDisplayed(attachmentTitle);
+  }
 }

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -91,8 +91,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
 
   @Test(
       description =
-          "Search with two differently privileged users when there is a restricted attachment",
-      dependsOnMethods = "searchWithLessACLS")
+          "Search with two differently privileged users when there is a restricted attachment")
   @NewUIOnly
   public void searchWithRestrictedAttachments() {
     String attachmentTitle = "https://en.wikipedia.org/wiki/Itanium";

--- a/autotest/Tests/tests/facet/institution/items/24/19096.xml
+++ b/autotest/Tests/tests/facet/institution/items/24/19096.xml
@@ -17,7 +17,7 @@
       <url>https://en.wikipedia.org/wiki/Itanium</url>
       <description>https://en.wikipedia.org/wiki/Itanium</description>
       <preview>false</preview>
-      <restricted>false</restricted>
+      <restricted>true</restricted>
     </com.tle.beans.item.attachments.LinkAttachment>
   </attachments>
   <searchDetails>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes

##### Description of change
The new search UI doesn't handle restricted attachments properly - they will still appear in a search, although the file itself will be inaccessible. 
Added to the convertToAttachment function to filter out these attachments when the user does not have VIEW_RESTRICTED_ATTACHMENTS granted.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
