### PR TITLE
Allow login notice editor to upload images

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
@@ -169,7 +169,8 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
   public String getMimeType(String name) throws IOException {
     CustomisationFile customisationFile = new CustomisationFile();
     if (fileSystemService.fileExists(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name)) {
-      return fileSystemService.getMimeType(customisationFile, name);
+      return fileSystemService.getMimeType(
+          customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name);
     }
     return MediaType.MEDIA_TYPE_WILDCARD;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
@@ -153,13 +153,13 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
     String nameWithoutExtension = FilenameUtils.removeExtension(name);
     String extension = '.' + FilenameUtils.getExtension(name);
     if (fileSystemService.fileExists(customisationFile, getLoginNoticeImageFileName(name))) {
-      int i = 1;
-      while (fileSystemService.fileExists(
-          customisationFile,
-          getLoginNoticeImageFileName(nameWithoutExtension + '_' + i + extension))) {
-        i++;
-      }
-      return nameWithoutExtension + '_' + i + extension;
+      int i = 0;
+      String uniqueFileName;
+      do {
+        uniqueFileName = (nameWithoutExtension + '_' + (++i) + extension);
+      } while (fileSystemService.fileExists(
+          customisationFile, getLoginNoticeImageFileName(uniqueFileName)));
+      return uniqueFileName;
     }
     return name;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
@@ -152,9 +152,7 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
     CustomisationFile customisationFile = new CustomisationFile();
     String nameWithoutExtension = FilenameUtils.removeExtension(name);
     String extension = '.' + FilenameUtils.getExtension(name);
-    String concatenatedName = nameWithoutExtension + extension;
-    if (fileSystemService.fileExists(
-        customisationFile, getLoginNoticeImageFileName(concatenatedName))) {
+    if (fileSystemService.fileExists(customisationFile, getLoginNoticeImageFileName(name))) {
       int i = 1;
       while (fileSystemService.fileExists(
           customisationFile,
@@ -163,7 +161,7 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
       }
       return nameWithoutExtension + '_' + i + extension;
     }
-    return concatenatedName;
+    return name;
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
@@ -112,7 +112,7 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
       }
       if (!imageFileUsed) {
         fileSystemService.removeFile(
-            customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + imageFile.getName());
+            customisationFile, getLoginNoticeImageFileName(imageFile.getName()));
       }
     }
   }
@@ -144,7 +144,7 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
     CustomisationFile customisationFile = new CustomisationFile();
     String nameToUse = iterateImageNameIfDuplicateExists(name);
     fileSystemService.write(
-        customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + nameToUse, imageFile, false);
+        customisationFile, getLoginNoticeImageFileName(nameToUse), imageFile, false);
     return nameToUse;
   }
 
@@ -152,25 +152,25 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
     CustomisationFile customisationFile = new CustomisationFile();
     String nameWithoutExtension = FilenameUtils.removeExtension(name);
     String extension = '.' + FilenameUtils.getExtension(name);
+    String concatenatedName = nameWithoutExtension + extension;
     if (fileSystemService.fileExists(
-        customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + nameWithoutExtension + extension)) {
+        customisationFile, getLoginNoticeImageFileName(concatenatedName))) {
       int i = 1;
       while (fileSystemService.fileExists(
           customisationFile,
-          LOGIN_NOTICE_IMAGE_FOLDER_NAME + nameWithoutExtension + '_' + i + extension)) {
+          getLoginNoticeImageFileName(nameWithoutExtension + '_' + i + extension))) {
         i++;
       }
       return nameWithoutExtension + '_' + i + extension;
     }
-    return nameWithoutExtension + extension;
+    return concatenatedName;
   }
 
   @Override
   public String getMimeType(String name) throws IOException {
     CustomisationFile customisationFile = new CustomisationFile();
-    if (fileSystemService.fileExists(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name)) {
-      return fileSystemService.getMimeType(
-          customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name);
+    if (fileSystemService.fileExists(customisationFile, getLoginNoticeImageFileName(name))) {
+      return fileSystemService.getMimeType(customisationFile, getLoginNoticeImageFileName(name));
     }
     return MediaType.MEDIA_TYPE_WILDCARD;
   }
@@ -178,8 +178,8 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
   @Override
   public InputStream getPreLoginNoticeImage(String name) throws IOException {
     CustomisationFile customisationFile = new CustomisationFile();
-    if (fileSystemService.fileExists(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name)) {
-      return fileSystemService.read(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name);
+    if (fileSystemService.fileExists(customisationFile, getLoginNoticeImageFileName(name))) {
+      return fileSystemService.read(customisationFile, getLoginNoticeImageFileName(name));
     }
     return null;
   }
@@ -209,5 +209,9 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
     if (!loginNoticeEditorPrivilegeTreeProvider.isAuthorised()) {
       throw new PrivilegeRequiredException(PERMISSION_KEY);
     }
+  }
+
+  private String getLoginNoticeImageFileName(String fileName) {
+    return LOGIN_NOTICE_IMAGE_FOLDER_NAME + fileName;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
The folder (loginnoticeimages/) was missing from the getMimeType call which meant that uploading images to the login notice editor would error out. Added this to the image path for that call to fix it. 
I am open to spending time to add a test for this, currently we have a test for using an image URL but not uploading direct, which is how this went unnoticed. 
#2833 
Before change:

https://user-images.githubusercontent.com/24543345/111723724-23263a80-88b8-11eb-8e17-75e65dfc053f.mp4

After change:

https://user-images.githubusercontent.com/24543345/111723998-92039380-88b8-11eb-8598-d3bac016e6b9.mp4


<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
