### PR TITLE
feat(front-end): Disable MIME type filters in gallery modes

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -239,6 +239,11 @@ const clickCategory = (container: HTMLElement, category: string) => {
   userEvent.click(getByText(container, category));
 };
 
+const queryMimeTypesSelector = (page: RenderResult) =>
+  page.queryByLabelText(
+    languageStrings.searchpage.mimeTypeFilterSelector.helperText
+  );
+
 describe("Refine search by searching attachments", () => {
   let page: RenderResult;
 
@@ -500,11 +505,7 @@ describe("Hide Refine Search controls", () => {
   it("If not MIME type filters are available, the selector should be hidden", async () => {
     mockMimeTypeFilters.mockResolvedValueOnce([]);
     const page = await renderSearchPage();
-    expect(
-      page.queryByLabelText(
-        languageStrings.searchpage.mimeTypeFilterSelector.helperText
-      )
-    ).not.toBeInTheDocument();
+    expect(queryMimeTypesSelector(page)).not.toBeInTheDocument();
   });
 });
 
@@ -958,6 +959,7 @@ describe("Changing display mode", () => {
       // And now check the visual change
       expect(queryGalleryItems().length).toBeGreaterThan(0);
       expect(queryListItems()).toHaveLength(0);
+      expect(queryMimeTypesSelector(page)).not.toBeInTheDocument();
     }
   );
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -354,7 +354,11 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
           case "gallery-video": // Coming soon
             return {
               from: "gallery-search",
-              content: await imageGallerySearch(options),
+              content: await imageGallerySearch({
+                ...options,
+                // `mimeTypeFilters` should be ignored in gallery modes
+                mimeTypeFilters: undefined,
+              }),
             };
           case "list":
             return { from: "item-search", content: await searchItems(options) };
@@ -676,6 +680,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         />
       ),
       disabled:
+        searchPageOptions.displayMode !== "list" ||
         searchSettings.mimeTypeFilters.length === 0 ||
         !!searchPageOptions.externalMimeTypes,
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This clash with the idea of what the gallery is providing (kind of, pre-packed filter configurations), so best to avoid clashes and hide/disable them.


https://user-images.githubusercontent.com/43919233/111733847-f2043500-88cc-11eb-8761-c31c7dad3d76.mp4


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
