### PR TITLE
feat(rest-api): Add support for 'musts' to search2

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/Check.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/Check.java
@@ -81,6 +81,13 @@ public final class Check {
     }
   }
 
+  /**
+   * Returns {@code true} if the string is {@code null} or is zero length <strong>after</strong>
+   * trimming.
+   *
+   * @param s a possible string to test
+   * @return true if empty, false if has length greater than zero after trimming.
+   */
   public static boolean isEmpty(String s) {
     return s == null || s.trim().length() == 0;
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -98,6 +98,13 @@ object SearchHelper {
     }
     search.setFreeTextQuery(freeTextQuery)
 
+    handleMusts(params.musts) match {
+      case Some(ms) =>
+        ms foreach {
+          case (field, value) => search.addMust(field, value.asJavaCollection)
+        }
+    }
+
     search
   }
 
@@ -171,6 +178,35 @@ object SearchHelper {
         case None    => throw new NotFoundException(s"No collection UUID matching $c")
     })
     Some(collectionIds.toList.asJava)
+  }
+
+  /**
+    * Takes a list of colon delimited strings (i.e. key:value), and splits them to build up a map.
+    * Entries in the map can have multiple values, so each additional `key:value` will simply append
+    * to the existing entry(key).
+    *
+    * @param musts a list of colon delimited strings to be split
+    * @return the processed strings, ready for calls into `DefaultSearch.addMusts` or None if there
+    *         was an issue processing the strings
+    */
+  def handleMusts(musts: Array[String]): Option[Map[String, List[String]]] = {
+    val delimiter         = ':'
+    val oneOrMoreNonDelim = s"([^$delimiter]+)"
+    val mustExprFormat    = s"$oneOrMoreNonDelim$delimiter$oneOrMoreNonDelim".r
+
+    def valid = (xs: Array[String]) => xs.forall(s => s.matches(mustExprFormat.regex))
+
+    if (valid(musts)) {
+      Option(musts.foldLeft(Map[String, List[String]]())((result, mustExpr) => {
+        val mustExprFormat(k, v) = mustExpr
+        result.get(k) match {
+          case Some(existing) => result ++ Map(k -> (existing :+ v))
+          case None           => result ++ Map(k -> List(v))
+        }
+      }))
+    } else {
+      throw new BadRequestException("Provided 'musts' expression(s) was incorrectly formatted.")
+    }
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -90,4 +90,9 @@ class SearchParam {
   @ApiParam("List of MIME types to filter by")
   @QueryParam("mimeTypes")
   var mimeTypes: Array[String] = _
+
+  @ApiParam(
+    "List of search index key/value pairs to filter by. e.g. videothumb:true or realthumb:true.")
+  @QueryParam("musts")
+  var musts: Array[String] = _
 }

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -170,6 +170,41 @@ public class Search2ApiTest extends AbstractRestApiTest {
     assertEquals(getAvailable(result), 0);
   }
 
+  @Test(description = "Filter search by a list of 'musts'")
+  public void validMustsSearch() throws IOException {
+    JsonNode result = doSearch(200, null, new NameValuePair("musts", "moderating:true"));
+    assertEquals(getAvailable(result), 9);
+
+    result =
+        doSearch(
+            200,
+            null,
+            new NameValuePair("musts", "moderating:true"),
+            new NameValuePair("musts", "uuid:ab16b5f0-a12e-43f5-9d8b-25870528ad41"),
+            new NameValuePair("musts", "uuid:24b977ec-4df4-4a43-8922-8ca6f82a296a"));
+    assertEquals(getAvailable(result), 2);
+
+    result =
+        doSearch(
+            200, null, new NameValuePair("musts", "uuid:ab16b5f0-a12e-43f5-9d8b-25870528ad41"));
+    assertEquals(getAvailable(result), 1);
+  }
+
+  @DataProvider(name = "badMustExpressions")
+  public static Object[][] badMustExpressions() {
+    return new Object[][] {
+      {"tooFewDelimiter"}, {"too:many:delimiter"}, {":emptyField"},
+      {"emptyValue:"}, {":"}, {""}
+    };
+  }
+
+  @Test(
+      description = "Report error with incorrectly formatted 'musts' expressions",
+      dataProvider = "badMustExpressions")
+  public void invalidMustsSearch(String badMust) throws IOException {
+    doSearch(400, null, new NameValuePair("musts", badMust));
+  }
+
   private JsonNode doSearch(int expectedCode, String query, NameValuePair... queryVals)
       throws IOException {
     final HttpMethod method = new GetMethod(SEARCH_API_ENDPOINT);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Add support for oEQ's internal search service's concept of 'musts'. This essentially provides support for lucene queries at the index field level.

This is needed so that we can implement the Video gallery where suitable items are searched for with `videothumb:true`.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
