### PR TITLE
Hide menu panel in selection sessions and items viewed from integration

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/RenderDataHelper.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/RenderDataHelper.ts
@@ -48,6 +48,7 @@ export const basicRenderData: RenderData = {
   autotestMode: false,
   newSearch: true,
   selectionSessionInfo: basicSelectionSessionInfo,
+  viewedFromIntegration: false,
 };
 
 export const renderDataForSelectOrAdd: RenderData = {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
@@ -51,6 +51,7 @@ export interface RenderData {
   autotestMode: boolean;
   newSearch: boolean;
   selectionSessionInfo: SelectionSessionInfo | null;
+  viewedFromIntegration: boolean;
 }
 
 declare const renderData: RenderData | undefined;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/AppConfig.ts
@@ -46,11 +46,29 @@ export interface SelectionSessionInfo {
 }
 
 export interface RenderData {
+  /**
+   * Path to base resources for this institution.
+   */
   baseResources: string;
+  /**
+   * True if in the new UI.
+   */
   newUI: boolean;
+  /**
+   * True if server is running in autotestMode (VM argument -Dequella.autotest=true)
+   */
   autotestMode: boolean;
+  /**
+   * True if using the new Search UI.
+   */
   newSearch: boolean;
+  /**
+   * If in a Selection Session, this will be populated with info about the session. If not, this will be null.
+   */
   selectionSessionInfo: SelectionSessionInfo | null;
+  /**
+   * True if this is an item viewed via integration (integ/gen item link)
+   */
   viewedFromIntegration: boolean;
 }
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -45,6 +45,10 @@ import { ErrorResponse } from "../api/errors";
 import MessageInfo from "../components/MessageInfo";
 import { TooltipIconButton } from "../components/TooltipIconButton";
 import { guestUser, PageContent } from "../legacycontent/LegacyContent";
+import {
+  isItemViewedFromIntegration,
+  isSelectionSessionOpen,
+} from "../modules/LegacySelectionSessionModule";
 import { languageStrings } from "../util/langstrings";
 import MainMenu from "./MainMenu";
 import { legacyPageUrl, routes } from "./routes";
@@ -290,7 +294,7 @@ function useFullscreen({ fullscreenMode, hideAppBar }: useFullscreenProps) {
         return true;
 
       default:
-        return false;
+        return isSelectionSessionOpen() || isItemViewedFromIntegration();
     }
   })();
   return hideAppBar || modeIsFullscreen;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -156,6 +156,14 @@ export const isSelectionSessionOpen = (): boolean =>
   isSelectionSessionInfo(getRenderData()?.selectionSessionInfo);
 
 /**
+ * Returns true if this is an /integ/gen item link - that is, a resource summary viewed via an integration.
+ */
+export const isItemViewedFromIntegration = (): boolean => {
+  const viewedFromIntegration = getRenderData()?.viewedFromIntegration;
+  return typeof viewedFromIntegration == "boolean" && viewedFromIntegration;
+};
+
+/**
  * Return true if Selection Session is in 'Structured'.
  */
 export const isSelectionSessionInStructured = (): boolean =>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/LegacySelectionSessionModule.ts
@@ -158,10 +158,8 @@ export const isSelectionSessionOpen = (): boolean =>
 /**
  * Returns true if this is an /integ/gen item link - that is, a resource summary viewed via an integration.
  */
-export const isItemViewedFromIntegration = (): boolean => {
-  const viewedFromIntegration = getRenderData()?.viewedFromIntegration;
-  return typeof viewedFromIntegration == "boolean" && viewedFromIntegration;
-};
+export const isItemViewedFromIntegration = (): boolean =>
+  getRenderData()?.viewedFromIntegration ?? false;
 
 /**
  * Return true if Selection Session is in 'Structured'.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -99,6 +99,11 @@ object RenderNewTemplate {
       .enabled
   }
 
+  // Check if the viewing a resource via integration.
+  def isViewingItemFromIntegration(req: HttpServletRequest): Boolean = {
+    req.getServletPath == "/integ" && req.getPathInfo.startsWith("/gen/")
+  }
+
   // Check if new Search page is enabled.
   def isNewSearchPageEnabled: Boolean = {
     RunWithDB
@@ -209,7 +214,9 @@ object RenderNewTemplate {
         "newSearch",
         java.lang.Boolean.valueOf(isNewSearchPageEnabled),
         "selectionSessionInfo",
-        getSelectionSessionInfo(context).orNull
+        getSelectionSessionInfo(context).orNull,
+        "viewedFromIntegration",
+        java.lang.Boolean.valueOf(isViewingItemFromIntegration(req))
       )
     val renderData =
       Option(req.getAttribute(SetupJSKey).asInstanceOf[ObjectExpression => ObjectExpression])


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] videos are included showing significant UI changes

##### Description of change
We were defaulting to not full screen, which became a problem in selection sessions as it would take a short while to update based on width and height of the viewport. Now the default is false *unless* in a selection session or integration item view (integ/gen item link) where it is true. 

This involved adding to the renderData information passed from RenderNewTemplate a new variable viewedFromIntegration, which depends on a check as to whether the request is an /integ/gen item link. 
Before:
https://user-images.githubusercontent.com/24543345/112430075-c03e1300-8d91-11eb-979f-08c494bc6a8e.mp4

After:
https://user-images.githubusercontent.com/24543345/112429361-a6e89700-8d90-11eb-839f-def89e8e41ee.mp4

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
