### PR TITLE
feat(oeq-ts-rest-api): Add support for search2 musts

### DIFF
--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -118,7 +118,7 @@ export interface SearchParams extends SearchParamsBase {
 }
 
 /**
- * Provides the lower leve implementation of SearchParams for sending directly to the server.
+ * Provides the lower level implementation of SearchParams for sending directly to the server.
  */
 interface SearchParamsProcessed extends SearchParamsBase {
   musts?: string[];
@@ -347,8 +347,9 @@ export interface SearchResult<T> {
 const isMustValid = ([field, values]: Must): boolean => {
   const containsColon = (s: string): boolean => s.match(':') !== null;
   const noColonsPresent = !containsColon(field) && !values.some(containsColon);
-  const noEmptyValues = values.length > 0 && !values.some((v) => v.length < 1);
-  return field.length > 0 && noEmptyValues && noColonsPresent;
+  const noEmptyValues =
+    values.length > 0 && !values.some((v) => v.trim().length < 1);
+  return field.trim().length > 0 && noEmptyValues && noColonsPresent;
 };
 
 // convert one

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Common from './Common';
 import { is } from 'typescript-is';
 import { GET } from './AxiosInstance';
+import * as Common from './Common';
 import * as Utils from './Utils';
 
 /**
- * Type of query parameters that can be used in a search.
+ * Used for specifying must expressions such as `moderating:true`. Neither string should contain
+ * any colons (or other exempt Lucene syntax characters).
  */
-export interface SearchParams {
+type Must = [string, string[]];
+
+interface SearchParamsBase {
   /**
    * Query string.
    */
@@ -84,6 +87,41 @@ export interface SearchParams {
    * List of MIME types to filter by.
    */
   mimeTypes?: string[];
+}
+
+/**
+ * Type of query parameters that can be used in a search.
+ */
+export interface SearchParams extends SearchParamsBase {
+  /**
+   * List of search index key/value pairs to filter by. e.g. videothumb:true or realthumb:true.
+   * If for example you wanted to use the above two in a query, you'd specify them as:
+   *
+   * ```typescript
+   * const musts = [
+   *   ["videothumb": ["true"]],
+   *   ["realthumb": ["true"]],
+   * ];
+   * ```
+   *
+   * If you wanted to search on a list of UUIDs, you'd:
+   *
+   * ```typescript
+   * const musts = [
+   *   ["uuids",
+   *     ["ab16b5f0-a12e-43f5-9d8b-25870528ad41",
+   *      "24b977ec-4df4-4a43-8922-8ca6f82a296a"]],
+   * ];
+   * ```
+   */
+  musts?: Must[];
+}
+
+/**
+ * Provides the lower leve implementation of SearchParams for sending directly to the server.
+ */
+interface SearchParamsProcessed extends SearchParamsBase {
+  musts?: string[];
 }
 
 /**
@@ -306,6 +344,40 @@ export interface SearchResult<T> {
   highlight: string[];
 }
 
+const isMustValid = ([field, values]: Must): boolean => {
+  const containsColon = (s: string): boolean => s.match(':') !== null;
+  const noColonsPresent = !containsColon(field) && !values.some(containsColon);
+  const noEmptyValues = values.length > 0 && !values.some((v) => v.length < 1);
+  return field.length > 0 && noEmptyValues && noColonsPresent;
+};
+
+// convert one
+const convertMust = ([field, values]: Must): string[] =>
+  values.map((v) => `${field}:${v}`);
+
+// convert many
+const convertMusts = (musts: Must[]): string[] =>
+  musts.reduce(
+    (prev: string[], must: Must) => prev.concat(convertMust(must)),
+    []
+  );
+
+const processMusts = (musts?: Must[]): string[] | undefined => {
+  if (!musts) {
+    return;
+  }
+  musts.forEach((m) => {
+    if (!isMustValid(m)) {
+      throw new TypeError('Provided must specification is invalid: ' + m);
+    }
+  });
+  return convertMusts(musts);
+};
+const processSearchParams = (
+  params?: SearchParams
+): SearchParamsProcessed | undefined =>
+  params ? { ...params, musts: processMusts(params.musts) } : undefined;
+
 const SEARCH2_API_PATH = '/search2';
 
 /**
@@ -322,7 +394,7 @@ export const search = (
     apiBasePath + SEARCH2_API_PATH,
     (data): data is SearchResult<SearchResultItemRaw> =>
       is<SearchResult<SearchResultItemRaw>>(data),
-    params
+    processSearchParams(params)
   ).then((data) =>
     Utils.convertDateFields<SearchResult<SearchResultItem>>(data, [
       'createdDate',

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -76,6 +76,35 @@ describe('Search for items', () => {
     });
     expect(searchResult.results).toHaveLength(7);
   });
+
+  it("supports a list of 'musts' specifications", async () => {
+    const searchResult = await doSearch({
+      musts: [
+        ['moderating', ['true']],
+        [
+          'uuid',
+          [
+            'ab16b5f0-a12e-43f5-9d8b-25870528ad41',
+            '24b977ec-4df4-4a43-8922-8ca6f82a296a',
+          ],
+        ],
+      ],
+    });
+    expect(searchResult.results).toHaveLength(2);
+  });
+
+  it.each<[string, [string, string[]][]]>([
+    ['Empty field name', [['', ['a value']]]],
+    ['Empty value array', [['field-no-values', []]]],
+    ['Empty value', [['field-empty-value', ['']]]],
+    ['Colon in field name', [['field:colon', ['value-no-colon']]]],
+    ['Colon in value', [['field-no-colon', ['value:colon']]]],
+  ])(
+    "attempts to validate the 'musts' client side before sending [%s]",
+    async (_, musts) => {
+      await expect(doSearch({ musts })).rejects.toThrow(TypeError);
+    }
+  );
 });
 
 describe('Search for attachments', () => {

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -95,8 +95,13 @@ describe('Search for items', () => {
 
   it.each<[string, [string, string[]][]]>([
     ['Empty field name', [['', ['a value']]]],
+    [
+      'Empty field name - whitespace',
+      [[' ', ['a value for whitespace field']]],
+    ],
     ['Empty value array', [['field-no-values', []]]],
     ['Empty value', [['field-empty-value', ['']]]],
+    ['Empty value - whitespace', [['field-empty-value-whitespace', [' ']]]],
     ['Colon in field name', [['field:colon', ['value-no-colon']]]],
     ['Colon in value', [['field-no-colon', ['value:colon']]]],
   ])(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

So that we can use that provided in #2841 

Added some typing to try and assist callers providing musts in a correct format before they're sent to the server. Maybe overkill, but could help.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
