### PR TITLE
Handle long strings without breaking layout

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -181,6 +181,10 @@ export const useStyles = makeStyles((theme: Theme) => {
   const tabHeight = 48;
   return {
     "@global": {
+      "a, p": {
+        //handle long strings without breaking the layout
+        overflowWrap: "anywhere",
+      },
       a: {
         textDecoration: "none",
         color: theme.palette.primary.main,

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1237,6 +1237,16 @@ div.area {
   float: none;
 }
 
+.itemsummary-layout #col1 {
+  //handle long strings  in item summaries without breaking the layout
+  overflow-wrap: anywhere;
+}
+
+.wizard-layout #col1 {
+  //handle wizard control names and descriptions without breaking the layout
+  max-width:85%;
+}
+
 .area h3 {
   @include typography-headline-6;
   color: $primaryTextColor;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -1244,7 +1244,7 @@ div.area {
 
 .wizard-layout #col1 {
   //handle wizard control names and descriptions without breaking the layout
-  max-width:85%;
+  max-width: 85%;
 }
 
 .area h3 {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -63,6 +63,7 @@ $col2Width: 250px;
 $standardBorderRadius: 4px;
 $roundButtonRadius: 50px;
 $termSelectorHeight: 68px;
+$savePanelWidth: 221px;
 
 @mixin boxShadow {
   box-shadow: $boxShadow;
@@ -1244,7 +1245,7 @@ div.area {
 
 .wizard-layout #col1 {
   //handle wizard control names and descriptions without breaking the layout
-  max-width: 85%;
+  max-width: calc(100% - #{$savePanelWidth});
 }
 
 .area h3 {
@@ -1784,7 +1785,7 @@ Search page
   }
 
   #col2 {
-    width: 221px;
+    width: $savePanelWidth;
     margin-left: $doubleMargin;
 
     .box hr {
@@ -2931,7 +2932,7 @@ Contribution wizard styling
 *****************************************************************************/
 .wizard-layout #col2,
 #affix-div {
-  width: 221px;
+  width: $savePanelWidth;
 }
 
 .wizard-layout .contribution-rightNav {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#2850
This problem was discovered as a support issue. So various strings can break the layout if they are too long, both in the legacy EBP UI and the new search UI. 
In the Template.tsx file, I added a global rule to all `a` and `p` tags to `overflow-wrap:anywhere`, which means they can simply break to a new line rather than extending the width of their containers.
In the `legacy.scss` I handle the same issue in contribution wizards and in item summaries. 
I was able to confirm that this handles well in the main UI and in a selection session.

Before change:

https://user-images.githubusercontent.com/24543345/113230769-7602e780-92e5-11eb-8549-0c58196c9771.mp4

After change:

https://user-images.githubusercontent.com/24543345/113230778-7c915f00-92e5-11eb-9689-947b43c2d863.mp4

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
