### PR TITLE
Add support to the GallerySearchModule for Video Gallery - and inital basic integration

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/GallerySearchModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/GallerySearchModule.mock.ts
@@ -274,12 +274,11 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
       mainEntry: {
         mimeType: "image/jpeg",
         name: "Kelpie1.jpg",
-        imagePathSmall:
+        thumbnailSmall:
           "http://localhost:8080/ian/thumbs/fe79c485-a6dd-4743-81e8-52de66494633/1/dbd6dd98-d731-4a8f-907e-ceaf9608da3b?gallery=thumbnail",
-        imagePathMedium:
+        thumbnailLarge:
           "http://localhost:8080/ian/thumbs/fe79c485-a6dd-4743-81e8-52de66494633/1/dbd6dd98-d731-4a8f-907e-ceaf9608da3b?gallery=preview",
-        imagePathFull:
-          "file/fe79c485-a6dd-4743-81e8-52de66494633/1/Kelpie1.jpg",
+        directUrl: "file/fe79c485-a6dd-4743-81e8-52de66494633/1/Kelpie1.jpg",
       },
       additionalEntries: [],
     },
@@ -296,23 +295,21 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
       mainEntry: {
         mimeType: "image/jpeg",
         name: "Kelpie2.jpg",
-        imagePathSmall:
+        thumbnailSmall:
           "http://localhost:8080/ian/thumbs/40e879db-393b-4256-bfe2-9a78771d6937/1/4fddbeb7-8d16-4417-be60-8709ce9d7b15?gallery=thumbnail",
-        imagePathMedium:
+        thumbnailLarge:
           "http://localhost:8080/ian/thumbs/40e879db-393b-4256-bfe2-9a78771d6937/1/4fddbeb7-8d16-4417-be60-8709ce9d7b15?gallery=preview",
-        imagePathFull:
-          "file/40e879db-393b-4256-bfe2-9a78771d6937/1/Kelpie2.jpg",
+        directUrl: "file/40e879db-393b-4256-bfe2-9a78771d6937/1/Kelpie2.jpg",
       },
       additionalEntries: [
         {
           mimeType: "image/jpeg",
           name: "Kelpie1.jpg",
-          imagePathSmall:
+          thumbnailSmall:
             "http://localhost:8080/ian/thumbs/40e879db-393b-4256-bfe2-9a78771d6937/1/df55f129-1bbb-427f-b8a0-46792559bea9?gallery=thumbnail",
-          imagePathMedium:
+          thumbnailLarge:
             "http://localhost:8080/ian/thumbs/40e879db-393b-4256-bfe2-9a78771d6937/1/df55f129-1bbb-427f-b8a0-46792559bea9?gallery=preview",
-          imagePathFull:
-            "file/40e879db-393b-4256-bfe2-9a78771d6937/1/Kelpie1.jpg",
+          directUrl: "file/40e879db-393b-4256-bfe2-9a78771d6937/1/Kelpie1.jpg",
         },
       ],
     },
@@ -329,43 +326,40 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
       mainEntry: {
         mimeType: "image/jpeg",
         name: "Wilkie Collins.jpg",
-        imagePathSmall:
+        thumbnailSmall:
           "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/a09056f0-c867-40ea-80c0-a1433f487182?gallery=thumbnail",
-        imagePathMedium:
+        thumbnailLarge:
           "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/a09056f0-c867-40ea-80c0-a1433f487182?gallery=preview",
-        imagePathFull:
+        directUrl:
           "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Wilkie Collins.jpg",
       },
       additionalEntries: [
         {
           mimeType: "image/jpeg",
           name: "Dickens.jpg",
-          imagePathSmall:
+          thumbnailSmall:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/e3f96e6b-a6aa-4c8e-975c-c2c3870daa34?gallery=thumbnail",
-          imagePathMedium:
+          thumbnailLarge:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/e3f96e6b-a6aa-4c8e-975c-c2c3870daa34?gallery=preview",
-          imagePathFull:
-            "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Dickens.jpg",
+          directUrl: "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Dickens.jpg",
         },
         {
           mimeType: "image/jpeg",
           name: "Conrad.jpg",
-          imagePathSmall:
+          thumbnailSmall:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/f226e79a-1d2c-4894-aaa1-032812351d29?gallery=thumbnail",
-          imagePathMedium:
+          thumbnailLarge:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/f226e79a-1d2c-4894-aaa1-032812351d29?gallery=preview",
-          imagePathFull:
-            "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Conrad.jpg",
+          directUrl: "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Conrad.jpg",
         },
         {
           mimeType: "image/jpeg",
           name: "Eliot.jpg",
-          imagePathSmall:
+          thumbnailSmall:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/3afceca2-63d0-47ea-b921-f199b73194fc?gallery=thumbnail",
-          imagePathMedium:
+          thumbnailLarge:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/3afceca2-63d0-47ea-b921-f199b73194fc?gallery=preview",
-          imagePathFull:
-            "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Eliot(2).jpg",
+          directUrl: "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Eliot(2).jpg",
         },
       ],
     },

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/GallerySearchModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/GallerySearchModule.mock.ts
@@ -256,6 +256,195 @@ export const basicImageSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
   highlight: [],
 };
 
+export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> = {
+  start: 0,
+  length: 3,
+  available: 15,
+  results: [
+    {
+      uuid: "de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5",
+      version: 1,
+      name: "How to grow African Violets",
+      description:
+        "YouTube resources to learn how to grow African Violets with 6 tips.",
+      status: "live",
+      createdDate: new Date("2021-03-29T16:21:41.801+11:00"),
+      modifiedDate: new Date("2021-03-29T16:21:41.799+11:00"),
+      collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
+      commentCount: 0,
+      starRatings: -1.0,
+      attachments: [
+        {
+          attachmentType: "custom/youtube",
+          id: "398dbef0-7d12-4b72-af3d-095dd70b019d",
+          description: "6 Tips For Caring for African Violets",
+          preview: false,
+          links: {
+            view:
+              "http://localhost:8080/ian/items/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/?attachment.uuid=398dbef0-7d12-4b72-af3d-095dd70b019d",
+            thumbnail:
+              "http://localhost:8080/ian/thumbs/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/398dbef0-7d12-4b72-af3d-095dd70b019d",
+            externalId: "9VCudo90K5I",
+          },
+        },
+      ],
+      thumbnail: "default",
+      displayFields: [],
+      displayOptions: {
+        attachmentType: "STRUCTURED",
+        disableThumbnail: false,
+        standardOpen: false,
+        integrationOpen: true,
+      },
+      keywordFoundInAttachment: false,
+      links: {
+        view:
+          "http://localhost:8080/ian/items/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/",
+        self:
+          "http://localhost:8080/ian/api/item/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/",
+      },
+      isLatestVersion: true,
+    },
+    {
+      uuid: "59139c45-788b-4200-a9cb-e4a39e76ad35",
+      version: 1,
+      name: "Quokka (JS) Example",
+      description: "An example video of using Quokka JS in IntelliJ",
+      status: "live",
+      createdDate: new Date("2021-03-25T17:18:42.259+11:00"),
+      modifiedDate: new Date("2021-03-25T17:18:42.258+11:00"),
+      collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
+      commentCount: 0,
+      starRatings: -1.0,
+      attachments: [
+        {
+          attachmentType: "file",
+          id: "d81a7599-89a2-474e-b756-50bda202b349",
+          description: "Quokka-2021-03-24_14.42.37.mp4",
+          preview: false,
+          mimeType: "video/mp4",
+          hasGeneratedThumb: true,
+          links: {
+            view:
+              "http://localhost:8080/ian/items/59139c45-788b-4200-a9cb-e4a39e76ad35/1/?attachment.uuid=d81a7599-89a2-474e-b756-50bda202b349",
+            thumbnail:
+              "http://localhost:8080/ian/thumbs/59139c45-788b-4200-a9cb-e4a39e76ad35/1/d81a7599-89a2-474e-b756-50bda202b349",
+          },
+          filePath: "Quokka-2021-03-24_14.42.37.mp4",
+        },
+      ],
+      thumbnail: "default",
+      displayFields: [],
+      displayOptions: {
+        attachmentType: "STRUCTURED",
+        disableThumbnail: false,
+        standardOpen: false,
+        integrationOpen: true,
+      },
+      keywordFoundInAttachment: false,
+      links: {
+        view:
+          "http://localhost:8080/ian/items/59139c45-788b-4200-a9cb-e4a39e76ad35/1/",
+        self:
+          "http://localhost:8080/ian/api/item/59139c45-788b-4200-a9cb-e4a39e76ad35/1/",
+      },
+      bookmarkId: 89567,
+      isLatestVersion: true,
+    },
+    {
+      uuid: "9d5112d4-87b6-4ac1-b773-ceaa4a6c5205",
+      version: 1,
+      name: "Daily Stoic Resources",
+      description: "Resources provided by the Daily Stoic",
+      status: "live",
+      createdDate: new Date("2021-03-23T15:14:12.714+11:00"),
+      modifiedDate: new Date("2021-03-23T15:14:12.713+11:00"),
+      collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
+      commentCount: 0,
+      starRatings: -1.0,
+      attachments: [
+        {
+          attachmentType: "file",
+          id: "e82207be-a9f2-442a-a17f-5c834d5b36cc",
+          description: "DailyStoicLogo.jpeg",
+          preview: false,
+          mimeType: "image/jpeg",
+          hasGeneratedThumb: true,
+          links: {
+            view:
+              "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/?attachment.uuid=e82207be-a9f2-442a-a17f-5c834d5b36cc",
+            thumbnail:
+              "http://localhost:8080/ian/thumbs/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/e82207be-a9f2-442a-a17f-5c834d5b36cc",
+          },
+          filePath: "DailyStoicLogo.jpeg",
+        },
+        {
+          attachmentType: "custom/youtube",
+          id: "33eb363d-77f4-4d40-84a3-d0ae1687b5f6",
+          description:
+            "These Simple Words Will Help You Through Life's Most Difficult Situations | Ryan Holiday",
+          preview: false,
+          links: {
+            view:
+              "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/?attachment.uuid=33eb363d-77f4-4d40-84a3-d0ae1687b5f6",
+            thumbnail:
+              "http://localhost:8080/ian/thumbs/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/33eb363d-77f4-4d40-84a3-d0ae1687b5f6",
+            externalId: "qMNMyLm57VA",
+          },
+        },
+        {
+          attachmentType: "custom/youtube",
+          id: "9fc093fa-f03a-45a5-98df-17381d63972f",
+          description:
+            "Stoicism and the Art of Resilience | Ryan Holiday | Epictetus",
+          preview: false,
+          links: {
+            view:
+              "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/?attachment.uuid=9fc093fa-f03a-45a5-98df-17381d63972f",
+            thumbnail:
+              "http://localhost:8080/ian/thumbs/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/9fc093fa-f03a-45a5-98df-17381d63972f",
+            externalId: "6-UQYo1YabY",
+          },
+        },
+        {
+          attachmentType: "custom/youtube",
+          id: "97bc82ed-fda4-40a9-91ea-e32da76e66a2",
+          description:
+            "Stoicism's Simple Secret To Being Happier | Ryan Holiday | Daily Stoic",
+          preview: false,
+          links: {
+            view:
+              "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/?attachment.uuid=97bc82ed-fda4-40a9-91ea-e32da76e66a2",
+            thumbnail:
+              "http://localhost:8080/ian/thumbs/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/97bc82ed-fda4-40a9-91ea-e32da76e66a2",
+            externalId: "DtB1Uk_aJOw",
+          },
+        },
+      ],
+      thumbnail: "default",
+      displayFields: [
+        { type: "node", name: "Resource Type", html: "Supplementary reading" },
+      ],
+      displayOptions: {
+        attachmentType: "STRUCTURED",
+        disableThumbnail: false,
+        standardOpen: false,
+        integrationOpen: true,
+      },
+      keywordFoundInAttachment: false,
+      links: {
+        view:
+          "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/",
+        self:
+          "http://localhost:8080/ian/api/item/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/",
+      },
+      bookmarkId: 89568,
+      isLatestVersion: true,
+    },
+  ],
+  highlight: [],
+};
+
 export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<GallerySearchResultItem> = {
   start: 0,
   length: 3,
@@ -360,6 +549,92 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
           thumbnailLarge:
             "http://localhost:8080/ian/thumbs/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/3afceca2-63d0-47ea-b921-f199b73194fc?gallery=preview",
           directUrl: "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Eliot(2).jpg",
+        },
+      ],
+    },
+  ],
+  highlight: [],
+};
+
+export const transformedBasicVideoSearchResponse: OEQ.Search.SearchResult<GallerySearchResultItem> = {
+  start: 0,
+  length: 3,
+  available: 15,
+  results: [
+    {
+      uuid: "de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5",
+      version: 1,
+      name: "How to grow African Violets",
+      links: {
+        view:
+          "http://localhost:8080/ian/items/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/",
+        self:
+          "http://localhost:8080/ian/api/item/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/",
+      },
+      mainEntry: {
+        mimeType: "openequella/youtube",
+        name: "6 Tips For Caring for African Violets",
+        thumbnailSmall: "https://i.ytimg.com/vi/9VCudo90K5I/default.jpg",
+        thumbnailLarge: "https://i.ytimg.com/vi/9VCudo90K5I/hqdefault.jpg",
+        directUrl: "https://www.youtube.com/watch?v=9VCudo90K5I",
+      },
+      additionalEntries: [],
+    },
+    {
+      uuid: "59139c45-788b-4200-a9cb-e4a39e76ad35",
+      version: 1,
+      name: "Quokka (JS) Example",
+      links: {
+        view:
+          "http://localhost:8080/ian/items/59139c45-788b-4200-a9cb-e4a39e76ad35/1/",
+        self:
+          "http://localhost:8080/ian/api/item/59139c45-788b-4200-a9cb-e4a39e76ad35/1/",
+      },
+      mainEntry: {
+        mimeType: "video/mp4",
+        name: "Quokka-2021-03-24_14.42.37.mp4",
+        thumbnailSmall:
+          "http://localhost:8080/ian/thumbs/59139c45-788b-4200-a9cb-e4a39e76ad35/1/d81a7599-89a2-474e-b756-50bda202b349?gallery=gallery",
+        thumbnailLarge:
+          "http://localhost:8080/ian/thumbs/59139c45-788b-4200-a9cb-e4a39e76ad35/1/d81a7599-89a2-474e-b756-50bda202b349?gallery=preview",
+        directUrl:
+          "file/59139c45-788b-4200-a9cb-e4a39e76ad35/1/Quokka-2021-03-24_14.42.37.mp4",
+      },
+      additionalEntries: [],
+    },
+    {
+      uuid: "9d5112d4-87b6-4ac1-b773-ceaa4a6c5205",
+      version: 1,
+      name: "Daily Stoic Resources",
+      links: {
+        view:
+          "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/",
+        self:
+          "http://localhost:8080/ian/api/item/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/",
+      },
+      mainEntry: {
+        mimeType: "openequella/youtube",
+        name:
+          "These Simple Words Will Help You Through Life's Most Difficult Situations | Ryan Holiday",
+        thumbnailSmall: "https://i.ytimg.com/vi/qMNMyLm57VA/default.jpg",
+        thumbnailLarge: "https://i.ytimg.com/vi/qMNMyLm57VA/hqdefault.jpg",
+        directUrl: "https://www.youtube.com/watch?v=qMNMyLm57VA",
+      },
+      additionalEntries: [
+        {
+          mimeType: "openequella/youtube",
+          name: "Stoicism and the Art of Resilience | Ryan Holiday | Epictetus",
+          thumbnailSmall: "https://i.ytimg.com/vi/6-UQYo1YabY/default.jpg",
+          thumbnailLarge: "https://i.ytimg.com/vi/6-UQYo1YabY/hqdefault.jpg",
+          directUrl: "https://www.youtube.com/watch?v=6-UQYo1YabY",
+        },
+        {
+          mimeType: "openequella/youtube",
+          name:
+            "Stoicism's Simple Secret To Being Happier | Ryan Holiday | Daily Stoic",
+          thumbnailSmall: "https://i.ytimg.com/vi/DtB1Uk_aJOw/default.jpg",
+          thumbnailLarge: "https://i.ytimg.com/vi/DtB1Uk_aJOw/hqdefault.jpg",
+          directUrl: "https://www.youtube.com/watch?v=DtB1Uk_aJOw",
         },
       ],
     },

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/FpTsMatchers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/FpTsMatchers.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as E from "fp-ts/Either";
+
+expect.extend({
+  /**
+   * An expect matcher for Jest to confirm the response is a E.Left - typically to confirm an
+   * error result.
+   *
+   * @param received The E.Either to validate
+   */
+  toBeLeft: (received: E.Either<any, any>): jest.CustomMatcherResult =>
+    E.isLeft(received)
+      ? {
+          pass: true,
+          message: () => `expected ${received} not to be E.Left`,
+        }
+      : {
+          pass: false,
+          message: () => `expected ${received} to be E.Left`,
+        },
+
+  /**
+   * An expect matcher for Jest to confirm the response is an E.Right - typically to confirm an
+   * success result.
+   *
+   * @param received The E.Either to validate
+   */
+  toBeRight: (received: E.Either<any, any>): jest.CustomMatcherResult =>
+    E.isRight(received)
+      ? {
+          pass: true,
+          message: () => `expected ${received} not to be E.Right`,
+        }
+      : {
+          pass: false,
+          message: () => `expected E.Right but got E.Left(${received.left})`,
+        },
+});
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeLeft(): jest.CustomMatcherResult;
+      toBeRight(): jest.CustomMatcherResult;
+    }
+  }
+}
+
+/**
+ * An expect matcher for Jest to confirm the response is an E.Right - typically to confirm an
+ * success result. The value is also returned, albeit (unfortunately) unioned with an undefined. It
+ * is considered safe to access the value via a bang - .e.g `const value = expectRight(either)!;`
+ *
+ * @param either The E.Either to validate
+ * @return The value contained in the E.Right
+ */
+export const expectRight = <V>(either: E.Either<unknown, V>): V | undefined => {
+  expect(either).toBeRight();
+  return E.isRight(either) ? either.right : undefined;
+};

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/FpTsMatchers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/FpTsMatchers.ts
@@ -64,9 +64,9 @@ declare global {
 }
 
 /**
- * An expect matcher for Jest to confirm the response is an E.Right - typically to confirm an
- * success result. The value is also returned, albeit (unfortunately) unioned with an undefined. It
- * is considered safe to access the value via a bang - .e.g `const value = expectRight(either)!;`
+ * An expect matcher for Jest to confirm the response is an E.Right - typically to confirm a
+ * success result. The value is also returned, albeit (unfortunately) unioned with an `undefined`.
+ * It is considered safe to access the value via a bang - .e.g `const value = expectRight(either)!;`
  *
  * @param either The E.Either to validate
  * @return The value contained in the E.Right

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/FpTsMatchers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/FpTsMatchers.ts
@@ -55,6 +55,7 @@ expect.extend({
 
 declare global {
   namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R> {
       toBeLeft(): jest.CustomMatcherResult;
       toBeRight(): jest.CustomMatcherResult;

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/GallerySearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/GallerySearchModule.test.ts
@@ -17,7 +17,6 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
-import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/Option";
 import { basicImageSearchResponse } from "../../../__mocks__/GallerySearchModule.mock";
 import {
@@ -32,6 +31,7 @@ import {
   defaultSearchOptions,
   searchItems,
 } from "../../../tsrc/modules/SearchModule";
+import { expectRight } from "../FpTsMatchers";
 
 jest.mock("@openequella/rest-api-client");
 jest.mock("../../../tsrc/modules/SearchModule");
@@ -42,29 +42,6 @@ const mockListMimeTypes = OEQ.MimeType.listMimeTypes as jest.Mock<
 const mockSearchItems = searchItems as jest.Mock<
   Promise<OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>>
 >;
-
-/**
- * An expect matcher for Jest to confirm the response is a E.Left - typically to confirm an
- * error result.
- *
- * @param either The E.Either to validate
- */
-const expectLeft = (either: E.Either<unknown, unknown>): void =>
-  expect(E.isLeft(either)).toBeTruthy();
-
-/**
- * An expect matcher for Jest to confirm the response is an E.Right - typically to confirm an
- * success result. The value is also returned, albeit (unfortunately) unioned with an undefined. It
- * is considered safe to access the value via a bang - .e.g `const value = expectRight(either)!;`
- *
- * @param either The E.Either to validate
- * @return The value contained in the E.Right
- */
-const expectRight = <V>(either: E.Either<unknown, V>): V | undefined => {
-  const value = E.isRight(either) ? either.right : undefined;
-  expect(value).toBeTruthy();
-  return value;
-};
 
 describe("buildGalleryEntry", () => {
   const itemUuid = "1eeb3df5-3809-4655-925b-24d994e42ff6";
@@ -92,28 +69,28 @@ describe("buildGalleryEntry", () => {
 
   it("fails if the Attachment has a missing MIME type", () => {
     const galleryEntry = buildGalleryEntry(itemUuid, itemVersion, {
-      ...attachment,
+      ...imageAttachment,
       mimeType: undefined,
     });
-    expectLeft(galleryEntry);
+    expect(galleryEntry).toBeLeft();
   });
 
   it("fails if the Attachment has a missing attachmentFilePath", () => {
     const galleryEntry = buildGalleryEntry(itemUuid, itemVersion, {
-      ...attachment,
+      ...imageAttachment,
       filePath: undefined,
     });
-    expectLeft(galleryEntry);
+    expect(galleryEntry).toBeLeft();
   });
 
   it.each([false, undefined])(
     "fails if the Attachment has a missing a thumbnail (value: %s)",
     (hasGeneratedThumb) => {
       const galleryEntry = buildGalleryEntry(itemUuid, itemVersion, {
-        ...attachment,
+        ...imageAttachment,
         hasGeneratedThumb,
       });
-      expectLeft(galleryEntry);
+      expect(galleryEntry).toBeLeft();
     }
   );
 });
@@ -225,7 +202,7 @@ describe("buildGallerySearchResultItem", () => {
       ...searchItem,
       attachments: undefined,
     });
-    expectLeft(result);
+    expect(result).toBeLeft();
   });
 
   // It would've been good to merge this with the above via an `it.each`, but unfortunately
@@ -235,7 +212,7 @@ describe("buildGallerySearchResultItem", () => {
       ...searchItem,
       attachments: [],
     });
-    expectLeft(result);
+    expect(result).toBeLeft();
   });
 
   it("will log and prune any problematic 'additional' attachments", () => {

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/GallerySearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/GallerySearchModule.test.ts
@@ -204,7 +204,7 @@ describe("buildGallerySearchResultItem", () => {
       searchItem
     );
     const { mainEntry, additionalEntries } = expectRight(result)!;
-    expect(mainEntry.imagePathFull).toBe(
+    expect(mainEntry.directUrl).toBe(
       // Based on the fact there is no base URL set in Jest tests
       "file/535e4e9b-4836-4011-8857-eb29260bf155/1/content.zip/images/ima_3166d0f.jpeg"
     );
@@ -250,9 +250,7 @@ describe("buildGallerySearchResultItem", () => {
     const { additionalEntries } = expectRight(result)!;
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(additionalEntries).toHaveLength(1);
-    expect(
-      additionalEntries[0].imagePathFull.endsWith(a3.filePath!)
-    ).toBeTruthy();
+    expect(additionalEntries[0].directUrl.endsWith(a3.filePath!)).toBeTruthy();
   });
 });
 

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -36,7 +36,10 @@ import { act } from "react-dom/test-utils";
 import { Router } from "react-router-dom";
 import { getAdvancedSearchesFromServerResult } from "../../../__mocks__/AdvancedSearchModule.mock";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
-import { transformedBasicImageSearchResponse } from "../../../__mocks__/GallerySearchModule.mock";
+import {
+  transformedBasicImageSearchResponse,
+  transformedBasicVideoSearchResponse,
+} from "../../../__mocks__/GallerySearchModule.mock";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
 import { getMimeTypeFilters } from "../../../__mocks__/MimeTypeFilter.mock";
 import { getRemoteSearchesFromServerResult } from "../../../__mocks__/RemoteSearchModule.mock";
@@ -96,7 +99,14 @@ const mockListClassification = jest.spyOn(
   "listClassifications"
 );
 const mockSearch = jest.spyOn(SearchModule, "searchItems");
-const mockGallerySearch = jest.spyOn(GallerySearchModule, "imageGallerySearch");
+const mockImageGallerySearch = jest.spyOn(
+  GallerySearchModule,
+  "imageGallerySearch"
+);
+const mockVideoGallerySearch = jest.spyOn(
+  GallerySearchModule,
+  "videoGallerySearch"
+);
 const mockSearchSettings = jest.spyOn(
   SearchSettingsModule,
   "getSearchSettingsFromServer"
@@ -982,21 +992,32 @@ describe("Changing display mode", () => {
     expect(queryListItems().length).toBeGreaterThan(0);
   });
 
-  it.each([modeGalleryImage, modeGalleryVideo])(
+  it.each([
+    [
+      modeGalleryImage,
+      mockImageGallerySearch,
+      transformedBasicImageSearchResponse,
+    ],
+    [
+      modeGalleryVideo,
+      mockVideoGallerySearch,
+      transformedBasicVideoSearchResponse,
+    ],
+  ])(
     "supports changing mode - [%s]",
-    async (mode: string) => {
+    async (mode: string, gallerySearch, mockResponse) => {
       expect(queryListItems().length).toBeGreaterThan(0);
       expect(queryGalleryItems()).toHaveLength(0);
 
       // Monitor the search function, and change the mode
-      const gallerySearchPromise = mockGallerySearch.mockResolvedValue(
-        transformedBasicImageSearchResponse
+      const gallerySearchPromise = gallerySearch.mockResolvedValue(
+        mockResponse
       );
       await changeMode(mode);
       await gallerySearchPromise;
 
       // Make sure the search has been triggered
-      expect(mockGallerySearch).toHaveBeenCalledTimes(1);
+      expect(gallerySearch).toHaveBeenCalledTimes(1);
 
       // And now check the visual change
       expect(queryGalleryItems().length).toBeGreaterThan(0);

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/GallerySearchResultHelpers.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/components/GallerySearchResultHelpers.ts
@@ -25,9 +25,9 @@ import {
 const buildGalleryEntry = (name: string): GalleryEntry => ({
   mimeType: "image/png",
   name,
-  imagePathSmall: "./placeholder-135x135.png",
-  imagePathMedium: "./placeholder-500x500.png",
-  imagePathFull: "./placeholder-500x500.png",
+  thumbnailSmall: "./placeholder-135x135.png",
+  thumbnailLarge: "./placeholder-500x500.png",
+  directUrl: "./placeholder-500x500.png",
 });
 
 export const buildItems = (howMany: number): GallerySearchResultItem[] =>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/AttachmentsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/AttachmentsModule.ts
@@ -17,6 +17,13 @@
  */
 import { AppConfig } from "../AppConfig";
 
+/** `attachmentType` for file attachments. */
+export const ATYPE_FILE = "file";
+/** `attachmentType` for link/URL attachments. */
+export const ATYPE_LINK = "link";
+/** `attachmentType` for attachments linking to YouTube videos. */
+export const ATYPE_YOUTUBE = "custom/youtube";
+
 /**
  * Build a direct URL to a file attachment.
  *

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/GallerySearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/GallerySearchModule.ts
@@ -41,19 +41,19 @@ export interface GalleryEntry {
    */
   name: string;
   /**
-   * The path to a small version of the image - typically the thumbnail with parameter `gallery` as
+   * The path to a small thumbnail - typically the thumbnail with parameter `gallery` as
    * `thumbnail`.
    */
-  imagePathSmall: string;
+  thumbnailSmall: string;
   /**
-   * The path to a larger version of the image - typically the thumbnail with parameter `gallery` as
+   * The path to a large thumbnail - typically the thumbnail with parameter `gallery` as
    * `preview`.
    */
-  imagePathMedium: string;
+  thumbnailLarge: string;
   /**
    * The URL to the actual raw asset, good for viewing in the lightbox (or perhaps downloading).
    */
-  imagePathFull: string;
+  directUrl: string;
 }
 
 /**
@@ -122,10 +122,10 @@ export const buildGalleryEntry = (
       )
     )
     .bind("name", E.right(attachment.description ?? attachment.id))
-    .bind("imagePathSmall", E.right(thumbnailLink(attachment, "thumbnail")))
-    .bind("imagePathMedium", E.right(thumbnailLink(attachment, "preview")))
+    .bind("thumbnailSmall", E.right(thumbnailLink(attachment, "thumbnail")))
+    .bind("thumbnailLarge", E.right(thumbnailLink(attachment, "preview")))
     .bind(
-      "imagePathFull",
+      "directUrl",
       pipe(
         attachment.filePath,
         E.fromNullable("Attachment is missing its `filePath`"),

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/GallerySearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/GallerySearchModule.ts
@@ -21,9 +21,15 @@ import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
 import { flow, pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
-import { buildFileAttachmentUrl } from "./AttachmentsModule";
-import { getImageMimeTypes } from "./MimeTypesModule";
+import { Literal, match, Unknown } from "runtypes";
+import {
+  ATYPE_FILE,
+  ATYPE_YOUTUBE,
+  buildFileAttachmentUrl,
+} from "./AttachmentsModule";
+import { CustomMimeTypes, getImageMimeTypes } from "./MimeTypesModule";
 import { searchItems, SearchOptions } from "./SearchModule";
+import * as yt from "./YouTubeModule";
 
 /**
  * The shape of data for entries to display in a Gallery, primarily consisting of links to access
@@ -77,10 +83,79 @@ export interface GallerySearchResultItem
   additionalEntries: GalleryEntry[];
 }
 
+const unsupportedAttachmentType = (id: string, attachmentType: string) =>
+  E.left(`Attachment ${id} of type "${attachmentType}" is not supported`);
+
 const warnOnLeft = E.mapLeft((left) => {
   console.warn(left);
   return left;
 });
+
+/**
+ * Checks that the attachment is a type which we can currently support.
+ *
+ * @param attachment validation candidate
+ */
+const validateAttachmentType = (
+  attachment: OEQ.Search.Attachment
+): E.Either<string, string> =>
+  pipe(
+    attachment.attachmentType,
+    E.fromPredicate(
+      (type) => [ATYPE_FILE, ATYPE_YOUTUBE].includes(type),
+      (type) =>
+        `Attachments of type ${type} are not supported. Attachment ID: ${attachment.id}`
+    )
+  );
+
+/**
+ * Based on `attachmentType` validates whether the provided `attachment` meets requirements
+ * for thumbnails
+ *
+ * @param attachment validation candidate
+ */
+const validateThumbnailRequirements = (
+  attachment: OEQ.Search.Attachment
+): E.Either<string, OEQ.Search.Attachment> =>
+  pipe(
+    attachment,
+    E.fromPredicate(
+      (a) =>
+        a.attachmentType === ATYPE_FILE
+          ? !!a.hasGeneratedThumb // result based on what the server tells us
+          : true, // For non `file` attachments, we currently do thumbnails ourselves
+      (a) => `Attachment ${a.id} does not meet thumbnail requirements.`
+    )
+  );
+
+/**
+ * For file based attachments, simply check and use the `mimeType` on the attachment. For supported
+ * other types build a custom `openequella/*` MIME type.
+ *
+ * @param attachment target from which to derive the MIME type
+ */
+const mimeType = ({
+  id,
+  mimeType,
+  attachmentType,
+}: OEQ.Search.Attachment): E.Either<string, string> =>
+  pipe(
+    attachmentType,
+    match(
+      [
+        Literal(ATYPE_FILE),
+        () =>
+          pipe(
+            mimeType,
+            E.fromNullable(
+              `File attachment ${id} is missing a defined MIME type`
+            )
+          ),
+      ],
+      [Literal(ATYPE_YOUTUBE), () => E.right(CustomMimeTypes.YOUTUBE)],
+      [Unknown, () => unsupportedAttachmentType(id, attachmentType)]
+    )
+  );
 
 /**
  * Builds a URL for displaying an attachment's thumbnail, optionally at the format as specified by
@@ -90,9 +165,67 @@ const warnOnLeft = E.mapLeft((left) => {
  * @param type Optional alternate formats
  */
 const thumbnailLink = (
-  attachment: OEQ.Search.Attachment,
-  type?: "thumbnail" | "preview"
-): string => attachment.links.thumbnail.concat(type ? `?gallery=${type}` : "");
+  { attachmentType, id, links }: OEQ.Search.Attachment,
+  type: "small" | "large"
+): E.Either<string, string> => {
+  const isSmall = type === "small";
+  const fileThumbnailLink = (basePath: string): string =>
+    basePath + "?gallery=" + (isSmall ? "gallery" : "preview");
+  const youTubeLink = (videoId: string): string =>
+    yt.buildThumbnailUrl(videoId, isSmall ? "default" : "high");
+
+  return attachmentType === ATYPE_FILE
+    ? E.right(fileThumbnailLink(links.thumbnail))
+    : pipe(
+        links.externalId,
+        E.fromNullable(
+          `Expected 'links.externalId' missing for attachment ${id} with type ${attachmentType}`
+        ),
+        E.map(youTubeLink)
+      );
+};
+
+/**
+ * Builds a URL for directly accessing the attachment. For file attachments (i.e. those residing in
+ * openEQUELLA) it will lead to a direct download/view from the server. For external attachments
+ * (e.g. YouTube) it will build a link (URL) using the `links.externalId` to access it via the
+ * owning system.
+ *
+ * @param itemUuid The UUID of the item it belongs to
+ * @param itemVersion The version of the item the attachment belongs to
+ * @param attachment The attachment to build this URL for
+ */
+const directUrl = (
+  itemUuid: string,
+  itemVersion: number,
+  { attachmentType, filePath, id, links }: OEQ.Search.Attachment
+): E.Either<string, string> =>
+  pipe(
+    attachmentType,
+    match(
+      [
+        Literal(ATYPE_FILE),
+        () =>
+          pipe(
+            filePath,
+            E.fromNullable(`File attachment ${id} is missing a 'filePath'.`),
+            E.map((path) => buildFileAttachmentUrl(itemUuid, itemVersion, path))
+          ),
+      ],
+      [
+        Literal(ATYPE_YOUTUBE),
+        () =>
+          pipe(
+            links.externalId,
+            E.fromNullable(
+              `YouTube attachment ${id} is missing an 'externalId'.`
+            ),
+            E.map(yt.buildViewUrl)
+          ),
+      ],
+      [Unknown, () => unsupportedAttachmentType(id, attachmentType)]
+    )
+  );
 
 /**
  * Transform an item's attachment into a `GalleryEntry`.
@@ -107,33 +240,13 @@ export const buildGalleryEntry = (
   attachment: OEQ.Search.Attachment
 ): E.Either<string, GalleryEntry> =>
   Do(E.either)
-    .do(
-      !!attachment.hasGeneratedThumb
-        ? E.right(true)
-        : E.left(
-            `Attachment ${attachment.id} on item ${itemUuid}/${itemVersion} does not have a thumbnail`
-          )
-    )
-    .bind(
-      "mimeType",
-      pipe(
-        attachment.mimeType,
-        E.fromNullable("Attachment is missing a defined MIME type")
-      )
-    )
+    .do(validateAttachmentType(attachment))
+    .do(validateThumbnailRequirements(attachment))
+    .bind("mimeType", mimeType(attachment))
     .bind("name", E.right(attachment.description ?? attachment.id))
-    .bind("thumbnailSmall", E.right(thumbnailLink(attachment, "thumbnail")))
-    .bind("thumbnailLarge", E.right(thumbnailLink(attachment, "preview")))
-    .bind(
-      "directUrl",
-      pipe(
-        attachment.filePath,
-        E.fromNullable("Attachment is missing its `filePath`"),
-        E.map((filePath) =>
-          buildFileAttachmentUrl(itemUuid, itemVersion, filePath)
-        )
-      )
-    )
+    .bind("thumbnailSmall", thumbnailLink(attachment, "small"))
+    .bind("thumbnailLarge", thumbnailLink(attachment, "large"))
+    .bind("directUrl", directUrl(itemUuid, itemVersion, attachment))
     .done();
 
 /**
@@ -193,9 +306,51 @@ const createAdditionalEntries = (
     )
   );
 
+/**
+ * Type for functions used for filtering attachments.
+ */
 export type AttachmentFilter = (
   attachments: OEQ.Search.Attachment[]
 ) => O.Option<OEQ.Search.Attachment[]>;
+
+/**
+ * Type for functions acting as predicates over attachments.
+ */
+type AttachmentPredicate = (attachment: OEQ.Search.Attachment) => boolean;
+
+/**
+ * Creates an attachment predicate function which will predicate based on matching an attachment's
+ * MIME type against the supplied `typeRegex`.
+ *
+ * @param typeRegex A regular expression to check against an attachment's MIME type/
+ */
+const attachmentMimeTypePredicate = (
+  typeRegex: string
+): AttachmentPredicate => (attachment: OEQ.Search.Attachment) =>
+  pipe(
+    attachment.mimeType,
+    O.fromNullable,
+    O.fold(
+      () => false,
+      (mt: string) => mt.match(typeRegex) !== null
+    )
+  );
+
+/**
+ * Creates an attachment filter using the supplied `AttachmentPredicate`. The resulting filter
+ * will return all attachments which match the predicate (`O.Some`) otherwise it will return none
+ * (`O.None`).
+ *
+ * @param predicate The predicate to specify which attachments to keep.
+ */
+const filterAttachments = (
+  predicate: AttachmentPredicate
+): AttachmentFilter => (
+  attachments: OEQ.Search.Attachment[]
+): O.Option<OEQ.Search.Attachment[]> =>
+  pipe(attachments, A.filter(predicate), (xs: OEQ.Search.Attachment[]) =>
+    xs.length === 0 ? O.none : O.some(xs)
+  );
 
 /**
  * Provides a means to generate a predicate function for filtering attachments. Needed due to the
@@ -206,20 +361,34 @@ export type AttachmentFilter = (
 const filterAttachmentsByMimeType = (typeRegex: string): AttachmentFilter => (
   attachments: OEQ.Search.Attachment[]
 ): O.Option<OEQ.Search.Attachment[]> =>
-  pipe(
-    attachments,
-    A.filter((a) =>
-      pipe(
-        a.mimeType,
-        O.fromNullable,
-        O.fold(
-          () => false,
-          (mt: string) => mt.match(typeRegex) !== null
-        )
-      )
-    ),
-    (xs: OEQ.Search.Attachment[]) => (xs.length === 0 ? O.none : O.some(xs))
+  pipe(attachments, filterAttachments(attachmentMimeTypePredicate(typeRegex)));
+
+/**
+ * Filters a list of attachments down to those which are either `file` attachments with a 'video'
+ * mimeType; or are of a suitable attachmentType - such as `custom/youtube`.
+ *
+ * @param attachments the attachments to be filtered
+ */
+const filterAttachmentsByVideo: AttachmentFilter = (
+  attachments: OEQ.Search.Attachment[]
+): O.Option<OEQ.Search.Attachment[]> => {
+  const videoMimeTypePredicate: AttachmentPredicate = attachmentMimeTypePredicate(
+    "video"
   );
+  // Arguably in the future we may want to change this to looking through a look-up list
+  // to include things like Kaltura - for now just straight comparison against the only
+  // one we're supporting
+  const attachmentTypePredicate: AttachmentPredicate = (a) =>
+    a.attachmentType === ATYPE_YOUTUBE;
+  // The above predicates combined into one
+  const combinedPredicate: AttachmentPredicate = (a) =>
+    [videoMimeTypePredicate, attachmentTypePredicate].some((predicate) =>
+      predicate(a)
+    );
+
+  // Do the filtering
+  return pipe(attachments, filterAttachments(combinedPredicate));
+};
 
 /**
  * Expecting a `OEQ.Search.SearchResultItem` returned from a search call, will filter out attachments
@@ -276,21 +445,23 @@ export const buildGallerySearchResultItem = (
     }));
 
 /**
- * Perform a search as per `options` and also request filtering to all (institution) known image
- * MIME types. The output ideally used to display a gallery of all available images at an institution
- * with links to their related item.
+ * Undertakes an `searchItems` based on the supplied `options` filtering out all attachments with
+ * `attachmentFilter`. And most importantly, converts the output from `itemSearch` to
+ * a collection of `GallerySearchResultItem`s.
  *
- * @param options Standard `SearchOptions` to refine the search by
+ * @param options Search options to be passed to `searchItems`.
+ * @param attachmentFilter The filter to filter all items attachment's by.
  */
-export const imageGallerySearch = async (
-  options: SearchOptions
+const gallerySearch = async (
+  options: SearchOptions,
+  attachmentFilter: AttachmentFilter
 ): Promise<OEQ.Search.SearchResult<GallerySearchResultItem>> => {
   const processSearchResultItem = (
     sri: OEQ.Search.SearchResultItem
   ): E.Either<string, GallerySearchResultItem> =>
     pipe(
       sri,
-      buildGallerySearchResultItem(filterAttachmentsByMimeType("image")),
+      buildGallerySearchResultItem(attachmentFilter),
       E.mapLeft((error) => {
         const msg = `Failed to create gallery item for item ${sri.uuid}: ${error}`;
         console.error(msg);
@@ -298,10 +469,7 @@ export const imageGallerySearch = async (
       })
     );
 
-  const searchResults = await searchItems({
-    ...options,
-    mimeTypes: await getImageMimeTypes(),
-  });
+  const searchResults = await searchItems(options);
   const items: GallerySearchResultItem[] = pipe(
     searchResults.results,
     A.map(processSearchResultItem),
@@ -311,3 +479,33 @@ export const imageGallerySearch = async (
 
   return { ...searchResults, length: items.length, results: items };
 };
+
+/**
+ * Perform a search as per `options` and also request filtering to all (institution) known image
+ * MIME types. The output ideally used to display a gallery of all available images at an institution
+ * with links to their related item.
+ *
+ * @param options Standard `SearchOptions` to refine the search by
+ */
+export const imageGallerySearch = async (
+  options: SearchOptions
+): Promise<OEQ.Search.SearchResult<GallerySearchResultItem>> =>
+  gallerySearch(
+    { ...options, mimeTypes: await getImageMimeTypes() },
+    filterAttachmentsByMimeType("image")
+  );
+
+/**
+ * Perform a search as per `options` and also request filtering to any items which potentially are
+ * have video attachments. The output ideally used to display a gallery of all available videos at
+ * an institution with links to their related item.
+ *
+ * @param options Standard `SearchOptions` to refine the search by
+ */
+export const videoGallerySearch = async (
+  options: SearchOptions
+): Promise<OEQ.Search.SearchResult<GallerySearchResultItem>> =>
+  gallerySearch(
+    { ...options, musts: [["videothumb", ["true"]]] },
+    filterAttachmentsByVideo
+  );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/MimeTypesModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/MimeTypesModule.ts
@@ -19,6 +19,13 @@ import * as OEQ from "@openequella/rest-api-client";
 import { memoize } from "lodash";
 import { API_BASE_URL } from "../AppConfig";
 
+/**
+ * A collection of custom internal MIME types for openEQUELLA
+ */
+export enum CustomMimeTypes {
+  YOUTUBE = "openequella/youtube",
+}
+
 export const getMIMETypesFromServer = (): Promise<
   OEQ.MimeType.MimeTypeEntry[]
 > => OEQ.MimeType.listMimeTypes(API_BASE_URL);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -104,6 +104,12 @@ export interface SearchOptions {
    * A list of MIME types provided by an Integration (e.g. with Moodle), which has a higher priority than `mimeTypes`.
    */
   externalMimeTypes?: string[];
+  /**
+   * List of search index key/value pairs to filter by. e.g. videothumb:true or realthumb:true.
+   *
+   * @see OEQ.Search.SearchParams for examples
+   */
+  musts?: OEQ.Search.Must[];
 }
 
 /**
@@ -411,6 +417,7 @@ export const searchItems = ({
   mimeTypes,
   mimeTypeFilters,
   externalMimeTypes,
+  musts,
 }: SearchOptions): Promise<
   OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>
 > => {
@@ -436,6 +443,7 @@ export const searchItems = ({
     searchAttachments: searchAttachments,
     whereClause: generateCategoryWhereQuery(selectedCategories),
     mimeTypes: externalMimeTypes ?? _mimeTypes,
+    musts: musts,
   };
 
   return OEQ.Search.search(API_BASE_URL, searchParams);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/YouTubeModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/YouTubeModule.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Builds a URL to access the YouTube provided thumbnail for a video specified with `videoId`. This
+ * is based on the URLs return from the Google API in 2021. They could change in the future.
+ *
+ * `quality` currently seems to correlate to:
+ *
+ *  - default : 120 x 90
+ *  - medium  : 320 x 180
+ *  - high    : 480 x 360
+ *  - max     : 1280 x 720
+ *
+ * @param videoId The id of a known YouTube video
+ * @param quality The desired quality of the thumbnail
+ */
+export const buildThumbnailUrl = (
+  videoId: string,
+  quality: "default" | "medium" | "high" | "max"
+): string => {
+  const baseUrl = `https://i.ytimg.com/vi/${videoId}/`;
+  switch (quality) {
+    case "default":
+      return baseUrl + "default.jpg";
+    case "high":
+      return baseUrl + "hqdefault.jpg";
+    case "max":
+      return baseUrl + "maxresdefault.jpg";
+    case "medium":
+      return baseUrl + "mqdefault.jpg";
+  }
+};
+
+export const buildViewUrl = (videoId: string): string =>
+  `https://www.youtube.com/watch?v=${videoId}`;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -38,6 +38,7 @@ import { addFavouriteSearch } from "../modules/FavouriteModule";
 import {
   GallerySearchResultItem,
   imageGallerySearch,
+  videoGallerySearch,
 } from "../modules/GallerySearchModule";
 import {
   buildSelectionSessionAdvancedSearchLink,
@@ -325,20 +326,26 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
    */
   useEffect(() => {
     if (state.status === "searching") {
+      const gallerySearch = async (
+        search: typeof imageGallerySearch | typeof videoGallerySearch,
+        options: SearchPageOptions
+      ): Promise<SearchPageSearchResult> => ({
+        from: "gallery-search",
+        content: await search({
+          ...options,
+          // `mimeTypeFilters` should be ignored in gallery modes
+          mimeTypeFilters: undefined,
+        }),
+      });
+
       const doSearch = async (
         options: SearchPageOptions
       ): Promise<SearchPageSearchResult> => {
         switch (options.displayMode) {
           case "gallery-image":
-          case "gallery-video": // Coming soon
-            return {
-              from: "gallery-search",
-              content: await imageGallerySearch({
-                ...options,
-                // `mimeTypeFilters` should be ignored in gallery modes
-                mimeTypeFilters: undefined,
-              }),
-            };
+            return gallerySearch(imageGallerySearch, options);
+          case "gallery-video":
+            return gallerySearch(videoGallerySearch, options);
           case "list":
             return { from: "item-search", content: await searchItems(options) };
           default:

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/GallerySearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/GallerySearchResult.tsx
@@ -108,7 +108,7 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
         const itemName = name ?? uuid;
         const buildOnClickHandler = ({
           mimeType,
-          imagePathFull: src,
+          directUrl: src,
           name,
         }: GalleryEntry) => () =>
           setLightboxProps({
@@ -126,7 +126,7 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
             uuid,
             version,
             `${uuid}-mainEntry`,
-            mainEntry.imagePathMedium,
+            mainEntry.thumbnailLarge,
             `${itemName} - Main Entry (${mainEntry.name})`,
             buildOnClickHandler(mainEntry)
           ),
@@ -135,7 +135,7 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
               uuid,
               version,
               `${uuid}-additionalEntry-${idx}`,
-              ae.imagePathMedium,
+              ae.thumbnailLarge,
               `${itemName} - Additional Entry ${idx + 1} (${ae.name})`,
               buildOnClickHandler(ae)
             )

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -204,6 +204,11 @@ export interface Attachment {
      * The URL for viewing this attachment's thumbnail.
      */
     thumbnail: string;
+    /**
+     * The ID of the attachment on an external system - as determined by the `attachmentType`.
+     * For example, for `custom/youtube` this is the YouTube video ID.
+     */
+    externalId?: string;
   };
   /**
    * If a file attachment, the path for the represented file

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -24,7 +24,7 @@ import * as Utils from './Utils';
  * Used for specifying must expressions such as `moderating:true`. Neither string should contain
  * any colons (or other exempt Lucene syntax characters).
  */
-type Must = [string, string[]];
+export type Must = [string, string[]];
 
 interface SearchParamsBase {
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds the transformation support to the `GallerySearchModule` to support Video Searches. As well as that, it then adds a function to do the `videoGallerySearch()`. Then, it was only a small bit of extra work to plug it in, so basic gallery view of videos is now functional (but need to add lightbox support for YouTube still - that's a future PR).

While at it, reworked the the Jest checks for `E.Left` and `E.Right` by setting up some custom Jest Matchers (`FpTsMatchers.ts`).

There was also a refactor around GalleryEntry so that it was no longer so Image specific.

Below video shows a quick look at the video gallery in action - noting the missing support for YouTube (coming soon).

https://user-images.githubusercontent.com/43919233/113254567-7bc2f200-9312-11eb-9b1b-81726bfe898e.mp4


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
