### PR TITLE
Add support to Video Gallery to preview YouTube videos

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/Lightbox.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/Lightbox.stories.tsx
@@ -21,6 +21,7 @@ import Lightbox, {
   LightboxConfig,
   LightboxProps,
 } from "../../tsrc/components/Lightbox";
+import { CustomMimeTypes } from "../../tsrc/modules/MimeTypesModule";
 
 export default {
   title: "component/Lightbox",
@@ -49,6 +50,11 @@ const audioConfig: LightboxConfig = {
   mimeType: "audio/ogg",
 };
 
+const youTubeConfig: LightboxConfig = {
+  src: "https://www.youtube.com/watch?v=x0SgN92HP_k",
+  title: "1788-L - N U / V E R / K A",
+  mimeType: CustomMimeTypes.YOUTUBE,
+};
 export const displayImage: Story<LightboxProps> = (args: LightboxProps) => (
   <Lightbox {...args} />
 );
@@ -71,6 +77,14 @@ export const displayVideo: Story<LightboxProps> = (args: LightboxProps) => (
 displayVideo.args = {
   open: true,
   config: videoConfig,
+};
+
+export const displayYouTube: Story<LightboxProps> = (args: LightboxProps) => (
+  <Lightbox {...args} />
+);
+displayYouTube.args = {
+  open: true,
+  config: youTubeConfig,
 };
 
 export const unsupportedContent: Story<LightboxProps> = (

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/components/YouTubeEmbed.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/components/YouTubeEmbed.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import YouTubeEmbed, {
+  YouTubeEmbedProps,
+} from "../../tsrc/components/YouTubeEmbed";
+
+export default {
+  title: "component/YouTubeEmbed",
+  component: YouTubeEmbed,
+} as Meta<YouTubeEmbedProps>;
+
+export const EmbeddedYouTubeVideo: Story<YouTubeEmbedProps> = (args) => (
+  <YouTubeEmbed {...args} />
+);
+EmbeddedYouTubeVideo.args = {
+  videoId: "OsctbVek0hs",
+};
+
+export const EmbeddedYouTubeVideoLarge: Story<YouTubeEmbedProps> = (args) => (
+  <YouTubeEmbed {...args} />
+);
+EmbeddedYouTubeVideoLarge.args = {
+  ...EmbeddedYouTubeVideo.args,
+  dimensions: {
+    width: 1120,
+    height: 630,
+  },
+};

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/Lightbox.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/components/Lightbox.test.tsx
@@ -17,11 +17,13 @@
  */
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
+import { displayYouTube } from "../../../__stories__/components/Lightbox.stories";
 import Lightbox, {
   isLightboxSupportedMimeType,
   LightboxConfig,
 } from "../../../tsrc/components/Lightbox";
 import { render } from "@testing-library/react";
+import { CustomMimeTypes } from "../../../tsrc/modules/MimeTypesModule";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import "@testing-library/jest-dom/extend-expect";
 
@@ -33,6 +35,7 @@ describe("isLightboxSupportedMimeType", () => {
     ["image/anything", true],
     ["video/ogg", true],
     ["video/quicktime", false],
+    [CustomMimeTypes.YOUTUBE, true],
   ])("MIME type: %s, supported: %s", (mimeType: string, expected: boolean) =>
     expect(isLightboxSupportedMimeType(mimeType)).toEqual(expected)
   );
@@ -94,4 +97,33 @@ describe("view previous/next attachment", () => {
       expect(queryByText(updatedTitle)).toBeInTheDocument();
     }
   );
+});
+
+describe("Support for YouTube videos", () => {
+  const youTubeLightboxConfig = displayYouTube.args!.config!;
+
+  it("displays an embedded YouTube player for valid view URL src", () => {
+    const { queryByTitle } = render(
+      <Lightbox onClose={jest.fn()} open config={youTubeLightboxConfig} />
+    );
+    expect(
+      queryByTitle(languageStrings.youTubePlayer.title)
+    ).toBeInTheDocument();
+  });
+
+  it("displays an error message if the view URL is invalid", () => {
+    const { queryByText } = render(
+      <Lightbox
+        onClose={jest.fn()}
+        open
+        config={{
+          ...youTubeLightboxConfig,
+          src: "https://www.youtube.com/watch/", // missing param v=1234xyz
+        }}
+      />
+    );
+    expect(
+      queryByText(languageStrings.lightboxComponent.youTubeVideoMissingId)
+    ).toBeInTheDocument();
+  });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/YouTubeModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/YouTubeModule.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  buildViewUrl,
+  extractVideoId,
+} from "../../../tsrc/modules/YouTubeModule";
+
+describe("extractVideoId()", () => {
+  it("returns the YouTube video ID from a view URL", () => {
+    const testVideoId = "FakeVideoId";
+    expect(extractVideoId(buildViewUrl(testVideoId))).toEqual(testVideoId);
+  });
+});

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/Lightbox.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/Lightbox.tsx
@@ -27,7 +27,11 @@ import {
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import CloseIcon from "@material-ui/icons/Close";
+import NavigateBeforeIcon from "@material-ui/icons/NavigateBefore";
+import NavigateNextIcon from "@material-ui/icons/NavigateNext";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
+import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
 import * as React from "react";
 import {
   ReactNode,
@@ -38,14 +42,16 @@ import {
 } from "react";
 import { Literal, match, Unknown } from "runtypes";
 import {
+  CustomMimeTypes,
   isBrowserSupportedAudio,
   isBrowserSupportedVideo,
+  OEQ_MIMETYPE_TYPE,
   splitMimeType,
 } from "../modules/MimeTypesModule";
+import { extractVideoId } from "../modules/YouTubeModule";
 import { languageStrings } from "../util/langstrings";
-import NavigateBeforeIcon from "@material-ui/icons/NavigateBefore";
-import NavigateNextIcon from "@material-ui/icons/NavigateNext";
 import { TooltipIconButton } from "./TooltipIconButton";
+import YouTubeEmbed from "./YouTubeEmbed";
 
 const useStyles = makeStyles((theme: Theme) => ({
   lightboxBackdrop: {
@@ -127,6 +133,7 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
   } = languageStrings.common.action;
   const {
     unsupportedContent: labelUnsupportedContent,
+    youTubeVideoMissingId,
   } = languageStrings.lightboxComponent;
 
   const [content, setContent] = useState<ReactNode | undefined>();
@@ -161,61 +168,88 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
 
   // Update content when config is updated.
   useEffect(() => {
-    const unsupportedContent = (
+    const lightBoxMessage = (msg: string) => (
       <Card>
         <CardContent>
           <Typography variant="h5" component="h2">
-            {labelUnsupportedContent}
+            {msg}
           </Typography>
         </CardContent>
       </Card>
     );
 
+    const unsupportedContent = lightBoxMessage(labelUnsupportedContent);
+
     const buildContent = () =>
-      match(
-        [
-          Literal("image"),
-          () => (
-            <img
-              className={`${classes.lightboxContent} ${classes.lightboxImage}`}
-              alt={title}
-              src={src}
-            />
-          ),
-        ],
-        [
-          Literal("video"),
-          () =>
-            isBrowserSupportedVideo(mimeType) ? (
-              <video
-                className={classes.lightboxContent}
-                controls
+      pipe(
+        splitMimeType(mimeType)[0],
+        match(
+          [
+            Literal("image"),
+            () => (
+              <img
+                className={`${classes.lightboxContent} ${classes.lightboxImage}`}
+                alt={title}
                 src={src}
-                aria-label={title}
               />
-            ) : (
-              unsupportedContent
             ),
-        ],
-        [
-          Literal("audio"),
-          () =>
-            isBrowserSupportedAudio(mimeType) ? (
-              <audio
-                className={classes.lightboxAudio}
-                controls
-                src={src}
-                aria-label={title}
-              />
-            ) : (
-              unsupportedContent
-            ),
-        ],
-        [Unknown, () => unsupportedContent]
-      )(splitMimeType(mimeType)[0]);
+          ],
+          [
+            Literal("video"),
+            () =>
+              isBrowserSupportedVideo(mimeType) ? (
+                <video
+                  className={classes.lightboxContent}
+                  controls
+                  src={src}
+                  aria-label={title}
+                />
+              ) : (
+                unsupportedContent
+              ),
+          ],
+          [
+            Literal("audio"),
+            () =>
+              isBrowserSupportedAudio(mimeType) ? (
+                <audio
+                  className={classes.lightboxAudio}
+                  controls
+                  src={src}
+                  aria-label={title}
+                />
+              ) : (
+                unsupportedContent
+              ),
+          ],
+          [
+            Literal(OEQ_MIMETYPE_TYPE),
+            () =>
+              mimeType === CustomMimeTypes.YOUTUBE
+                ? pipe(
+                    extractVideoId(src),
+                    O.fromNullable,
+                    O.fold(
+                      () => lightBoxMessage(youTubeVideoMissingId),
+                      (id) => <YouTubeEmbed videoId={id} />
+                    )
+                  )
+                : unsupportedContent,
+          ],
+          [Unknown, () => unsupportedContent]
+        )
+      );
 
     setContent(buildContent());
-  }, [lightBoxConfig, classes, mimeType, src, title, labelUnsupportedContent]);
+  }, [
+    lightBoxConfig,
+    classes,
+    mimeType,
+    src,
+    title,
+    labelUnsupportedContent,
+    youTubeVideoMissingId,
+  ]);
 
   const handleOpenInNewWindow = (event: SyntheticEvent) => {
     event.stopPropagation();

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/Lightbox.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/Lightbox.tsx
@@ -338,6 +338,7 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
 export const isLightboxSupportedMimeType = (mimeType: string): boolean =>
   splitMimeType(mimeType)[0] === "image" ||
   isBrowserSupportedAudio(mimeType) ||
-  isBrowserSupportedVideo(mimeType);
+  isBrowserSupportedVideo(mimeType) ||
+  [CustomMimeTypes.YOUTUBE].includes(mimeType);
 
 export default Lightbox;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/YouTubeEmbed.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/YouTubeEmbed.tsx
@@ -1,0 +1,58 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+
+export interface YouTubeEmbedProps {
+  /**
+   * The dimensions (in pixels) for the `iframe` embedding the YouTube player.
+   */
+  dimensions?: {
+    /**
+     * The height (in pixels) for the `iframe` embedding the YouTube player.
+     */
+    height: number;
+    /**
+     * The width (in pixels) for the `iframe` embedding the YouTube player.
+     */
+    width: number;
+  };
+
+  /**
+   * The YouTube video's Id - often from the end of a view URL (i.e.
+   * `videoId` from `https://www.youtube.com/watch?v=<videoId>`)
+   */
+  videoId: string;
+}
+
+/**
+ * A simple component for the embedding of a YouTube video using the standard YouTube embed code
+ * - well as at April 2021.
+ */
+const YouTubeEmbed = ({ dimensions, videoId }: YouTubeEmbedProps) => (
+  <iframe
+    width={dimensions?.width ?? 560}
+    height={dimensions?.height ?? 315}
+    src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+    title="YouTube video player"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+);
+
+export default YouTubeEmbed;

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/YouTubeEmbed.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/YouTubeEmbed.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import * as React from "react";
+import { languageStrings } from "../util/langstrings";
 
 export interface YouTubeEmbedProps {
   /**
@@ -48,7 +49,7 @@ const YouTubeEmbed = ({ dimensions, videoId }: YouTubeEmbedProps) => (
     width={dimensions?.width ?? 560}
     height={dimensions?.height ?? 315}
     src={`https://www.youtube-nocookie.com/embed/${videoId}`}
-    title="YouTube video player"
+    title={languageStrings.youTubePlayer.title}
     frameBorder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/MimeTypesModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/MimeTypesModule.ts
@@ -19,12 +19,13 @@ import * as OEQ from "@openequella/rest-api-client";
 import { memoize } from "lodash";
 import { API_BASE_URL } from "../AppConfig";
 
+export const OEQ_MIMETYPE_TYPE = "openequella";
 /**
  * A collection of custom internal MIME types for openEQUELLA
  */
-export enum CustomMimeTypes {
-  YOUTUBE = "openequella/youtube",
-}
+export const CustomMimeTypes = {
+  YOUTUBE: `${OEQ_MIMETYPE_TYPE}/youtube`,
+};
 
 export const getMIMETypesFromServer = (): Promise<
   OEQ.MimeType.MimeTypeEntry[]

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/YouTubeModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/YouTubeModule.ts
@@ -49,3 +49,11 @@ export const buildThumbnailUrl = (
 
 export const buildViewUrl = (videoId: string): string =>
   `https://www.youtube.com/watch?v=${videoId}`;
+
+/**
+ * Will extract the Video ID from a YouTube view URL - i.e. a URL which has a `v` search param.
+ *
+ * @param viewUrl a YouTube view URL containing a `v` search param.
+ */
+export const extractVideoId = (viewUrl: string): string | null =>
+  new URL(viewUrl).searchParams.get("v");

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -661,6 +661,7 @@ export const languageStrings = {
     unsupportedContent: "Provided content is not supported",
     viewNext: "View next attachment",
     viewPrevious: "View previous attachment",
+    youTubeVideoMissingId: "The provided YouTube video is missing a video ID",
   },
   fileUploader: {
     noFileSelected: "No attached resources",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -667,4 +667,7 @@ export const languageStrings = {
     noFileSelected: "No attached resources",
     failedToDelete: "Failed to delete '%s' due to error: %s",
   },
+  youTubePlayer: {
+    title: "YouTube video player",
+  },
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This simply adds support to the Lightbox to support previewing YouTube videos from the video gallery. Also paves the way to then support using this in the lightbox used to preview attachments in search results.

Things to note:

* Embed component is based on current embed code provided by YouTube - including default dimensions.
* Did bring in fp-ts `pipe` and `Option` into Lightbox component as it just keeps things sooo much tidier and readable. (This includes using `pipe` -> `match`.)
* Lightbox now has a `match` clause looking of `openequella` MIME types, and then within which just explicity checks for `openequella/youtube`. In the future I imagine this will be refactored out once we start supporting some of the other custom oEQ types - e.g. Kaltura. For now, possibly a bit awkward, but seemed overkill and in violation to take it further.
* And have also attempted to re-use data from the Storybook stories for the the tests - this is meant to be one of the selling points of the latest Storybook, but we're yet to start using it.


https://user-images.githubusercontent.com/43919233/113955488-2b421c00-985f-11eb-9578-ec6c463d9e58.mp4


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
