### PR TITLE
feat(front-end): Add attachment count to search results

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -20,6 +20,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   Badge,
+  Chip,
   Grid,
   List,
   ListItem,
@@ -36,8 +37,9 @@ import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
 import ExpandMore from "@material-ui/icons/ExpandMore";
 import InsertDriveFile from "@material-ui/icons/InsertDriveFile";
 import Search from "@material-ui/icons/Search";
-import { SyntheticEvent, useEffect, useState } from "react";
+import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
+import { SyntheticEvent, useEffect, useState } from "react";
 import ItemAttachmentLink from "../../components/ItemAttachmentLink";
 import {
   getSearchPageAttachmentClass,
@@ -54,7 +56,6 @@ import {
 } from "../../modules/ViewerModule";
 import { languageStrings } from "../../util/langstrings";
 import { ResourceSelector } from "./ResourceSelector";
-import * as OEQ from "@openequella/rest-api-client";
 
 const {
   searchResult: searchResultStrings,
@@ -262,7 +263,10 @@ export const SearchResultAttachmentsList = ({
   );
 
   const accordionText = (
-    <Typography>{searchResultStrings.attachments}</Typography>
+    <Typography>
+      {searchResultStrings.attachments}&nbsp;&nbsp;
+      <Chip label={attachments.length} size="small" color="primary" />
+    </Typography>
   );
 
   const accordionSummaryContent = inSelectionSession ? (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

![image](https://user-images.githubusercontent.com/43919233/113971815-d7dec680-987c-11eb-8a88-5fbe5c58011f.png)

And when there are also result / found in attachment highlighting:

![image](https://user-images.githubusercontent.com/43919233/113971754-bbdb2500-987c-11eb-9462-8ceda15e286a.png)


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
