### PR TITLE
Fix margins and padding for custom data fields on resource summary

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -3706,6 +3706,20 @@ Item summary styling
   width: 49%;
 }
 
+.displayNodes p {
+  margin: $doubleMargin 0;
+}
+.displayNodes h3 {
+  padding-top: $doubleMargin;
+}
+
+h3.item-description-title {
+  margin: $doubleMargin 0;
+}
+p.item-description {
+  margin: $doubleMargin 0 0 0;
+}
+
 .action-button.select {
   background-image: url("../images/addselected.ltr.png");
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
#2715 
This is a CSS change to realign custom data fields on resource summary pages. 

Before change: 
![image](https://user-images.githubusercontent.com/24543345/113981165-b1278c80-988a-11eb-9f45-aa67980d7d23.png)

After change:
![image](https://user-images.githubusercontent.com/24543345/113981228-c13f6c00-988a-11eb-8594-d8443c53ba1b.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
