### PR TITLE
Make attachments draggable in SearchResultAttachmentsList.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResult.tsx
@@ -32,7 +32,7 @@ import FavoriteIcon from "@material-ui/icons/Favorite";
 import FavoriteBorderIcon from "@material-ui/icons/FavoriteBorder";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import ReactHtmlParser from "react-html-parser";
 import { HashLink } from "react-router-hash-link";
 import { sprintf } from "sprintf-js";
@@ -52,7 +52,6 @@ import {
   isSelectionSessionInStructured,
   isSelectionSessionOpen,
   isSelectSummaryButtonDisabled,
-  prepareDraggable,
   selectResource,
 } from "../../modules/LegacySelectionSessionModule";
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
@@ -158,15 +157,6 @@ export default function SearchResult({
   const [bookmarkId, setBookmarkId] = useState<number | undefined>(
     bookmarkDefaultId
   );
-
-  // In Selection Session, make each attachment draggable.
-  useEffect(() => {
-    if (inStructured) {
-      attachments.forEach((attachment) => {
-        prepareDraggable(attachment.id, false);
-      });
-    }
-  }, [attachments, inStructured]);
 
   const handleSelectResource = (
     itemKey: string,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -44,6 +44,7 @@ import {
   isSelectionSessionInSkinny,
   isSelectionSessionInStructured,
   isSelectionSessionOpen,
+  prepareDraggable,
   selectResource,
 } from "../../modules/LegacySelectionSessionModule";
 import {
@@ -118,6 +119,15 @@ export const SearchResultAttachmentsList = ({
     attachmentsAndViewerConfigs,
     setAttachmentsAndViewerConfigs,
   ] = useState<AttachmentAndViewerConfig[]>([]);
+
+  // In Selection Session, make each attachment draggable.
+  useEffect(() => {
+    if (inStructured) {
+      attachmentsAndViewerConfigs.forEach(({ attachment }) => {
+        prepareDraggable(attachment.id, false);
+      });
+    }
+  }, [attachmentsAndViewerConfigs, inStructured]);
 
   // Responsible for determining the MIME type viewer for the provided attachments
   useEffect(() => {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Since we have created a new component `SearchResultAttachmentsList` to handle attachments, the preparation for drag and drop should be moved to there as well. And the useEffect should depend on the state variable `attachmentsAndViewerConfigs` because the attachment list is built based on it.


https://user-images.githubusercontent.com/47203811/114112056-e382c980-991e-11eb-911b-ec8384f91ce9.mp4

