### PR TITLE
Use Raw search mode for Old UI saved or shared searches

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/modules/SearchModule.test.ts
@@ -266,6 +266,10 @@ describe("SearchModule", () => {
     jest
       .spyOn(SearchFilterSettingsModule, "getMimeTypeFiltersFromServer")
       .mockResolvedValue(getMimeTypeFilters);
+    const defaultConvertedSearchOptions = {
+      ...defaultSearchOptions,
+      rawMode: true,
+    };
 
     it("should return default search for any parameters that aren't supported", async () => {
       const unsupportedQueryString = "?test=nothing&cool=beans";
@@ -273,7 +277,7 @@ describe("SearchModule", () => {
         await legacyQueryStringToSearchOptions(
           new URLSearchParams(unsupportedQueryString)
         )
-      ).toEqual(defaultSearchOptions);
+      ).toEqual(defaultConvertedSearchOptions);
     });
 
     it("should convert legacy search parameters to searchOptions", async () => {
@@ -289,7 +293,7 @@ describe("SearchModule", () => {
       );
 
       const expectedSearchOptions: SearchOptions = {
-        ...defaultSearchOptions,
+        ...defaultConvertedSearchOptions,
         sortOrder: "DATECREATED",
         searchAttachments: true,
         collections: [
@@ -350,7 +354,7 @@ describe("SearchModule", () => {
           new URLSearchParams(queryString)
         );
         expect(convertedSearchOptions).toEqual({
-          ...defaultSearchOptions,
+          ...defaultConvertedSearchOptions,
           lastModifiedDateRange: expectedRange,
         });
       }
@@ -363,7 +367,7 @@ describe("SearchModule", () => {
       const convertedSearchOptions = await legacyQueryStringToSearchOptions(
         new URLSearchParams(collectionQueryString)
       );
-      expect(convertedSearchOptions).toEqual(defaultSearchOptions);
+      expect(convertedSearchOptions).toEqual(defaultConvertedSearchOptions);
     });
   });
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -568,6 +568,7 @@ export const legacyQueryStringToSearchOptions = async (
     mimeTypes,
     mimeTypeFilters,
     externalMimeTypes: getExternalMIMETypes(),
+    rawMode: true,
   };
   return searchOptions;
 };


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

As discussed, use Raw search mode in new UI for searches saved or shared in old UI mode.