### PR TITLE
Add Download CSV button to Search page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/UserModule.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/UserModule.mock.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const getCurrentUserMock: OEQ.LegacyContent.CurrentUserDetails = {
+  id: "test",
+  username: "test",
+  firstName: "test",
+  lastName: "test",
+  accessibilityMode: true,
+  autoLoggedIn: false,
+  guest: false,
+  prefsEditable: true,
+  menuGroups: [],
+  canDownloadSearchResult: true,
+};

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
@@ -53,6 +53,19 @@ export const users: OEQ.UserQuery.UserDetails[] = [
   },
 ];
 
+export const defaultCurrentUserDetails: OEQ.LegacyContent.CurrentUserDetails = {
+  id: "test",
+  username: "test",
+  firstName: "test",
+  lastName: "test",
+  accessibilityMode: true,
+  autoLoggedIn: false,
+  guest: false,
+  prefsEditable: true,
+  menuGroups: [],
+  canDownloadSearchResult: true,
+};
+
 /**
  * Helper function to inject into component for user retrieval.
  *

--- a/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
+++ b/Source/Plugins/Core/com.equella.core/js/__mocks__/UserSearch.mock.ts
@@ -53,19 +53,6 @@ export const users: OEQ.UserQuery.UserDetails[] = [
   },
 ];
 
-export const defaultCurrentUserDetails: OEQ.LegacyContent.CurrentUserDetails = {
-  id: "test",
-  username: "test",
-  firstName: "test",
-  lastName: "test",
-  accessibilityMode: true,
-  autoLoggedIn: false,
-  guest: false,
-  prefsEditable: true,
-  menuGroups: [],
-  canDownloadSearchResult: true,
-};
-
 /**
  * Helper function to inject into component for user retrieval.
  *

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/ExportSearchResultLink.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/ExportSearchResultLink.stories.tsx
@@ -1,0 +1,48 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { Meta, Story } from "@storybook/react";
+import {
+  ExportSearchResultLink,
+  ExportSearchResultLinkProps,
+} from "../../tsrc/search/components/ExportSearchResultLink";
+
+export default {
+  title: "Search/ExportSearchResultLink",
+  component: ExportSearchResultLink,
+  argTypes: {
+    onExport: { action: "on Export" },
+  },
+} as Meta<ExportSearchResultLinkProps>;
+
+export const ExportEnabled: Story<ExportSearchResultLinkProps> = (args) => (
+  <ExportSearchResultLink {...args} />
+);
+
+ExportEnabled.args = {
+  url: "test",
+  exportDisabled: false,
+};
+
+export const ExportCompleted: Story<ExportSearchResultLinkProps> = (args) => (
+  <ExportSearchResultLink {...args} />
+);
+ExportCompleted.args = {
+  ...ExportEnabled.args,
+  exportDisabled: true,
+};

--- a/Source/Plugins/Core/com.equella.core/js/__stories__/search/ExportSearchResultLink.stories.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__stories__/search/ExportSearchResultLink.stories.tsx
@@ -33,10 +33,9 @@ export default {
 export const ExportEnabled: Story<ExportSearchResultLinkProps> = (args) => (
   <ExportSearchResultLink {...args} />
 );
-
 ExportEnabled.args = {
   url: "test",
-  exportDisabled: false,
+  alreadyExported: false,
 };
 
 export const ExportCompleted: Story<ExportSearchResultLinkProps> = (args) => (
@@ -44,5 +43,5 @@ export const ExportCompleted: Story<ExportSearchResultLinkProps> = (args) => (
 );
 ExportCompleted.args = {
   ...ExportEnabled.args,
-  exportDisabled: true,
+  alreadyExported: true,
 };

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -48,6 +48,7 @@ import {
   getSearchResult,
   getSearchResultsCustom,
 } from "../../../__mocks__/SearchResult.mock";
+import { defaultCurrentUserDetails } from "../../../__mocks__/UserSearch.mock";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as AdvancedSearchModule from "../../../tsrc/modules/AdvancedSearchModule";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
@@ -94,6 +95,7 @@ const defaultTheme = createMuiTheme({
 });
 const mockCollections = jest.spyOn(CollectionsModule, "collectionListSummary");
 const mockListUsers = jest.spyOn(UserModule, "listUsers");
+const mockCurrentUser = jest.spyOn(UserModule, "getCurrentUserDetails");
 const mockListClassification = jest.spyOn(
   SearchFacetsModule,
   "listClassifications"
@@ -134,6 +136,7 @@ const searchSettingPromise = mockSearchSettings.mockResolvedValue(
 const searchPromise = mockSearch.mockResolvedValue(getSearchResult);
 mockCollections.mockResolvedValue(getCollectionMap);
 mockListUsers.mockResolvedValue(UserSearchMock.users);
+mockCurrentUser.mockResolvedValue(defaultCurrentUserDetails);
 mockListClassification.mockResolvedValue(CategorySelectorMock.classifications);
 
 // Mock out a collaborator of SearchResult
@@ -1075,4 +1078,17 @@ describe("Export search result", () => {
       ).toBeInTheDocument();
     }
   );
+
+  it("doesn't show the Download button if user have no permission", async () => {
+    // Remove previously rendered result so that we can mock the current user details.
+    page.unmount();
+    mockCurrentUser.mockResolvedValueOnce({
+      ...defaultCurrentUserDetails,
+      canDownloadSearchResult: false,
+    });
+    const { queryByLabelText } = await renderSearchPage();
+    expect(
+      queryByLabelText(languageStrings.searchpage.export.title)
+    ).not.toBeInTheDocument();
+  });
 });

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -48,7 +48,7 @@ import {
   getSearchResult,
   getSearchResultsCustom,
 } from "../../../__mocks__/SearchResult.mock";
-import { defaultCurrentUserDetails } from "../../../__mocks__/UserSearch.mock";
+import { getCurrentUserMock } from "../../../__mocks__/UserModule.mock";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as AdvancedSearchModule from "../../../tsrc/modules/AdvancedSearchModule";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
@@ -136,7 +136,7 @@ const searchSettingPromise = mockSearchSettings.mockResolvedValue(
 const searchPromise = mockSearch.mockResolvedValue(getSearchResult);
 mockCollections.mockResolvedValue(getCollectionMap);
 mockListUsers.mockResolvedValue(UserSearchMock.users);
-mockCurrentUser.mockResolvedValue(defaultCurrentUserDetails);
+mockCurrentUser.mockResolvedValue(getCurrentUserMock);
 mockListClassification.mockResolvedValue(CategorySelectorMock.classifications);
 
 // Mock out a collaborator of SearchResult
@@ -1083,7 +1083,7 @@ describe("Export search result", () => {
     // Remove previously rendered result so that we can mock the current user details.
     page.unmount();
     mockCurrentUser.mockResolvedValueOnce({
-      ...defaultCurrentUserDetails,
+      ...getCurrentUserMock,
       canDownloadSearchResult: false,
     });
     const { queryByLabelText } = await renderSearchPage();

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -1026,3 +1026,53 @@ describe("Changing display mode", () => {
     }
   );
 });
+
+describe("Export search result", () => {
+  let page: RenderResult;
+  beforeEach(async () => {
+    page = await renderSearchPage();
+  });
+
+  const selectCollections = async (...collectionNames: string[]) => {
+    userEvent.click(
+      page.getByLabelText(languageStrings.searchpage.collectionSelector.title)
+    );
+    for (const name of collectionNames) {
+      await act(async () => {
+        await userEvent.click(screen.getByText(name));
+      });
+    }
+  };
+
+  const getDownloadButton = () =>
+    page.getByLabelText(languageStrings.searchpage.export.title);
+
+  it("shows a Download Icon button to allow exporting", async () => {
+    await selectCollections(getCollectionMap[0].name);
+    expect(
+      page.queryByLabelText(languageStrings.searchpage.export.title)
+    ).toBeInTheDocument();
+  });
+
+  it("shows a Tick Icon to indicate search result is downloaded already", async () => {
+    await selectCollections(getCollectionMap[0].name);
+    userEvent.click(getDownloadButton());
+    expect(
+      page.queryByTitle(languageStrings.searchpage.export.exportCompleted)
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["zero", []],
+    ["more than one", getCollectionMap.slice(0, 2).map((c) => c.name)],
+  ])(
+    "disables export if %s collection is selected",
+    async (collectionNumber: string, collections: string[]) => {
+      await selectCollections(...collections);
+      userEvent.click(getDownloadButton());
+      expect(
+        screen.getByText(languageStrings.searchpage.export.collectionLimit)
+      ).toBeInTheDocument();
+    }
+  );
+});

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/MessageInfo.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/MessageInfo.tsx
@@ -65,11 +65,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+export type MessageInfoVariant = "success" | "warning" | "error" | "info";
+
 export interface MessageInfoProps {
   open: boolean;
   onClose: () => void;
   title: string;
-  variant: "success" | "warning" | "error" | "info";
+  variant: MessageInfoVariant;
 }
 
 const MessageInfo = ({ open, title, variant, onClose }: MessageInfoProps) => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -58,6 +58,7 @@ export const guestUser: OEQ.LegacyContent.CurrentUserDetails = {
     notifications: 0,
   },
   menuGroups: [],
+  canDownloadSearchResult: false,
 };
 
 export interface ExternalRedirect {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -398,11 +398,10 @@ export const newSearchQueryToSearchOptions = async (
 };
 
 /**
- * A function that takes search options and converts search options to search params,
- * and then does a search and returns a list of Items.
- * @param searchOptions Search options selected on Search page.
+ * A function that converts search options to search params.
+ * @param searchOptions Search options to be converted to search params.
  */
-export const searchItems = ({
+const buildSearchParams = ({
   query,
   rowsPerPage,
   currentPage,
@@ -418,9 +417,7 @@ export const searchItems = ({
   mimeTypeFilters,
   externalMimeTypes,
   musts,
-}: SearchOptions): Promise<
-  OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>
-> => {
+}: SearchOptions): OEQ.Search.SearchParams => {
   const processedQuery = query ? formatQuery(query, !rawMode) : undefined;
   // We use selected filters to generate MIME types. However, in Image Gallery,
   // image MIME types are applied before any filter gets selected.
@@ -430,7 +427,7 @@ export const searchItems = ({
     mimeTypeFilters && mimeTypeFilters.length > 0
       ? mimeTypeFilters.flatMap((f) => f.mimeTypes)
       : mimeTypes;
-  const searchParams: OEQ.Search.SearchParams = {
+  return {
     query: processedQuery,
     start: currentPage * rowsPerPage,
     length: rowsPerPage,
@@ -445,9 +442,26 @@ export const searchItems = ({
     mimeTypes: externalMimeTypes ?? _mimeTypes,
     musts: musts,
   };
-
-  return OEQ.Search.search(API_BASE_URL, searchParams);
 };
+
+/**
+ * A function that executes a search with provided search options.
+ * @param searchOptions Search options selected on Search page.
+ */
+export const searchItems = (
+  searchOptions: SearchOptions
+): Promise<OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>> =>
+  OEQ.Search.search(API_BASE_URL, buildSearchParams(searchOptions));
+
+/**
+ * A function that builds a URL for exporting a search result
+ * @param searchOptions Search options selected on Search page.
+ */
+export const buildExportUrl = (searchOptions: SearchOptions): string =>
+  OEQ.Search.buildExportUrl(
+    API_BASE_URL,
+    buildSearchParams({ ...searchOptions, currentPage: 0 })
+  );
 
 const findCollectionsByUuid = async (
   collectionUuids: string[]

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -269,11 +269,6 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     [dispatch]
   );
 
-  // Allow exporting a search result when searchPageOptions gets changed.
-  useEffect(() => {
-    setAlreadyDownloaded(false);
-  }, [searchPageOptions]);
-
   /**
    * Error display -> similar to onError hook, however in the context of reducer need to do manually.
    */
@@ -400,6 +395,8 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
             });
             // scroll back up to the top of the page
             if (state.scrollToTop) window.scrollTo(0, 0);
+            // Allow downloading new search result.
+            setAlreadyDownloaded(false);
           }
         )
         .catch(handleError);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -32,9 +32,9 @@ export interface ExportSearchResultLinkProps {
    */
   onExport: () => boolean;
   /**
-   * `true` if an export is not allowed.
+   * `true` if a search result is already exported.
    */
-  exportDisabled: boolean;
+  alreadyExported: boolean;
 }
 
 const exportStrings = languageStrings.searchpage.export;
@@ -46,7 +46,7 @@ const exportStrings = languageStrings.searchpage.export;
 export const ExportSearchResultLink = ({
   url,
   onExport,
-  exportDisabled,
+  alreadyExported,
 }: ExportSearchResultLinkProps) => {
   // Prevent the link from following the URL if an export is invalid.
   const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -57,7 +57,7 @@ export const ExportSearchResultLink = ({
     return true;
   };
 
-  return exportDisabled ? (
+  return alreadyExported ? (
     // Just need an Icon instead of an Icon button.
     <Tooltip title={exportStrings.exportCompleted}>
       <DoneIcon color="secondary" />

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -28,11 +28,12 @@ export interface ExportSearchResultLinkProps {
    */
   url: string;
   /**
-   * Handler fired to check an export. Return `false` to indicate an export is invalid.
+   *  Handler fired before triggering an export. Return `false` to prevent
+   *  an export being triggered.
    */
   onExport: () => boolean;
   /**
-   * `true` if a search result is already exported.
+   * `true` to show a complete indicator and disable additional clicking.
    */
   alreadyExported: boolean;
 }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -1,0 +1,72 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Link, Tooltip } from "@material-ui/core";
+import DoneIcon from "@material-ui/icons/Done";
+import GetAppIcon from "@material-ui/icons/GetApp";
+import * as React from "react";
+import { TooltipIconButton } from "../../components/TooltipIconButton";
+import { languageStrings } from "../../util/langstrings";
+
+export interface ExportSearchResultLinkProps {
+  /**
+   * The full URL to download a search result
+   */
+  url: string;
+  /**
+   * Handler fired to check an export. Return `false` to indicate an export is invalid.
+   */
+  onExport: () => boolean;
+  /**
+   * `true` if an export is not allowed.
+   */
+  exportDisabled: boolean;
+}
+
+const exportStrings = languageStrings.searchpage.export;
+
+/**
+ * Build a Download icon button wrapped by a link to export a search result,
+ * or a Tick icon to indicate the search result is downloaded already.
+ */
+export const ExportSearchResultLink = ({
+  url,
+  onExport,
+  exportDisabled,
+}: ExportSearchResultLinkProps) => {
+  // Prevent the link from following the URL if an export is invalid.
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!onExport()) {
+      e.preventDefault();
+      return false;
+    }
+    return true;
+  };
+
+  return exportDisabled ? (
+    // Just need an Icon instead of an Icon button.
+    <Tooltip title={exportStrings.exportCompleted}>
+      <DoneIcon color="secondary" />
+    </Tooltip>
+  ) : (
+    <Link download href={url} onClick={onClick}>
+      <TooltipIconButton title={exportStrings.title}>
+        <GetAppIcon />
+      </TooltipIconButton>
+    </Link>
+  );
+};

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -38,6 +38,10 @@ import * as React from "react";
 import { TooltipIconButton } from "../../components/TooltipIconButton";
 import { isSelectionSessionOpen } from "../../modules/LegacySelectionSessionModule";
 import { languageStrings } from "../../util/langstrings";
+import {
+  ExportSearchResultLink,
+  ExportSearchResultLinkProps,
+} from "./ExportSearchResultLink";
 import SearchOrderSelect, { SearchOrderSelectProps } from "./SearchOrderSelect";
 import { SearchPagination, SearchPaginationProps } from "./SearchPagination";
 import SearchResult from "./SearchResult";
@@ -99,6 +103,10 @@ export interface SearchResultListProps {
    * Props for the Icon button that controls whether show Refine panel in small screens
    */
   refineSearchProps: RefineSearchProps;
+  /**
+   * Props required by ExportSearchResultLink.
+   */
+  exportProps: ExportSearchResultLinkProps;
 }
 
 const searchPageStrings = languageStrings.searchpage;
@@ -124,6 +132,7 @@ export const SearchResultList = ({
   onClearSearchOptions,
   onCopySearchLink,
   onSaveSearch,
+  exportProps,
 }: SearchResultListProps) => {
   const classes = useStyles();
   const inSelectionSession: boolean = isSelectionSessionOpen();
@@ -166,6 +175,9 @@ export const SearchResultList = ({
               >
                 <FavoriteBorderIcon />
               </TooltipIconButton>
+            </Grid>
+            <Grid item>
+              <ExportSearchResultLink {...exportProps} />
             </Grid>
             <Hidden mdUp>
               <Grid item>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -106,7 +106,10 @@ export interface SearchResultListProps {
   /**
    * Props required by ExportSearchResultLink.
    */
-  exportProps: ExportSearchResultLinkProps;
+  exportProps: {
+    isExportPermitted: boolean;
+    exportLinkProps: ExportSearchResultLinkProps;
+  };
 }
 
 const searchPageStrings = languageStrings.searchpage;
@@ -132,7 +135,7 @@ export const SearchResultList = ({
   onClearSearchOptions,
   onCopySearchLink,
   onSaveSearch,
-  exportProps,
+  exportProps: { isExportPermitted, exportLinkProps },
 }: SearchResultListProps) => {
   const classes = useStyles();
   const inSelectionSession: boolean = isSelectionSessionOpen();
@@ -176,9 +179,11 @@ export const SearchResultList = ({
                 <FavoriteBorderIcon />
               </TooltipIconButton>
             </Grid>
-            <Grid item>
-              <ExportSearchResultLink {...exportProps} />
-            </Grid>
+            {isExportPermitted && (
+              <Grid item>
+                <ExportSearchResultLink {...exportLinkProps} />
+              </Grid>
+            )}
             <Hidden mdUp>
               <Grid item>
                 <TooltipIconButton

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -356,6 +356,11 @@ export const languageStrings = {
     categorySelector: {
       title: "Classifications",
     },
+    export: {
+      collectionLimit: "Download limited to one collection.",
+      exportCompleted: "File downloaded",
+      title: "Download search result to a CSV file",
+    },
     favouriteItem: {
       removeAlert: "Are you sure you want to remove from your favourites?",
       tags: {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -25,6 +25,7 @@ import java.util.Collections
 import com.dytech.common.io.DevNullWriter
 import com.tle.beans.item.ItemTaskId
 import com.tle.common.institution.CurrentInstitution
+import com.tle.common.security.SecurityConstants
 import com.tle.common.settings.standard.AutoLogin
 import com.tle.common.usermanagement.user.CurrentUser
 import com.tle.core.i18n.CoreStrings
@@ -108,7 +109,8 @@ case class CurrentUserDetails(id: String,
                               guest: Boolean,
                               prefsEditable: Boolean,
                               menuGroups: Iterable[Iterable[MenuItem]],
-                              counts: Option[ItemCounts])
+                              counts: Option[ItemCounts],
+                              canDownloadSearchResult: Boolean)
 
 object LegacyContentController extends AbstractSectionsController with SectionFilter {
 
@@ -344,6 +346,11 @@ class LegacyContentApi {
 
     val accessibilityMode = LegacyGuice.accessibilityModeService.isAccessibilityMode
 
+    val canDownloadSearchResult: Boolean = LegacyGuice.aclManager
+      .filterNonGrantedPrivileges(SecurityConstants.EXPORT_SEARCH_RESULT)
+      .asScala
+      .nonEmpty
+
     val prefsEditable = !(cu.isSystem || cu.isGuest) && !(cu.wasAutoLoggedIn &&
       LegacyGuice.configService.getProperties(new AutoLogin).isEditDetailsDisallowed)
     val menuGroups = {
@@ -403,7 +410,8 @@ class LegacyContentApi {
           prefsEditable = prefsEditable,
           menuGroups = menuGroups,
           counts = counts,
-          accessibilityMode = accessibilityMode
+          accessibilityMode = accessibilityMode,
+          canDownloadSearchResult = canDownloadSearchResult
         )
       )
       .cacheControl(cacheControl)

--- a/oeq-ts-rest-api/src/LegacyContent.ts
+++ b/oeq-ts-rest-api/src/LegacyContent.ts
@@ -44,6 +44,7 @@ export interface CurrentUserDetails {
   prefsEditable: boolean;
   menuGroups: Array<Array<MenuItem>>;
   counts?: ItemCounts;
+  canDownloadSearchResult: boolean;
 }
 
 /**

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { stringify } from 'query-string';
 import { is } from 'typescript-is';
 import { GET } from './AxiosInstance';
 import * as Common from './Common';
@@ -385,6 +386,7 @@ const processSearchParams = (
   params ? { ...params, musts: processMusts(params.musts) } : undefined;
 
 const SEARCH2_API_PATH = '/search2';
+const EXPORT_PATH = '/search2/export';
 
 /**
  * Communicate with REST endpoint 'search2' to do a search with specified search criteria.
@@ -408,3 +410,11 @@ export const search = (
     ])
   );
 };
+
+/**
+ * Build a full URL for downloading a search result.
+ * @param apiBasePath Base URI to the oEQ institution and API.
+ * @param params Query parameters as search criteria.
+ */
+export const buildExportUrl = (apiBasePath: string, params: SearchParams) =>
+  apiBasePath + EXPORT_PATH + '?' + stringify(params);

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -386,7 +386,7 @@ const processSearchParams = (
   params ? { ...params, musts: processMusts(params.musts) } : undefined;
 
 const SEARCH2_API_PATH = '/search2';
-const EXPORT_PATH = '/search2/export';
+const EXPORT_PATH = `${SEARCH2_API_PATH}/export`;
 
 /**
  * Communicate with REST endpoint 'search2' to do a search with specified search criteria.

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -132,3 +132,17 @@ describe('Search for attachments', () => {
     }
   );
 });
+
+describe('Build URL for downloading search result', function () {
+  it('builds a full URL including query strings', () => {
+    const searchParams: OEQ.Search.SearchParams = {
+      query: 'API',
+      start: 0,
+      length: 10,
+      collections: ['a77112e6-3370-fd02-6ac6-6bc5aec22001'],
+    };
+    expect(OEQ.Search.buildExportUrl(TC.API_PATH, searchParams)).toBe(
+      'http://localhost:8080/rest/api/search2/export?collections=a77112e6-3370-fd02-6ac6-6bc5aec22001&length=10&query=API&start=0'
+    );
+  });
+});

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -150,7 +150,7 @@ describe('Exports search results for the specified search params', function () {
   });
 
   it('generates a URL which communicates to the export endpoints', async () => {
-    await OEQ.Auth.login(TC.API_PATH, TC.USERNAME_SUPER, 'a123456');
+    await OEQ.Auth.login(TC.API_PATH, TC.USERNAME_SUPER, TC.PASSWORD_SUPER);
     const exportUrl = OEQ.Search.buildExportUrl(TC.API_PATH, searchParams);
     await expect(
       GET(exportUrl, (data): data is string => is<string>(data))

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -15,6 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { is } from 'typescript-is';
+import { GET } from '../src/AxiosInstance';
 import * as OEQ from '../src';
 import * as TC from './TestConfig';
 
@@ -133,16 +135,25 @@ describe('Search for attachments', () => {
   );
 });
 
-describe('Build URL for downloading search result', function () {
+describe('Exports search results for the specified search params', function () {
+  const searchParams: OEQ.Search.SearchParams = {
+    query: 'API',
+    start: 0,
+    length: 10,
+    collections: ['a77112e6-3370-fd02-6ac6-6bc5aec22001'],
+  };
+
   it('builds a full URL including query strings', () => {
-    const searchParams: OEQ.Search.SearchParams = {
-      query: 'API',
-      start: 0,
-      length: 10,
-      collections: ['a77112e6-3370-fd02-6ac6-6bc5aec22001'],
-    };
     expect(OEQ.Search.buildExportUrl(TC.API_PATH, searchParams)).toBe(
       'http://localhost:8080/rest/api/search2/export?collections=a77112e6-3370-fd02-6ac6-6bc5aec22001&length=10&query=API&start=0'
     );
+  });
+
+  it('generates a URL which communicates to the export endpoints', async () => {
+    await OEQ.Auth.login(TC.API_PATH, TC.USERNAME_SUPER, 'a123456');
+    const exportUrl = OEQ.Search.buildExportUrl(TC.API_PATH, searchParams);
+    await expect(
+      GET(exportUrl, (data): data is string => is<string>(data))
+    ).resolves.toBeTruthy();
   });
 });


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

In this PR, I created a new ts component named `ExportSearchResultLink`. It is either a link or a icon, depending on whether the search result has been downloaded or not. This component is integrated in `SearchResultList`. I also refactored how to use `snackbar` in search page, to support showing a warning.


https://user-images.githubusercontent.com/47203811/114338155-cc014600-9b95-11eb-9093-ef812cd29edc.mp4

