### PR TITLE
Allow some margin between .displayNodeHalf elements

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -3715,7 +3715,7 @@ Item summary styling
   display: inline-block;
   vertical-align: top;
   margin: -$doubleMargin $doubleMargin 0 0;
-  width: calc(50% - 2 * $doubleMargin);
+  width: calc(50% - #{2 * $doubleMargin});
 }
 
 .displayNodes p {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -3715,7 +3715,7 @@ Item summary styling
   display: inline-block;
   vertical-align: top;
   margin: -$doubleMargin $doubleMargin 0 0;
-  width: calc(50% - 32px);
+  width: calc(50% - 2 * $doubleMargin);
 }
 
 .displayNodes p {

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -3714,8 +3714,8 @@ Item summary styling
 .itemsummary-layout #col1 .displayNodeHalf {
   display: inline-block;
   vertical-align: top;
-  margin: -15px 0;
-  width: 49%;
+  margin: -$doubleMargin $doubleMargin 0 0;
+  width: calc(50% - 32px);
 }
 
 .displayNodes p {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
Small tweak related to #2715. Just to add a little horizontal padding between the half page custom node displays. 
![image](https://user-images.githubusercontent.com/24543345/114350029-007ffc80-9bac-11eb-9359-7246928cdb83.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
