### PR TITLE
Ensure a long search params does not break audit log

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -18,6 +18,8 @@
 
 package com.tle.web.api.search
 
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.tle.beans.entity.Schema
 import com.tle.beans.item.ItemIdKey
 import com.tle.common.search.DefaultSearch
@@ -93,9 +95,9 @@ class SearchResource {
     LegacyGuice.auditLogService.logGeneric("Download",
                                            "SearchResult",
                                            "CSV",
-                                           req.getQueryString,
                                            null,
-                                           null)
+                                           null,
+                                           convertParamsToJsonString(params))
 
     resp.setContentType("text/csv")
     resp.setHeader("Content-Disposition", " attachment; filename=search.csv")
@@ -111,6 +113,15 @@ class SearchResource {
                                      writeRow(bos, _))
 
     bos.close()
+  }
+
+  private def convertParamsToJsonString(params: SearchParam): String = {
+    val mapper = JsonMapper
+      .builder()
+      .addModule(DefaultScalaModule)
+      .build()
+
+    mapper.writeValueAsString(params)
   }
 }
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -92,12 +92,7 @@ class SearchResource {
         throw new NotFoundException(s"Failed to find Schema for Collection: $collectionId")
     }
 
-    LegacyGuice.auditLogService.logGeneric("Download",
-                                           "SearchResult",
-                                           "CSV",
-                                           null,
-                                           null,
-                                           convertParamsToJsonString(params))
+    LegacyGuice.auditLogService.logSearchExport("CSV", convertParamsToJsonString(params))
 
     resp.setContentType("text/csv")
     resp.setHeader("Content-Disposition", " attachment; filename=search.csv")

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/auditlog/AuditLogService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/auditlog/AuditLogService.java
@@ -51,6 +51,14 @@ public interface AuditLogService {
 
   void logSearch(String type, String freeText, String within, long resultCount);
 
+  /**
+   * Log the request of exporting search result.
+   *
+   * @param format The export file format
+   * @param searchParams Search criteria of the export
+   */
+  void logSearchExport(String format, String searchParams);
+
   void logFederatedSearch(String freeText, String searchId);
 
   /**

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/auditlog/impl/AuditLogServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/auditlog/impl/AuditLogServiceImpl.java
@@ -60,6 +60,7 @@ public class AuditLogServiceImpl implements AuditLogService {
   private static final String SUMMARY_VIEWED_TYPE = "SUMMARY_VIEWED";
 
   private static final String SEARCH_FEDERATED_TYPE = "FEDERATED";
+  private static final String SEARCH_EXPORT_TYPE = "EXPORT";
 
   private static final String USED_TYPE = "USED";
 
@@ -223,6 +224,13 @@ public class AuditLogServiceImpl implements AuditLogService {
   @Transactional
   public void logSearch(String type, String freeText, String within, long resultCount) {
     logGeneric(SEARCH_CATEGORY, type, freeText, within, Long.toString(resultCount), null);
+  }
+
+  @Override
+  @Transactional
+  public void logSearchExport(String format, String searchParams) {
+    // searchParams could be a long string so use 'data4'.
+    logGeneric(SEARCH_CATEGORY, SEARCH_EXPORT_TYPE, format, null, null, searchParams);
   }
 
   @Override

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ExportTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ExportTest.java
@@ -76,6 +76,18 @@ public class Search2ExportTest extends AbstractRestApiTest {
     assertEquals(headers.length, 29);
   }
 
+  @Test(description = "Long query string should not break the export")
+  public void exportWithLongQueryString() throws IOException {
+    NameValuePair[] queryStrings = Arrays.copyOf(defaultQueryStrings, 4);
+    queryStrings[3] =
+        new NameValuePair(
+            "query",
+            "LongStringb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024eb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024eb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024eb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024eb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024eb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024eb2be4e8e-a0d4-4e6a-b9ff-4c65a7c8024e");
+    HttpMethod method = buildExportRequest(queryStrings);
+    int statusCode = makeClientRequest(method);
+    assertEquals(statusCode, 200);
+  }
+
   private HttpMethod buildExportRequest(NameValuePair[] queryStrings) {
     final HttpMethod method = new GetMethod(EXPORT_API_ENDPOINT);
     method.addRequestHeader("accept", "text/csv");


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Previously, the search param was stored in column 'data2' which has a length limit. So when  search param was too long the audit log threw an error. 

This PR changes  'data2' to  'data4' which has no limit and saves search param in Json format.

![image](https://user-images.githubusercontent.com/47203811/114498607-bbb99b80-9c67-11eb-88e4-84e7fc0c22a1.png)

