### PR TITLE
Do not center Lightbox title

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -34,6 +34,7 @@ import FilterListIcon from "@material-ui/icons/FilterList";
 import { makeStyles } from "@material-ui/core/styles";
 import Share from "@material-ui/icons/Share";
 import * as OEQ from "@openequella/rest-api-client";
+import clsx from "clsx";
 import * as React from "react";
 import { TooltipIconButton } from "../../components/TooltipIconButton";
 import { isSelectionSessionOpen } from "../../modules/LegacySelectionSessionModule";
@@ -53,6 +54,9 @@ const useStyles = makeStyles({
   centralSpinner: {
     top: "50%",
     position: "fixed",
+  },
+  textCentered: {
+    textAlign: "center",
   },
 });
 
@@ -208,12 +212,11 @@ export const SearchResultList = ({
           </Grid>
         }
       />
-      {/*Add an inline style to make the spinner display at the Card's horizontal center.*/}
-      <CardContent style={{ textAlign: "center" }}>
+      <CardContent className={clsx(showSpinner && classes.textCentered)}>
         {showSpinner && (
           <CircularProgress
             variant="indeterminate"
-            className={children ? classes.centralSpinner : ""}
+            className={clsx(children && classes.centralSpinner)}
           />
         )}
         {searchResultList}


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The Lightbox title was centered in Image/Video gallery due to an inline style applied to `SeachResultLIst`. This PR makes this style conditionally working.

In standard mode 
![image](https://user-images.githubusercontent.com/47203811/114649889-a8203a80-9d24-11eb-9d5a-7f31735d2bcc.png)


In gallery mode
![image](https://user-images.githubusercontent.com/47203811/114649926-b79f8380-9d24-11eb-8022-34c7b9d4f000.png)
