### PR TITLE
Prevent badge text from falling into multiple lines

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -186,6 +186,7 @@ export const useStyles = makeStyles((theme: Theme) => {
         overflowWrap: "anywhere",
       },
       button: {
+        //button text should not overflow mid word
         overflowWrap: "break-word",
       },
       a: {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/Template.tsx
@@ -185,6 +185,9 @@ export const useStyles = makeStyles((theme: Theme) => {
         //handle long strings without breaking the layout
         overflowWrap: "anywhere",
       },
+      button: {
+        overflowWrap: "break-word",
+      },
       a: {
         textDecoration: "none",
         color: theme.palette.primary.main,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
Related to the fix for #2850. 
To fix long strings breaking the layout, global rules were added to the template to `overflow-wrap: anywhere` on all `<a/>` and `<p/>` tags. This affected the Notifications and Tasks icons as they were children of `<a/>` tags, causing any more than one digit of notifications or tasks in the badge to display incorrectly. 
Added a rule to exempt `<button/>` tags from the rule.

Before change:

![image](https://user-images.githubusercontent.com/24543345/115165896-90193400-a0f3-11eb-9628-553176ed7d2a.png)

After change:

![image](https://user-images.githubusercontent.com/24543345/115165882-7677ec80-a0f3-11eb-80e2-bc092f07fad6.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
