### PR TITLE
Integrate facets with galleries

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/search/interfaces/SearchResource.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/search/interfaces/SearchResource.java
@@ -85,6 +85,10 @@ public interface SearchResource {
       @ApiParam(
               "A list of MIME types to filter items based on their attachments matching the specified types.")
           @QueryParam("mimeTypes")
-          List<String> mimeTypes);
+          List<String> mimeTypes,
+      @ApiParam(
+              "List of search index key/value pairs to filter by. e.g. videothumb:true or realthumb:true.")
+          @QueryParam("musts")
+          List<String> musts);
   // @formatter:on
 }

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -109,6 +109,14 @@ const mockVideoGallerySearch = jest.spyOn(
   GallerySearchModule,
   "videoGallerySearch"
 );
+const mockListImageGalleryClassifications = jest.spyOn(
+  GallerySearchModule,
+  "listImageGalleryClassifications"
+);
+const mockListVideoGalleryClassifications = jest.spyOn(
+  GallerySearchModule,
+  "listVideoGalleryClassifications"
+);
 const mockSearchSettings = jest.spyOn(
   SearchSettingsModule,
   "getSearchSettingsFromServer"
@@ -999,28 +1007,33 @@ describe("Changing display mode", () => {
     [
       modeGalleryImage,
       mockImageGallerySearch,
+      mockListImageGalleryClassifications,
       transformedBasicImageSearchResponse,
     ],
     [
       modeGalleryVideo,
       mockVideoGallerySearch,
+      mockListVideoGalleryClassifications,
       transformedBasicVideoSearchResponse,
     ],
   ])(
     "supports changing mode - [%s]",
-    async (mode: string, gallerySearch, mockResponse) => {
+    async (mode: string, gallerySearch, listClassifications, mockResponse) => {
       expect(queryListItems().length).toBeGreaterThan(0);
       expect(queryGalleryItems()).toHaveLength(0);
 
-      // Monitor the search function, and change the mode
-      const gallerySearchPromise = gallerySearch.mockResolvedValue(
-        mockResponse
-      );
-      await changeMode(mode);
-      await gallerySearchPromise;
+      // Monitor the search and classifications functions, and change the mode
+      await Promise.all([
+        gallerySearch.mockResolvedValue(mockResponse),
+        listClassifications.mockResolvedValue(
+          CategorySelectorMock.classifications
+        ),
+        changeMode(mode),
+      ]);
 
       // Make sure the search has been triggered
       expect(gallerySearch).toHaveBeenCalledTimes(1);
+      expect(listClassifications).toHaveBeenCalledTimes(1);
 
       // And now check the visual change
       expect(queryGalleryItems().length).toBeGreaterThan(0);

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/GallerySearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/GallerySearchModule.ts
@@ -28,6 +28,7 @@ import {
   buildFileAttachmentUrl,
 } from "./AttachmentsModule";
 import { CustomMimeTypes, getImageMimeTypes } from "./MimeTypesModule";
+import { Classification, listClassifications } from "./SearchFacetsModule";
 import { searchItems, SearchOptions } from "./SearchModule";
 import * as yt from "./YouTubeModule";
 
@@ -495,6 +496,7 @@ export const imageGallerySearch = async (
     filterAttachmentsByMimeType("image")
   );
 
+const videoGalleryMusts: OEQ.Search.Must[] = [["videothumb", ["true"]]];
 /**
  * Perform a search as per `options` and also request filtering to any items which potentially are
  * have video attachments. The output ideally used to display a gallery of all available videos at
@@ -506,6 +508,30 @@ export const videoGallerySearch = async (
   options: SearchOptions
 ): Promise<OEQ.Search.SearchResult<GallerySearchResultItem>> =>
   gallerySearch(
-    { ...options, musts: [["videothumb", ["true"]]] },
+    { ...options, musts: videoGalleryMusts },
     filterAttachmentsByVideo
   );
+
+/**
+ * Perform a facet search as per `options` and also request facets to only be generated for items
+ * which potentially have image attachments. The output ideally used to alongside the search
+ * results for `imageGallerySearch`.
+ *
+ * @param options Standard `SearchOptions` to refine the faceting by
+ */
+export const listImageGalleryClassifications = async (
+  options: SearchOptions
+): Promise<Classification[]> =>
+  listClassifications({ ...options, mimeTypes: await getImageMimeTypes() });
+
+/**
+ * Perform a facet search as per `options` and also request facets to only be generated for items
+ * which potentially have video attachments. The output ideally used to alongside the search
+ * results for `videoGallerySearch`.
+ *
+ * @param options Standard `SearchOptions` to refine the faceting by
+ */
+export const listVideoGalleryClassifications = async (
+  options: SearchOptions
+): Promise<Classification[]> =>
+  listClassifications({ ...options, musts: videoGalleryMusts });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchFacetsModule.ts
@@ -95,8 +95,9 @@ const convertSearchOptions: (
       status,
       rawMode,
       mimeTypes,
+      musts,
     } = options;
-    let searchFacetsParams: OEQ.SearchFacets.SearchFacetsParams = {
+    const searchFacetsParams: OEQ.SearchFacets.SearchFacetsParams = {
       nodes: [],
       q: query ? formatQuery(query, !rawMode) : undefined,
       modifiedAfter: getISODateString(lastModifiedDateRange?.start),
@@ -107,14 +108,14 @@ const convertSearchOptions: (
         OEQ.Common.ItemStatuses.alternatives.map((i) => i.value).sort()
       ),
       mimeTypes,
+      musts,
     };
-    if (collections && collections.length > 0) {
-      searchFacetsParams = {
-        ...searchFacetsParams,
-        collections: collections.map((c) => c.uuid),
-      };
-    }
-    return searchFacetsParams;
+    return collections && collections.length > 0
+      ? {
+          ...searchFacetsParams,
+          collections: collections.map((c) => c.uuid),
+        }
+      : searchFacetsParams;
   }
 );
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -17,6 +17,7 @@
  */
 import { Drawer, Grid, Hidden } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
+import { pipe } from "fp-ts/function";
 
 import { isEqual } from "lodash";
 import * as React from "react";
@@ -38,6 +39,8 @@ import { addFavouriteSearch } from "../modules/FavouriteModule";
 import {
   GallerySearchResultItem,
   imageGallerySearch,
+  listImageGalleryClassifications,
+  listVideoGalleryClassifications,
   videoGallerySearch,
 } from "../modules/GallerySearchModule";
 import {
@@ -370,8 +373,25 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         }
       };
 
+      // Depending on what display mode we're in, determine which function we use to list
+      // the classifications to match the search.
+      const getClassifications = pipe(state.options.displayMode, (mode) => {
+        switch (mode) {
+          case "gallery-image":
+            return listImageGalleryClassifications;
+          case "gallery-video":
+            return listVideoGalleryClassifications;
+          case "list":
+            return listClassifications;
+          default:
+            throw new TypeError(
+              "Unexpected `displayMode` for determining classifications listing function"
+            );
+        }
+      });
+
       setSearchPageOptions(state.options);
-      Promise.all([doSearch(state.options), listClassifications(state.options)])
+      Promise.all([doSearch(state.options), getClassifications(state.options)])
         .then(
           ([result, classifications]: [
             SearchPageSearchResult,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -375,20 +375,25 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
 
       // Depending on what display mode we're in, determine which function we use to list
       // the classifications to match the search.
-      const getClassifications = pipe(state.options.displayMode, (mode) => {
-        switch (mode) {
-          case "gallery-image":
-            return listImageGalleryClassifications;
-          case "gallery-video":
-            return listVideoGalleryClassifications;
-          case "list":
-            return listClassifications;
-          default:
-            throw new TypeError(
-              "Unexpected `displayMode` for determining classifications listing function"
-            );
+      const getClassifications: (
+        _: SearchOptions
+      ) => Promise<Classification[]> = pipe(
+        state.options.displayMode,
+        (mode) => {
+          switch (mode) {
+            case "gallery-image":
+              return listImageGalleryClassifications;
+            case "gallery-video":
+              return listVideoGalleryClassifications;
+            case "list":
+              return listClassifications;
+            default:
+              throw new TypeError(
+                "Unexpected `displayMode` for determining classifications listing function"
+              );
+          }
         }
-      });
+      );
 
       setSearchPageOptions(state.options);
       Promise.all([doSearch(state.options), getClassifications(state.options)])

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
@@ -66,10 +66,12 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.UriInfo;
 import org.apache.log4j.Logger;
+import scala.collection.JavaConverters;
 
 /** @author Aaron & Dustin */
 @SuppressWarnings("nls")
@@ -203,7 +205,8 @@ public class SearchResourceImpl implements EquellaSearchResource {
       String modifiedBefore,
       String owner,
       String showall,
-      List<String> mimeTypes) {
+      List<String> mimeTypes,
+      List<String> musts) {
     final String whereClause = where;
     final boolean onlyLive = !(showall != null && Utils.parseLooseBool(showall, false));
     final Collection<String> cols = (collections == null ? null : CsvList.asList(collections));
@@ -224,7 +227,18 @@ public class SearchResourceImpl implements EquellaSearchResource {
             null,
             owner,
             new DefaultSearch());
+    // Add MIME types
     search.setMimeTypes(mimeTypes);
+    // Add 'musts'
+    Optional.of(musts)
+        .filter(ms -> !ms.isEmpty())
+        .map(ms -> ms.toArray(new String[] {}))
+        .map(SearchHelper::handleMusts)
+        .map(JavaConverters::mapAsJavaMap)
+        .ifPresent(
+            ms ->
+                ms.forEach(
+                    (field, value) -> search.addMust(field, JavaConverters.seqAsJavaList(value))));
 
     final MatrixResults matrixResults =
         freetextService.matrixSearch(search, nodeList, true, width, true);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
@@ -232,7 +232,7 @@ public class SearchResourceImpl implements EquellaSearchResource {
     // Add 'musts'
     Optional.of(musts)
         .filter(ms -> !ms.isEmpty())
-        .map(ms -> ms.toArray(new String[] {}))
+        .map(ms -> ms.toArray(new String[0]))
         .map(SearchHelper::handleMusts)
         .map(JavaConverters::mapAsJavaMap)
         .ifPresent(

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -369,7 +369,7 @@ const convertMusts = (musts: Must[]): string[] =>
     []
   );
 
-const processMusts = (musts?: Must[]): string[] | undefined => {
+export const processMusts = (musts?: Must[]): string[] | undefined => {
   if (!musts) {
     return;
   }
@@ -380,6 +380,7 @@ const processMusts = (musts?: Must[]): string[] | undefined => {
   });
   return convertMusts(musts);
 };
+
 const processSearchParams = (
   params?: SearchParams
 ): SearchParamsProcessed | undefined =>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This ensures that the classifications and categories are correct when in the Image and Video galleries. This requires that the same additional filters (MIME types or musts) are sent to list the classifications function.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
