### PR TITLE
Front-end improvements for exporting search result

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/PrivilegeTree.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/PrivilegeTree.java
@@ -418,6 +418,7 @@ public final class PrivilegeTree {
     PrivilegeNode itemDefinition = itemDefinitions.getChildren().get(0);
     itemDefinition.registerPrivilege("SEARCH_COLLECTION");
     itemDefinition.registerPrivilege("CREATE_ITEM");
+    itemDefinition.registerPrivilege(SecurityConstants.EXPORT_SEARCH_RESULT);
     itemDefinition.getChildren().add(itemStatus);
     itemDefinition.getChildren().add(itemMetadata);
 
@@ -552,7 +553,6 @@ public final class PrivilegeTree {
     institution.registerPrivilege("INTEGRATION_SELECTION_SESSION");
     institution.registerPrivilege("VIEW_APIDOCS");
     institution.registerPrivilege("LIST_USERS");
-    institution.registerPrivilege(SecurityConstants.EXPORT_SEARCH_RESULT);
 
     // OAuth hax
     institution.registerPrivilege("ADMINISTER_OAUTH_TOKENS");

--- a/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/__tests__/tsrc/search/SearchPage.test.tsx
@@ -1057,14 +1057,6 @@ describe("Export search result", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows a Tick Icon to indicate search result is downloaded already", async () => {
-    await selectCollections(getCollectionMap[0].name);
-    userEvent.click(getDownloadButton());
-    expect(
-      page.queryByTitle(languageStrings.searchpage.export.exportCompleted)
-    ).toBeInTheDocument();
-  });
-
   it.each([
     ["zero", []],
     ["more than one", getCollectionMap.slice(0, 2).map((c) => c.name)],

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/TooltipIconButton.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/TooltipIconButton.tsx
@@ -31,6 +31,7 @@ export type TooltipIconButtonProps = Omit<TooltipProps, "onClick"> &
  * Provide an IconButton wrapped by a Tooltip.
  */
 export const TooltipIconButton = ({
+  id,
   title,
   onClick,
   children,
@@ -40,6 +41,7 @@ export const TooltipIconButton = ({
 }: TooltipIconButtonProps) => (
   <Tooltip title={title}>
     <IconButton
+      id={id}
       onClick={onClick}
       aria-label={ariaLabel ?? title}
       size={size}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -480,6 +480,16 @@ export const buildExportUrl = (searchOptions: SearchOptions): string =>
     buildSearchParams({ ...searchOptions, currentPage: 0 })
   );
 
+/**
+ * Send a request to confirm if an export is valid.
+ * @param searchOptions Search options selected on Search page.
+ */
+export const confirmExport = (searchOptions: SearchOptions): Promise<boolean> =>
+  OEQ.Search.confirmExportRequest(
+    API_BASE_URL,
+    buildSearchParams(searchOptions)
+  );
+
 const findCollectionsByUuid = async (
   collectionUuids: string[]
 ): Promise<Collection[] | undefined> => {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/modules/SearchModule.ts
@@ -416,6 +416,7 @@ export const newSearchQueryToSearchOptions = async (
 
 /**
  * A function that converts search options to search params.
+ *
  * @param searchOptions Search options to be converted to search params.
  */
 const buildSearchParams = ({
@@ -463,6 +464,7 @@ const buildSearchParams = ({
 
 /**
  * A function that executes a search with provided search options.
+ *
  * @param searchOptions Search options selected on Search page.
  */
 export const searchItems = (
@@ -472,6 +474,7 @@ export const searchItems = (
 
 /**
  * A function that builds a URL for exporting a search result
+ *
  * @param searchOptions Search options selected on Search page.
  */
 export const buildExportUrl = (searchOptions: SearchOptions): string =>
@@ -482,6 +485,7 @@ export const buildExportUrl = (searchOptions: SearchOptions): string =>
 
 /**
  * Send a request to confirm if an export is valid.
+ *
  * @param searchOptions Search options selected on Search page.
  */
 export const confirmExport = (searchOptions: SearchOptions): Promise<boolean> =>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -20,7 +20,7 @@ import * as OEQ from "@openequella/rest-api-client";
 
 import { isEqual } from "lodash";
 import * as React from "react";
-import { useCallback, useEffect, useReducer, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useHistory, useLocation } from "react-router";
 import { generateFromError } from "../api/errors";
 import { AppConfig } from "../AppConfig";
@@ -59,6 +59,7 @@ import {
 } from "../modules/SearchFilterSettingsModule";
 import {
   buildExportUrl,
+  confirmExport,
   DateRange,
   defaultPagedSearchResult,
   defaultSearchOptions,
@@ -246,6 +247,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
     setShowFavouriteSearchDialog,
   ] = useState<boolean>(false);
   const [alreadyDownloaded, setAlreadyDownloaded] = useState<boolean>(false);
+  const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
   const handleError = useCallback(
     (error: Error) => {
@@ -496,11 +498,22 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         message: searchStrings.export.collectionLimit,
         variant: "warning",
       });
-      return false;
+      return;
     }
-    // Do not allow exporting the same search result again until searchPageOptions gets changed.
-    setAlreadyDownloaded(true);
-    return true;
+
+    confirmExport(searchPageOptions)
+      .then(() => {
+        // All checks pass so manually trigger a click on the export link.
+        exportLinkRef.current?.click();
+        // Do not allow exporting the same search result again until searchPageOptions gets changed.
+        setAlreadyDownloaded(true);
+      })
+      .catch((error: OEQ.Errors.ApiError) => {
+        setSnackBar({
+          message: error.message,
+          variant: "warning",
+        });
+      });
   };
 
   const handleCopySearch = () => {
@@ -874,6 +887,7 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
                 exportProps={{
                   isExportPermitted:
                     currentUser?.canDownloadSearchResult ?? false,
+                  linkRef: exportLinkRef,
                   exportLinkProps: {
                     url: buildExportUrl(searchPageOptions),
                     onExport: handleExport,

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -509,8 +509,27 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
         setAlreadyDownloaded(true);
       })
       .catch((error: OEQ.Errors.ApiError) => {
+        const generateExportErrorMessage = (
+          error: OEQ.Errors.ApiError
+        ): string => {
+          const {
+            badRequest,
+            unauthorised,
+            notFound,
+          } = searchStrings.export.errorMessages;
+          switch (error.status) {
+            case 400:
+              return badRequest;
+            case 403:
+              return unauthorised;
+            case 404:
+              return notFound;
+            default:
+              return error.message;
+          }
+        };
         setSnackBar({
-          message: error.message,
+          message: generateExportErrorMessage(error),
           variant: "warning",
         });
       });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -61,6 +61,7 @@ export const ExportSearchResultLink = React.forwardRef<
       >
         <GetAppIcon />
       </TooltipIconButton>
+      {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
       <a hidden download href={url} ref={linkRef} />
     </>
   );

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -31,7 +31,7 @@ export interface ExportSearchResultLinkProps {
    *  Handler fired before triggering an export. Return `false` to prevent
    *  an export being triggered.
    */
-  onExport: () => boolean;
+  onExport: () => void;
   /**
    * `true` to show a complete indicator and disable additional clicking.
    */
@@ -44,30 +44,21 @@ const exportStrings = languageStrings.searchpage.export;
  * Build a Download icon button wrapped by a link to export a search result,
  * or a Tick icon to indicate the search result is downloaded already.
  */
-export const ExportSearchResultLink = ({
-  url,
-  onExport,
-  alreadyExported,
-}: ExportSearchResultLinkProps) => {
-  // Prevent the link from following the URL if an export is invalid.
-  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (!onExport()) {
-      e.preventDefault();
-      return false;
-    }
-    return true;
-  };
-
+export const ExportSearchResultLink = React.forwardRef<
+  HTMLAnchorElement,
+  ExportSearchResultLinkProps
+>(({ alreadyExported, url, onExport }, linkRef) => {
   return alreadyExported ? (
     // Just need an Icon instead of an Icon button.
     <Tooltip title={exportStrings.exportCompleted}>
       <DoneIcon color="secondary" />
     </Tooltip>
   ) : (
-    <Link download href={url} onClick={onClick}>
-      <TooltipIconButton title={exportStrings.title}>
+    <>
+      <TooltipIconButton title={exportStrings.title} onClick={onExport}>
         <GetAppIcon />
       </TooltipIconButton>
-    </Link>
+      <Link hidden download href={url} ref={linkRef} />
+    </>
   );
-};
+});

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -28,8 +28,7 @@ export interface ExportSearchResultLinkProps {
    */
   url: string;
   /**
-   *  Handler fired before triggering an export. Return `false` to prevent
-   *  an export being triggered.
+   *  Handler for exporting search result.
    */
   onExport: () => void;
   /**

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/ExportSearchResultLink.tsx
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Link, Tooltip } from "@material-ui/core";
+import { Tooltip } from "@material-ui/core";
 import DoneIcon from "@material-ui/icons/Done";
 import GetAppIcon from "@material-ui/icons/GetApp";
 import * as React from "react";
@@ -51,14 +51,18 @@ export const ExportSearchResultLink = React.forwardRef<
   return alreadyExported ? (
     // Just need an Icon instead of an Icon button.
     <Tooltip title={exportStrings.exportCompleted}>
-      <DoneIcon color="secondary" />
+      <DoneIcon color="secondary" id="exportCompleted" />
     </Tooltip>
   ) : (
     <>
-      <TooltipIconButton title={exportStrings.title} onClick={onExport}>
+      <TooltipIconButton
+        title={exportStrings.title}
+        onClick={onExport}
+        id="exportSearchResult"
+      >
         <GetAppIcon />
       </TooltipIconButton>
-      <Link hidden download href={url} ref={linkRef} />
+      <a hidden download href={url} ref={linkRef} />
     </>
   );
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchResultList.tsx
@@ -112,6 +112,7 @@ export interface SearchResultListProps {
    */
   exportProps: {
     isExportPermitted: boolean;
+    linkRef: React.RefObject<HTMLAnchorElement>;
     exportLinkProps: ExportSearchResultLinkProps;
   };
 }
@@ -139,7 +140,7 @@ export const SearchResultList = ({
   onClearSearchOptions,
   onCopySearchLink,
   onSaveSearch,
-  exportProps: { isExportPermitted, exportLinkProps },
+  exportProps: { isExportPermitted, linkRef, exportLinkProps },
 }: SearchResultListProps) => {
   const classes = useStyles();
   const inSelectionSession: boolean = isSelectionSessionOpen();
@@ -185,7 +186,7 @@ export const SearchResultList = ({
             </Grid>
             {isExportPermitted && (
               <Grid item>
-                <ExportSearchResultLink {...exportLinkProps} />
+                <ExportSearchResultLink {...exportLinkProps} ref={linkRef} />
               </Grid>
             )}
             <Hidden mdUp>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -359,6 +359,11 @@ export const languageStrings = {
       collectionLimit: "Download limited to one collection.",
       exportCompleted: "File downloaded",
       title: "Download search result to a CSV file",
+      errorMessages: {
+        badRequest: "Failed to export as this request is invalid.",
+        unauthorised: "Sorry, you are not authorised to export this search.",
+        notFound: "Failed to find details to export this search.",
+      },
     },
     favouriteItem: {
       removeAlert: "Are you sure you want to remove from your favourites?",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/util/langstrings.ts
@@ -358,7 +358,8 @@ export const languageStrings = {
       exportCompleted: "File downloaded",
       title: "Download search result to a CSV file",
       errorMessages: {
-        badRequest: "Failed to export as this request is invalid.",
+        badRequest:
+          "Export failed due to the server indicating the request was invalid.",
         unauthorised: "Sorry, you are not authorised to export this search.",
         notFound: "Failed to find details to export this search.",
       },

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/ExportCSVHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/ExportCSVHelper.scala
@@ -201,10 +201,6 @@ object ExportCSVHelper {
     })
   }
 
-  def getSchemaFromCollection(collectionId: String): Option[Schema] = {
-    Option(LegacyGuice.itemDefinitionService.getByUuid(collectionId)).map(_.getSchema)
-  }
-
   /**
     * Write CSV contents into a BufferedOutputStream.
     * @param bos BufferedOutputStream A BufferedOutputStream wrapping another underlying OutputStream.

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -19,6 +19,9 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   @FindBy(id = "collapsibleRefinePanelButton")
   private WebElement collapsibleRefinePanelButton;
 
+  @FindBy(id = "exportSearchResult")
+  private WebElement exportButton;
+
   public NewSearchPage(PageContext context) {
     super(context);
   }
@@ -76,6 +79,19 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   public void expandRefineControlPanel() {
     collapsibleRefinePanelButton.click();
   }
+
+  /** Execute an export by clicking the export button. */
+  public void export() {
+    exportButton.click();
+  }
+
+  /** Find the Tick icon. */
+  public WebElement getExportDoneButton() {
+    WebElement tickIcon = driver.findElement(By.id("exportCompleted"));
+    getWaiter().until(ExpectedConditions.visibilityOf(tickIcon));
+    return tickIcon;
+  }
+
   /**
    * Select Collections by typing keywords in the Selector's TextField.
    *
@@ -218,6 +234,22 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    */
   public void verifyAttachmentNotDisplayed(String attachmentText) {
     waiter.until(ExpectedConditions.numberOfElementsToBe(attachmentLinkByText(attachmentText), 0));
+  }
+
+  /** Verify that the export button is hidden. */
+  public void verifyExportButtonNotDisplayed() {
+    waiter.until(ExpectedConditions.numberOfElementsToBe(By.id("exportSearchResult"), 0));
+  }
+
+  /**
+   * Find the snackbar and verify its message.
+   *
+   * @param message The message expected to be displayed in the snackbar.
+   */
+  public void verifySnackbarMessage(String message) {
+    WebElement snackbar =
+        driver.findElement(By.xpath("//span[@id='client-snackbar' and text()='" + message + "']"));
+    getWaiter().until(ExpectedConditions.visibilityOf(snackbar));
   }
 
   /**

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -1,6 +1,7 @@
 package io.github.openequella.search;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.tle.webtests.framework.TestInstitution;
 import com.tle.webtests.pageobject.viewitem.SummaryPage;
@@ -87,6 +88,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
     searchPage.waitForSearchCompleted(7);
     searchPage.selectCollection("Hardware");
     searchPage.waitForSearchCompleted(7);
+    searchPage.verifyExportButtonNotDisplayed();
   }
 
   @Test(
@@ -115,5 +117,29 @@ public class NewSearchPageTest extends AbstractSessionTest {
     searchPage.changeQuery(searchTerm);
     searchPage.waitForSearchCompleted(1);
     searchPage.verifyAttachmentNotDisplayed(attachmentTitle);
+  }
+
+  @Test(description = "Export search result with a Collection")
+  @NewUIOnly
+  public void export() {
+    final String COLLECTION_ERROR_MESSAGE = "Download limited to one collection.";
+    searchPage = new NewSearchPage(context).load();
+
+    searchPage.newSearch();
+    searchPage.export();
+    // Show snackbar to indicate the Collection selection error.
+    searchPage.verifySnackbarMessage(COLLECTION_ERROR_MESSAGE);
+
+    searchPage.selectCollection("programming");
+    searchPage.waitForSearchCompleted(9);
+    searchPage.export();
+    // Show a Tick icon to indicate an export is done.
+    assertTrue(searchPage.getExportDoneButton().isDisplayed());
+
+    searchPage.selectCollection("hardware");
+    searchPage.waitForSearchCompleted(16);
+    searchPage.export();
+    // Show snackbar again to indicate the Collection selection error.
+    searchPage.verifySnackbarMessage(COLLECTION_ERROR_MESSAGE);
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR includes two major changes: 

1. changing the configuration of ACL `EXPORT_SEARCH_RESULT` on Collection level instead of Institution level.
2. better front-end error handling.

With the first change, the export button is displayed as long as user has the ACL granted against at least one Collection.  When user exports with a Collection which does not allow to export, the snack bar pops up with a warning message.

For the better error handling,  `ref` is used to help manually trigger a click event on the export link after the head request gets resolved. If the request gets rejected, an error message is showed.


https://user-images.githubusercontent.com/47203811/115316029-e0f45f80-a1bb-11eb-8792-ec9be874c0ae.mp4

