### PR TITLE
Use 'useReducer' to better handle the state of SearchBar

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/SearchPage.tsx
@@ -15,12 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Drawer, Grid, Hidden } from "@material-ui/core";
+import { debounce, Drawer, Grid, Hidden } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
 
 import { isEqual } from "lodash";
 import * as React from "react";
-import { useCallback, useEffect, useReducer, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { useHistory, useLocation } from "react-router";
 import { generateFromError } from "../api/errors";
 import { AppConfig } from "../AppConfig";
@@ -418,13 +418,20 @@ const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const handleSortOrderChanged = (order: OEQ.SearchSettings.SortOrder) =>
     search({ ...searchPageOptions, sortOrder: order });
 
-  const handleQueryChanged = (query: string) =>
-    search({
-      ...searchPageOptions,
-      query: query,
-      currentPage: 0,
-      selectedCategories: undefined,
-    });
+  const handleQueryChanged = useMemo(
+    () =>
+      debounce(
+        (query: string) =>
+          search({
+            ...searchPageOptions,
+            query: query,
+            currentPage: 0,
+            selectedCategories: undefined,
+          }),
+        500
+      ),
+    [searchPageOptions, search]
+  );
 
   const handleDisplayModeChanged = (mode: DisplayMode) =>
     search({ ...searchPageOptions, displayMode: mode });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -26,7 +26,7 @@ import {
 import { makeStyles } from "@material-ui/core/styles";
 import SearchIcon from "@material-ui/icons/Search";
 import * as React from "react";
-import { useCallback, useEffect, useReducer, useState } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import { languageStrings } from "../../util/langstrings";
 
 const useStyles = makeStyles({
@@ -68,24 +68,24 @@ export interface SearchBarProps {
 
 const searchStrings = languageStrings.searchpage;
 
-type State =
-  | { status: "init"; query: string }
-  | { status: "searching"; query: string }
-  | { status: "done" };
+interface State {
+  status: "init" | "queryUpdated" | "waiting";
+  query: string;
+}
 
 type Action =
-  | { type: "newSearch"; initialQuery: string }
-  | { type: "debouncedSearch"; debouncedQuery: string }
-  | { type: "waitForNewQuery" };
+  | { type: "clearQuery" }
+  | { type: "updateQuery"; query: string }
+  | { type: "waitForNewQuery"; query: string };
 
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "newSearch":
-      return { status: "init", query: action.initialQuery };
-    case "debouncedSearch":
-      return { status: "searching", query: action.debouncedQuery };
+    case "clearQuery":
+      return { status: "init", query: "" };
+    case "updateQuery":
+      return { status: "queryUpdated", query: action.query };
     case "waitForNewQuery":
-      return { status: "done" };
+      return { status: "waiting", query: action.query };
     default:
       throw new TypeError("Unexpected action passed to reducer!");
   }
@@ -106,13 +106,12 @@ export default function SearchBar({
 }: SearchBarProps) {
   const classes = useStyles();
   const [state, dispatch] = useReducer(reducer, { status: "init", query });
-  const [currentQuery, setCurrentQuery] = useState<string>(query);
 
   const search = useCallback(
     (query: string) => {
       dispatch({
-        type: "debouncedSearch",
-        debouncedQuery: query,
+        type: "updateQuery",
+        query,
       });
     },
     [dispatch]
@@ -120,30 +119,29 @@ export default function SearchBar({
 
   useEffect(() => {
     // When props query becomes falsy, it means a new search has been performed to clear SearchPageOptions.
-    // So we dispatch the action of "newSearch".
+    // So we dispatch the action of "clearQuery".
     if (!query) {
       dispatch({
-        type: "newSearch",
-        initialQuery: query,
+        type: "clearQuery",
       });
     }
   }, [query]);
 
   useEffect(() => {
-    if (state.status === "done") {
+    if (state.status === "waiting") {
+      // Most likely called because of a change in onQueryChange so no action required
       return;
-    }
-    setCurrentQuery(state.query);
-    if (state.status === "searching") {
+    } else if (state.status === "queryUpdated") {
       onQueryChange(state.query);
       dispatch({
         type: "waitForNewQuery",
+        query: state.query,
       });
     }
   }, [state, dispatch, onQueryChange]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Escape" && currentQuery) {
+    if (event.key === "Escape" && state.query) {
       // iff there is a current query, clear it out and trigger a search
       search("");
     }
@@ -163,7 +161,7 @@ export default function SearchBar({
         className={classes.input}
         onKeyDown={handleKeyDown}
         onChange={handleOnChange}
-        value={currentQuery}
+        value={state.query}
         placeholder={
           wildcardMode
             ? searchStrings.wildcardSearchEnabledPlaceholder

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 import {
-  debounce,
   Divider,
   FormControlLabel,
   IconButton,
@@ -27,10 +26,8 @@ import {
 import { makeStyles } from "@material-ui/core/styles";
 import SearchIcon from "@material-ui/icons/Search";
 import * as React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import { languageStrings } from "../../util/langstrings";
-
-const ESCAPE_KEY_CODE = 27;
 
 const useStyles = makeStyles({
   root: {
@@ -71,8 +68,31 @@ export interface SearchBarProps {
 
 const searchStrings = languageStrings.searchpage;
 
+type State =
+  | { status: "init"; query: string }
+  | { status: "searching"; query: string }
+  | { status: "done" };
+
+type Action =
+  | { type: "newSearch"; initialQuery: string }
+  | { type: "debouncedSearch"; debouncedQuery: string }
+  | { type: "waitForNewQuery" };
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "newSearch":
+      return { status: "init", query: action.initialQuery };
+    case "debouncedSearch":
+      return { status: "searching", query: action.debouncedQuery };
+    case "waitForNewQuery":
+      return { status: "done" };
+    default:
+      throw new TypeError("Unexpected action passed to reducer!");
+  }
+};
+
 /**
- * Debounced searchbar component to be used in the Search Page.
+ * Provide a input field to update the query of search criteria.
  * This component does not handle the API query itself,
  * that should be done in the parent component in response to the
  * onXyzChange callbacks and the doSearch.
@@ -85,37 +105,52 @@ export default function SearchBar({
   doSearch,
 }: SearchBarProps) {
   const classes = useStyles();
-
+  const [state, dispatch] = useReducer(reducer, { status: "init", query });
   const [currentQuery, setCurrentQuery] = useState<string>(query);
 
-  // The line below triggers the warning:
-  // > React Hook useCallback received a function whose dependencies are unknown. Pass an inline function instead
-  // It was not obvious how to do this with `debounce`, however attempts were made to manually
-  // validate the dependencies.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedOnQueryChange = useCallback(debounce(onQueryChange, 500), [
-    doSearch,
-    onQueryChange,
-  ]);
+  const search = useCallback(
+    (query: string) => {
+      dispatch({
+        type: "debouncedSearch",
+        debouncedQuery: query,
+      });
+    },
+    [dispatch]
+  );
 
-  // Update state when search query is cleared.
   useEffect(() => {
-    setCurrentQuery(query);
+    // When props query becomes falsy, it means a new search has been performed to clear SearchPageOptions.
+    // So we dispatch the action of "newSearch".
+    if (!query) {
+      dispatch({
+        type: "newSearch",
+        initialQuery: query,
+      });
+    }
   }, [query]);
 
+  useEffect(() => {
+    if (state.status === "done") {
+      return;
+    }
+    setCurrentQuery(state.query);
+    if (state.status === "searching") {
+      onQueryChange(state.query);
+      dispatch({
+        type: "waitForNewQuery",
+      });
+    }
+  }, [state, dispatch, onQueryChange]);
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.keyCode === ESCAPE_KEY_CODE && currentQuery) {
+    if (event.key === "Escape" && currentQuery) {
       // iff there is a current query, clear it out and trigger a search
-      setCurrentQuery("");
-      onQueryChange("");
+      search("");
     }
   };
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const updatedQuery = event.target.value;
-
-    setCurrentQuery(updatedQuery);
-    debouncedOnQueryChange(updatedQuery);
+    search(event.target.value);
   };
 
   return (


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR fixes the debounce issue of SearchBar by using `useReducer`. Also, the usage of `debounce` has been moved to SearchPage as whether to debounce a search is what SearchPage cares.



https://user-images.githubusercontent.com/47203811/116189953-19bca780-a76d-11eb-9d0a-33576229dc13.mp4

