### PR TITLE
Fix MUI warnings about `ref`

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/MainMenu.tsx
@@ -27,7 +27,7 @@ import {
 } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router";
 import { useStyles } from "./Template";
 
 interface MainMenuProps {
@@ -49,23 +49,17 @@ interface MainMenuProps {
  */
 const MainMenu = ({ menuGroups, onClickNavItem }: MainMenuProps) => {
   const classes = useStyles(useTheme());
-
+  const history = useHistory();
   const navItem = (item: OEQ.LegacyContent.MenuItem, ind: number) => (
     <ListItem
-      component={(p) => {
-        const props = {
-          ...p,
-          rel: item.newWindow ? "noopener noreferrer" : undefined,
-          target: item.newWindow ? "_blank" : undefined,
-          onClick: onClickNavItem,
-        };
-        return item.route ? (
-          <Link {...props} to={item.route} />
-        ) : (
-          <a {...props} href={item.href}>
-            {}
-          </a>
-        );
+      component="a"
+      href={item.href}
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+        onClickNavItem();
+        if (item.route) {
+          e.preventDefault();
+          history.push(item.route);
+        }
       }}
       key={ind}
       button


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Two warnings about `ref` have been there for quite a while. They are caused from component  `MainMenu`. Details about the warnings can be found from [MUI Guide](https://material-ui.com/guides/composition/#caveat-with-refs).

This PR fixes the two warnings by refactoring how to build a MUI ListItem that works as a link in component `MainMenu`.