### PR TITLE
Ensure search bar shows the correct query

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/search/components/SearchBar.tsx
@@ -117,15 +117,25 @@ export default function SearchBar({
     [dispatch]
   );
 
+  // The state query should be consistent with prop query. But there are two situations where they
+  // are different.
+  // One is when a new search has been performed to clear SearchPageOptions. In this case, we dispatch
+  // the action of "clearQuery".
+  // The other is when the page is rendered with previously selected search options where a query is
+  // included. We dispatch the action of "waitForNewQuery" to update the state without triggering
+  // an extra search.
   useEffect(() => {
-    // When props query becomes falsy, it means a new search has been performed to clear SearchPageOptions.
-    // So we dispatch the action of "clearQuery".
-    if (!query) {
+    if (!query && state.query) {
       dispatch({
         type: "clearQuery",
       });
+    } else if (query && !state.query) {
+      dispatch({
+        type: "waitForNewQuery",
+        query,
+      });
     }
-  }, [query]);
+  }, [query, state.query]);
 
   useEffect(() => {
     if (state.status === "waiting") {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The previous fix for SearchBar debounce issue can cause another issue: when open a shared search where a query is included, SearchBar does not show the query. So PR brings in an additional fix based on the debounce issue fix.


https://user-images.githubusercontent.com/47203811/116650627-ebd1a000-a9c4-11eb-98a3-5e38c72f2b8f.mp4

