### PR TITLE
Feature/rewrite audit log entry migration

### DIFF
--- a/Source/Plugins/Admin/com.tle.web.adminconsole/jarsrc/build.sbt
+++ b/Source/Plugins/Admin/com.tle.web.adminconsole/jarsrc/build.sbt
@@ -27,7 +27,10 @@ excludeDependencies ++= Seq(
 packageOptions in assembly += Package.ManifestAttributes("Permissions" -> "all-permissions")
 assemblyOption in assembly := (assemblyOption in assembly).value
 assemblyMergeStrategy in assembly := {
-  case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
+  case PathList("org", "xmlpull", "v1", _*)      => MergeStrategy.first
+  case PathList("javax", "activation", _*)       => MergeStrategy.first
+  case PathList("javax", "xml", _*)              => MergeStrategy.first
+  case PathList("META-INF", "versions", "9", _*) => MergeStrategy.first
   // Added due to a [deduplicate: different file contents found in the following] error against:
   // org.springframework/spring-context/jars/spring-context-3.2.18.RELEASE.jar:overview.html
   // org.springframework/spring-web/jars/spring-web-3.2.18.RELEASE.jar:overview.html

--- a/Source/Plugins/Admin/com.tle.web.adminconsole/jarsrc/build.sbt
+++ b/Source/Plugins/Admin/com.tle.web.adminconsole/jarsrc/build.sbt
@@ -27,7 +27,8 @@ excludeDependencies ++= Seq(
 packageOptions in assembly += Package.ManifestAttributes("Permissions" -> "all-permissions")
 assemblyOption in assembly := (assemblyOption in assembly).value
 assemblyMergeStrategy in assembly := {
-  case PathList("org", "xmlpull", "v1", _*)      => MergeStrategy.first
+  case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
+  // The following three were added when the hibernate-types was added the the hibernate module
   case PathList("javax", "activation", _*)       => MergeStrategy.first
   case PathList("javax", "xml", _*)              => MergeStrategy.first
   case PathList("META-INF", "versions", "9", _*) => MergeStrategy.first

--- a/Source/Plugins/Applet/com.tle.web.filemanager.applet/appletsrc/build.sbt
+++ b/Source/Plugins/Applet/com.tle.web.filemanager.applet/appletsrc/build.sbt
@@ -21,7 +21,10 @@ packageOptions in assembly += Package.ManifestAttributes(
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 assemblyMergeStrategy in assembly := {
-  case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
+  case PathList("org", "xmlpull", "v1", _*)      => MergeStrategy.first
+  case PathList("javax", "activation", _*)       => MergeStrategy.first
+  case PathList("javax", "xml", "bind", _*)      => MergeStrategy.first
+  case PathList("META-INF", "versions", "9", _*) => MergeStrategy.first
   // Added due to a [deduplicate: different file contents found in the following] error against:
   // org.springframework/spring-context/jars/spring-context-3.2.18.RELEASE.jar:overview.html
   // org.springframework/spring-web/jars/spring-web-3.2.18.RELEASE.jar:overview.html

--- a/Source/Plugins/Applet/com.tle.web.filemanager.applet/appletsrc/build.sbt
+++ b/Source/Plugins/Applet/com.tle.web.filemanager.applet/appletsrc/build.sbt
@@ -21,7 +21,8 @@ packageOptions in assembly += Package.ManifestAttributes(
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 assemblyMergeStrategy in assembly := {
-  case PathList("org", "xmlpull", "v1", _*)      => MergeStrategy.first
+  case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
+  // The following three were added when the hibernate-types was added the the hibernate module
   case PathList("javax", "activation", _*)       => MergeStrategy.first
   case PathList("javax", "xml", "bind", _*)      => MergeStrategy.first
   case PathList("META-INF", "versions", "9", _*) => MergeStrategy.first

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
@@ -20,7 +20,6 @@ package com.tle.beans.audit;
 
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import com.tle.beans.Institution;
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -33,9 +32,7 @@ import javax.persistence.ManyToOne;
 import org.hibernate.annotations.AttributeAccessor;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
 
-@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 @Entity
 @AttributeAccessor("field")
 public class AuditLogEntry implements AuditLogTable {

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.beans.audit;
+
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import com.tle.beans.Institution;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import org.hibernate.annotations.AttributeAccessor;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@Entity
+@AttributeAccessor("field")
+public class AuditLogEntry implements AuditLogTable {
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @Index(name = "audit_institution_id")
+  @XStreamOmitField
+  private Institution institution;
+
+  @Index(name = "audit_timestamp")
+  private Date timestamp;
+
+  @Column(length = 20)
+  @Index(name = "audit_event_category")
+  private String eventCategory;
+
+  @Column(length = 20)
+  @Index(name = "audit_event_type")
+  private String eventType;
+
+  @Column(length = 255, nullable = false)
+  @Index(name = "audit_user_id")
+  private String userId;
+
+  @Column(length = 40)
+  @Index(name = "audit_session_id")
+  private String sessionId;
+
+  @Column(length = 255)
+  @Index(name = "audit_data1")
+  private String data1;
+
+  @Column(length = 255)
+  @Index(name = "audit_data2")
+  private String data2;
+
+  @Column(length = 255)
+  @Index(name = "audit_data3")
+  private String data3;
+
+  @Lob private String data4;
+
+  @Type(type = "jsonb")
+  @Column(columnDefinition = "jsonb")
+  private String meta;
+
+  public AuditLogEntry() {
+    super();
+  }
+
+  @Override
+  public long getId() {
+    return id;
+  }
+
+  @Override
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  @Override
+  public Institution getInstitution() {
+    return institution;
+  }
+
+  @Override
+  public void setInstitution(Institution institution) {
+    this.institution = institution;
+  }
+
+  @Override
+  public Date getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Date timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public String getEventCategory() {
+    return eventCategory;
+  }
+
+  public void setEventCategory(String eventCategory) {
+    this.eventCategory = eventCategory;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  @Override
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  @Override
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  public String getData1() {
+    return data1;
+  }
+
+  public void setData1(String data1) {
+    this.data1 = data1;
+  }
+
+  public String getData2() {
+    return data2;
+  }
+
+  public void setData2(String data2) {
+    this.data2 = data2;
+  }
+
+  public String getData3() {
+    return data3;
+  }
+
+  public void setData3(String data3) {
+    this.data3 = data3;
+  }
+
+  public String getData4() {
+    return data4;
+  }
+
+  public void setData4(String data4) {
+    this.data4 = data4;
+  }
+
+  public String getMeta() {
+    return meta;
+  }
+
+  public void setMeta(String meta) {
+    this.meta = meta;
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/jarsrc/build.sbt
+++ b/Source/Plugins/Core/com.equella.core/jarsrc/build.sbt
@@ -18,7 +18,10 @@ packageOptions in assembly += Package.ManifestAttributes(
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 assemblyMergeStrategy in assembly := {
-  case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
+  case PathList("org", "xmlpull", "v1", _*)      => MergeStrategy.first
+  case PathList("javax", "activation", _*)       => MergeStrategy.first
+  case PathList("javax", "xml", "bind", _*)      => MergeStrategy.first
+  case PathList("META-INF", "versions", "9", _*) => MergeStrategy.first
   // Added due to a [deduplicate: different file contents found in the following] error against:
   // org.springframework/spring-context/jars/spring-context-3.2.18.RELEASE.jar:overview.html
   // org.springframework/spring-web/jars/spring-web-3.2.18.RELEASE.jar:overview.html

--- a/Source/Plugins/Core/com.equella.core/jarsrc/build.sbt
+++ b/Source/Plugins/Core/com.equella.core/jarsrc/build.sbt
@@ -18,7 +18,8 @@ packageOptions in assembly += Package.ManifestAttributes(
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 assemblyMergeStrategy in assembly := {
-  case PathList("org", "xmlpull", "v1", _*)      => MergeStrategy.first
+  case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
+  // The following three were added when the hibernate-types was added the the hibernate module
   case PathList("javax", "activation", _*)       => MergeStrategy.first
   case PathList("javax", "xml", "bind", _*)      => MergeStrategy.first
   case PathList("META-INF", "versions", "9", _*) => MergeStrategy.first

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -1675,6 +1675,11 @@
     <parameter id="bean" value="bean:com.tle.core.legacy.initial.AuditLogData4Migration" />
     <parameter id="date" value="1970-01-01" />
   </extension>
+  <extension plugin-id="com.tle.core.migration" point-id="migration" id="NewAuditLogColumn">
+    <parameter id="id" value="NewAuditLogColumn" />
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v66.NewAuditLogColumn" />
+    <parameter id="date" value="2018-06-01" />
+  </extension>
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="addIndexes">
     <parameter id="id" value="com.tle.core.migration.initial.EnsureForeignKeyIndexes" />
     <parameter id="bean" value="bean:com.tle.core.legacy.initial.EnsureForeignKeyIndexes" />

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -76,6 +76,7 @@
 /com.tle.core.entity.services.migration.v64.AddInstitutionFileWarningColumn.title=Add quota warning column to institution
 /com.tle.core.entity.services.migration.v64.displaytemplatetitle.title=Add new title to display template entities
 /com.tle.core.entity.services.migration.v64.thumbnail.columnsize.title=Increasing column size for item thumbnails
+/com.tle.core.entity.services.migration.v66.auditlogentry.meta=Add new column to audit log
 /com.tle.core.entity.services.migration.v20192.unknownuser.lastowner=Add last owner to item
 /com.tle.core.entity.services.migration.v20192.unknownuser.alluser=Create a new table for all users
 /com.tle.core.entity.services.migration.v20202.facetedsearch.classification=Create a new table for faceted search classification

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.institution.migration.v66;
 
 import com.tle.core.guice.Bind;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
@@ -23,7 +23,6 @@ import com.tle.core.hibernate.impl.HibernateMigrationHelper;
 import com.tle.core.migration.AbstractHibernateSchemaMigration;
 import com.tle.core.migration.MigrationInfo;
 import com.tle.core.migration.MigrationResult;
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.util.List;
 import javax.inject.Singleton;
 import javax.persistence.Column;
@@ -34,7 +33,6 @@ import javax.persistence.Id;
 import org.hibernate.Session;
 import org.hibernate.annotations.AttributeAccessor;
 import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
 
 @Bind
 @Singleton
@@ -74,7 +72,6 @@ public class NewAuditLogColumn extends AbstractHibernateSchemaMigration {
     return new MigrationInfo("com.tle.core.entity.services.migration.v66.auditlogentry.meta");
   }
 
-  @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
   @Entity(name = "AuditLogEntry")
   @AttributeAccessor("field")
   public static class FakeAuditLogEntry {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
@@ -1,0 +1,71 @@
+package com.tle.core.institution.migration.v66;
+
+import com.tle.core.guice.Bind;
+import com.tle.core.hibernate.impl.HibernateMigrationHelper;
+import com.tle.core.migration.AbstractHibernateSchemaMigration;
+import com.tle.core.migration.MigrationInfo;
+import com.tle.core.migration.MigrationResult;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.util.List;
+import javax.inject.Singleton;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.hibernate.Session;
+import org.hibernate.annotations.AttributeAccessor;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
+@Bind
+@Singleton
+public class NewAuditLogColumn extends AbstractHibernateSchemaMigration {
+
+  @Override
+  protected void executeDataMigration(
+      HibernateMigrationHelper helper, MigrationResult result, Session session) throws Exception {}
+
+  @Override
+  protected int countDataMigrations(HibernateMigrationHelper helper, Session session) {
+    return 1;
+  }
+
+  @Override
+  public boolean isBackwardsCompatible() {
+    return true;
+  }
+
+  @Override
+  protected List<String> getDropModifySql(HibernateMigrationHelper helper) {
+    return null;
+  }
+
+  @Override
+  protected List<String> getAddSql(HibernateMigrationHelper helper) {
+    return helper.getAddColumnsSQL("audit_log_entry", "meta");
+  }
+
+  @Override
+  protected Class<?>[] getDomainClasses() {
+    return new Class<?>[] {FakeAuditLogEntry.class};
+  }
+
+  @Override
+  public MigrationInfo createMigrationInfo() {
+    return new MigrationInfo("com.tle.core.entity.services.migration.v66.auditlogentry.meta");
+  }
+
+  @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+  @Entity(name = "AuditLogEntry")
+  @AttributeAccessor("field")
+  public static class FakeAuditLogEntry {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    long id;
+
+    @Type(type = "jsonb")
+    @Column(columnDefinition = "jsonb")
+    private String meta;
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/migration/initial/InitialSchema.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/migration/initial/InitialSchema.java
@@ -27,6 +27,7 @@ import com.tle.beans.SchemaScript;
 import com.tle.beans.Staging;
 import com.tle.beans.UserPreference;
 import com.tle.beans.activation.ActivateRequest;
+import com.tle.beans.audit.AuditLogEntry;
 import com.tle.beans.entity.BaseEntity;
 import com.tle.beans.entity.EntityLock;
 import com.tle.beans.entity.LanguageBundle;
@@ -81,9 +82,10 @@ import org.java.plugin.registry.Extension.Parameter;
 @Singleton
 public class InitialSchema extends AbstractCreateMigration {
   private PluginTracker<Object> initialTracker;
-  private static PluginResourceHelper r = ResourcesService.getResourceHelper(InitialSchema.class);
+  private static final PluginResourceHelper r =
+      ResourcesService.getResourceHelper(InitialSchema.class);
 
-  private static Class<?>[] clazzes =
+  private static final Class<?>[] clazzes =
       new Class<?>[] {
         ConfigurationProperty.class,
         ItemDefinitionScript.class,
@@ -143,7 +145,8 @@ public class InitialSchema extends AbstractCreateMigration {
         TargetListEntry.class,
         VersionSelection.class,
         BaseEntity.Attribute.class,
-        ACLEntryMapping.class
+        ACLEntryMapping.class,
+        AuditLogEntry.class
       };
 
   @SuppressWarnings("nls")

--- a/Source/Plugins/Core/com.equella.serverbase/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.serverbase/resources/lang/i18n-resource-centre.properties
@@ -10,7 +10,7 @@ institution.validate.long={0} is too long - maximum is {1}
 institution.validate.quota.notanumber=The quota entered is not a valid number
 institution.validate.url=Institution URL
 institution.validate.url.inside=URL must not be ''inside'' of an existing institution''s URL space, in this case {0}. This may cause the other institution to work incorrectly.
-institution.validate.url.invalidhost=The hostname contains invalid characters. 
+institution.validate.url.invalidhost=The hostname contains invalid characters.
 institution.validate.url.overwrite=URL must not ''overwrite'' an existing institution''s URL space, in this case {0}. This may cause this institution to work incorrectly.
 institution.validate.url.use=Institution URL ''{0}'' is already in use by the Institution Management site
 institution.validate.url.valid=''{0}'' is not a valid URL
@@ -18,6 +18,5 @@ institution.validate.use={0} ''{1}'' is already in use by another institution
 
 task.status=Completed {0} of {1} migration tasks ({2}%)
 
-mig.auditcol.title = Add new column to audit log
 mig.viewcount.title = Create view count tables
 mig.newentities.title = Create new style entity tables

--- a/Source/Plugins/Core/com.equella.serverbase/scalasrc/com/tle/core/db/DBSchema.scala
+++ b/Source/Plugins/Core/com.equella.serverbase/scalasrc/com/tle/core/db/DBSchema.scala
@@ -82,20 +82,6 @@ trait DBSchema extends StdColumns {
     auditLog.query.where('institution_id, BinOp.EQ).build
   )
 
-  val auditLogTable = auditLog.definition
-
-  val auditLogIndexColumns: TableColumns = auditLog.subset(
-    Cols('institution_id, 'timestamp, 'event_category, 'event_type, 'user_id) ++ Cols(
-      'session_id,
-      'data1,
-      'data2,
-      'data3
-    )
-  )
-
-  allTables += auditLogTable
-  allIndexes ++= indexEach(auditLogIndexColumns, "audit_" + _.name)
-
   val auditLogNewColumns = auditLog.subset(Cols('meta))
 
   val itemViewId    = Cols('inst, 'item_uuid, 'item_version)

--- a/Source/Plugins/Core/com.equella.serverbase/scalasrc/com/tle/core/db/migration/Migrations.scala
+++ b/Source/Plugins/Core/com.equella.serverbase/scalasrc/com/tle/core/db/migration/Migrations.scala
@@ -29,5 +29,5 @@ import scala.collection.JavaConverters._
 object Migrations {
 
   def migrationList: util.Collection[MigrationExt] =
-    Iterable[MigrationExt](NewAuditLogColumn, NewViewCountTables, NewEntityTable).asJavaCollection
+    Iterable[MigrationExt](NewViewCountTables, NewEntityTable).asJavaCollection
 }

--- a/Source/Plugins/Core/com.equella.serverbase/scalasrc/com/tle/core/db/migration/NewViewCountTables.scala
+++ b/Source/Plugins/Core/com.equella.serverbase/scalasrc/com/tle/core/db/migration/NewViewCountTables.scala
@@ -22,17 +22,6 @@ import com.tle.core.i18n.ServerStrings
 import com.tle.core.migration.MigrationResult
 import io.doolse.simpledba.jdbc.JDBCIO
 
-object NewAuditLogColumn
-    extends SimpleMigration("NewAuditLogColumn",
-                            2018,
-                            6,
-                            1,
-                            ServerStrings.lookup.prefix("mig.auditcol")) {
-  def migration(progress: MigrationResult, schemaMigration: DBSchemaMigration): JDBCIO[Unit] = {
-    schemaMigration.addColumns(schemaMigration.auditLogNewColumns, progress)
-  }
-}
-
 object NewViewCountTables
     extends SimpleMigration("NewViewCountTables",
                             2018,

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.hibernate.type;
+
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.CustomType;
+
+public class HibernateCustomTypes {
+  private static final CustomType TYPE_BLANKABLE =
+      new CustomType(new HibernateEscapedString(Types.VARCHAR), new String[] {"blankable"});
+
+  private static final CustomType TYPE_XSTREAM =
+      new CustomType(
+          new ImmutableHibernateXStreamType(Types.CLOB), new String[] {"xstream_immutable"});
+
+  private static final CustomType TYPE_CSV =
+      new CustomType(new HibernateCsvType(Types.VARCHAR), new String[] {"csv"});
+
+  private static final BasicType TYPE_JSONB = new JsonBinaryType(String.class);
+
+  public static ArrayList<BasicType> getCustomTypes() {
+    return new ArrayList<>(Arrays.asList(TYPE_JSONB, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM));
+  }
+}

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
@@ -20,8 +20,8 @@ package com.tle.core.hibernate.type;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CustomType;
 
@@ -38,7 +38,7 @@ public class HibernateCustomTypes {
 
   private static final BasicType TYPE_JSONB = new JsonBinaryType(String.class);
 
-  public static ArrayList<BasicType> getCustomTypes() {
-    return new ArrayList<>(Arrays.asList(TYPE_JSONB, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM));
+  public static List<BasicType> getCustomTypes() {
+    return Arrays.asList(TYPE_JSONB, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM);
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedOracle10gDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedOracle10gDialect.java
@@ -20,9 +20,7 @@ package com.tle.hibernate.dialect;
 
 import com.google.common.collect.ImmutableList;
 import com.tle.core.hibernate.ExtendedDialect;
-import com.tle.core.hibernate.type.HibernateCsvType;
-import com.tle.core.hibernate.type.HibernateEscapedString;
-import com.tle.core.hibernate.type.ImmutableHibernateXStreamType;
+import com.tle.core.hibernate.type.HibernateCustomTypes;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -34,19 +32,10 @@ import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.mapping.Column;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.CustomType;
 import org.hibernate.type.StandardBasicTypes;
 
 @SuppressWarnings("nls")
 public class ExtendedOracle10gDialect extends Oracle10gDialect implements ExtendedDialect {
-  private static final CustomType TYPE_BLANKABLE =
-      new CustomType(new HibernateEscapedString(Types.VARCHAR), new String[] {"blankable"});
-  private static final CustomType TYPE_XSTREAM =
-      new CustomType(
-          new ImmutableHibernateXStreamType(Types.CLOB), new String[] {"xstream_immutable"});
-  private static final CustomType TYPE_CSV =
-      new CustomType(new HibernateCsvType(Types.VARCHAR), new String[] {"csv"});
-
   private static final String URL_SCHEME = "jdbc:oracle:thin:"; // $NON-NLS-1$
 
   private final UniqueDelegate uniqueDelegate;
@@ -158,7 +147,7 @@ public class ExtendedOracle10gDialect extends Oracle10gDialect implements Extend
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    return ImmutableList.of(TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM);
+    return ImmutableList.copyOf(HibernateCustomTypes.getCustomTypes());
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -159,7 +159,7 @@ public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements Exten
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    ArrayList<BasicType> customTypes = HibernateCustomTypes.getCustomTypes();
+    List<BasicType> customTypes = new ArrayList<>(HibernateCustomTypes.getCustomTypes());
     customTypes.add(new TextClobType());
     return ImmutableList.copyOf(customTypes);
   }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -20,10 +20,7 @@ package com.tle.hibernate.dialect;
 
 import com.google.common.collect.ImmutableList;
 import com.tle.core.hibernate.ExtendedDialect;
-import com.tle.core.hibernate.type.HibernateCsvType;
-import com.tle.core.hibernate.type.HibernateEscapedString;
-import com.tle.core.hibernate.type.ImmutableHibernateXStreamType;
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import com.tle.core.hibernate.type.HibernateCustomTypes;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -37,19 +34,11 @@ import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.mapping.Column;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.CustomType;
 import org.hibernate.type.TextType;
 
 @SuppressWarnings("nls")
 public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements ExtendedDialect {
   private static final String URL_SCHEME = "jdbc:postgresql://";
-  private static final CustomType TYPE_BLANKABLE =
-      new CustomType(new HibernateEscapedString(Types.VARCHAR), new String[] {"blankable"});
-  private static final CustomType TYPE_XSTREAM =
-      new CustomType(
-          new ImmutableHibernateXStreamType(Types.CLOB), new String[] {"xstream_immutable"});
-  private static final CustomType TYPE_CSV =
-      new CustomType(new HibernateCsvType(Types.VARCHAR), new String[] {"csv"});
   private final UniqueDelegate uniqueDelegate;
 
   public ExtendedPostgresDialect() {
@@ -170,8 +159,9 @@ public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements Exten
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    return ImmutableList.of(
-        new TextClobType(), JsonBinaryType.INSTANCE, TYPE_XSTREAM, TYPE_CSV, TYPE_BLANKABLE);
+    ArrayList<BasicType> customTypes = HibernateCustomTypes.getCustomTypes();
+    customTypes.add(new TextClobType());
+    return ImmutableList.copyOf(customTypes);
   }
 
   public static class TextClobType extends TextType {

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -23,6 +23,7 @@ import com.tle.core.hibernate.ExtendedDialect;
 import com.tle.core.hibernate.type.HibernateCsvType;
 import com.tle.core.hibernate.type.HibernateEscapedString;
 import com.tle.core.hibernate.type.ImmutableHibernateXStreamType;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -169,7 +170,8 @@ public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements Exten
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    return ImmutableList.of(new TextClobType(), TYPE_XSTREAM, TYPE_CSV, TYPE_BLANKABLE);
+    return ImmutableList.of(
+        new TextClobType(), JsonBinaryType.INSTANCE, TYPE_XSTREAM, TYPE_CSV, TYPE_BLANKABLE);
   }
 
   public static class TextClobType extends TextType {

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -31,7 +31,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.mapping.Column;
@@ -40,7 +40,7 @@ import org.hibernate.type.CustomType;
 import org.hibernate.type.TextType;
 
 @SuppressWarnings("nls")
-public class ExtendedPostgresDialect extends PostgreSQLDialect implements ExtendedDialect {
+public class ExtendedPostgresDialect extends PostgreSQL82Dialect implements ExtendedDialect {
   private static final String URL_SCHEME = "jdbc:postgresql://";
   private static final CustomType TYPE_BLANKABLE =
       new CustomType(new HibernateEscapedString(Types.VARCHAR), new String[] {"blankable"});

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -31,7 +31,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.hibernate.dialect.PostgreSQL82Dialect;
+import org.hibernate.dialect.PostgreSQL9Dialect;
 import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.mapping.Column;
@@ -40,7 +40,7 @@ import org.hibernate.type.CustomType;
 import org.hibernate.type.TextType;
 
 @SuppressWarnings("nls")
-public class ExtendedPostgresDialect extends PostgreSQL82Dialect implements ExtendedDialect {
+public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements ExtendedDialect {
   private static final String URL_SCHEME = "jdbc:postgresql://";
   private static final CustomType TYPE_BLANKABLE =
       new CustomType(new HibernateEscapedString(Types.VARCHAR), new String[] {"blankable"});

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/SQLServerDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/SQLServerDialect.java
@@ -21,12 +21,11 @@ package com.tle.hibernate.dialect;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.tle.core.hibernate.ExtendedDialect;
-import com.tle.core.hibernate.type.HibernateCsvType;
-import com.tle.core.hibernate.type.HibernateEscapedString;
-import com.tle.core.hibernate.type.ImmutableHibernateXStreamType;
+import com.tle.core.hibernate.type.HibernateCustomTypes;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -41,7 +40,6 @@ import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.CustomType;
 import org.hibernate.type.StandardBasicTypes;
 
 // TECH_DEBT - StringHelper is now internal - https://github.com/openequella/openEQUELLA/issues/2507
@@ -53,17 +51,8 @@ public class SQLServerDialect extends org.hibernate.dialect.SQLServer2005Dialect
   // queries with '?' in them need to be ordinal ( ie `?4` ).  However, this class
   // does not leverage the JPA / Hibernate logic, so we can leave the `?`s as-is.
 
-  private static final CustomType TYPE_BLANKABLE =
-      new CustomType(new HibernateEscapedString(Types.NVARCHAR), new String[] {"blankable"});
-  private static final CustomType TYPE_XSTREAM =
-      new CustomType(
-          new ImmutableHibernateXStreamType(Types.LONGNVARCHAR),
-          new String[] {"xstream_immutable"});
-  private static final CustomType TYPE_CSV =
-      new CustomType(new HibernateCsvType(Types.NVARCHAR), new String[] {"csv"});
-
   private static final String URL_SCHEME = "jdbc:sqlserver://";
-  private String dropConstraintsSQL;
+  private final String dropConstraintsSQL;
 
   private final UniqueDelegate uniqueDelegate;
 
@@ -85,7 +74,8 @@ public class SQLServerDialect extends org.hibernate.dialect.SQLServer2005Dialect
     try (InputStream inp = getClass().getResourceAsStream("dropconstraints.sql")) {
       // Sonar whinges about the new InputStreamReader not being closed in
       // a finally block, but the existing finally block does that ...?
-      BufferedReader bufReader = new BufferedReader(new InputStreamReader(inp, "UTF-8")); // NOSONAR
+      BufferedReader bufReader =
+          new BufferedReader(new InputStreamReader(inp, StandardCharsets.UTF_8)); // NOSONAR
       String line = null;
       while ((line = bufReader.readLine()) != null) {
         sbuf.append(line);
@@ -218,8 +208,10 @@ public class SQLServerDialect extends org.hibernate.dialect.SQLServer2005Dialect
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    return ImmutableList.of(
-        new NStringType(), new LongNStringType(), TYPE_BLANKABLE, TYPE_XSTREAM, TYPE_CSV);
+    ArrayList<BasicType> customTypes = HibernateCustomTypes.getCustomTypes();
+    customTypes.add(new NStringType());
+    customTypes.add(new LongNStringType());
+    return ImmutableList.copyOf(customTypes);
   }
 
   /**

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/SQLServerDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/SQLServerDialect.java
@@ -208,7 +208,7 @@ public class SQLServerDialect extends org.hibernate.dialect.SQLServer2005Dialect
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    ArrayList<BasicType> customTypes = HibernateCustomTypes.getCustomTypes();
+    List<BasicType> customTypes = new ArrayList<>(HibernateCustomTypes.getCustomTypes());
     customTypes.add(new NStringType());
     customTypes.add(new LongNStringType());
     return ImmutableList.copyOf(customTypes);

--- a/Source/Plugins/Generic/org.hibernate/build.sbt
+++ b/Source/Plugins/Generic/org.hibernate/build.sbt
@@ -3,6 +3,7 @@ lazy val CustomCompile = config("compile") extend Hibernate
 val springVersion      = "5.2.9.RELEASE"
 
 libraryDependencies := Seq(
+  "com.vladmihalcea"         % "hibernate-types-52"    % "2.10.4",
   "org.hibernate"            % "hibernate-core"        % "5.4.21.Final",
   "org.hibernate"            % "hibernate-validator"   % "6.1.5.Final",
   "javax.persistence"        % "javax.persistence-api" % "2.2",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR brings the Java entity class `AuditLogEntry` back and rewrites migration `NewAuditLogColumn` in oEQ traditional approach. By doing this, some usage of simpleDBA has been removed. To support Postgres `jsonb` type, I added a hibernate type library and addressed dependency duplication issue caused by this library.

