### PR TITLE
chore: Address SBT deprecation warnings due to upgrade to 1.5

### DIFF
--- a/Dev/learningedge-config/build.sbt
+++ b/Dev/learningedge-config/build.sbt
@@ -7,7 +7,7 @@ prepareDevConfig := {
   val baseDir         = baseDirectory.value
   val srcRoot         = baseDir.getParentFile.getParentFile
   val pluginRoots     = Seq(srcRoot / "Source/Plugins", srcRoot / "Platform", srcRoot / "Interface")
-  val installerConfig = (baseDirectory in LocalProject("Installer")).value / "data/server/learningedge-config"
+  val installerConfig = (LocalProject("Installer") / baseDirectory).value / "data/server/learningedge-config"
   val defaultsDir     = baseDirectory.value / "defaults"
   val fromInstaller = Seq(
     installerConfig / "hikari.properties"

--- a/Installer/build.sbt
+++ b/Installer/build.sbt
@@ -43,6 +43,8 @@ installerZip := {
     upZip          -> s"manager/updates/${upZip.getName}"
   ) ++ allServerFiles
   log.info(s"Creating installer ${outZip.absolutePath}")
-  IO.zip(allFiles.map(t => (t._1, s"$dirname/${t._2}")), outZip)
+  IO.zip(allFiles.map(t => (t._1, s"$dirname/${t._2}")),
+         outZip,
+         Option((ThisBuild / buildTimestamp).value))
   outZip
 }

--- a/Installer/build.sbt
+++ b/Installer/build.sbt
@@ -23,9 +23,9 @@ excludeDependencies ++= Seq(
   "stax"            % "stax-api"
 )
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
 
-mainClass in assembly := Some("com.dytech.edge.installer.application.Launch")
+(assembly / mainClass) := Some("com.dytech.edge.installer.application.Launch")
 
 lazy val equellaserver  = LocalProject("equellaserver")
 lazy val upgradeManager = LocalProject("UpgradeManager")
@@ -37,7 +37,7 @@ installerZip := {
   val outZip         = target.value / s"$dirname.zip"
   val serverData     = baseDirectory.value / "data/server"
   val allServerFiles = serverData ** "*" pair (relativeTo(serverData), false)
-  val upZip          = (upgradeZip in equellaserver).value
+  val upZip          = (equellaserver / upgradeZip).value
   val allFiles = Seq(
     assembly.value -> "enterprise-install.jar",
     upZip          -> s"manager/updates/${upZip.getName}"

--- a/Source/Plugins/Admin/com.tle.web.adminconsole/build.sbt
+++ b/Source/Plugins/Admin/com.tle.web.adminconsole/build.sbt
@@ -1,13 +1,13 @@
 lazy val adminConsoleJar = project in file("jarsrc")
 
-resourceGenerators in Compile += Def.task {
-  val outJar  = (resourceManaged in Compile).value / "web/adminconsole.jar"
-  val jarFile = (assembly in adminConsoleJar).value
+(Compile / resourceGenerators) += Def.task {
+  val outJar  = (Compile / resourceManaged).value / "web/adminconsole.jar"
+  val jarFile = (adminConsoleJar / assembly).value
   (jarSigner.value).apply(jarFile, outJar)
   Seq(outJar)
 }.taskValue
 
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyMergeStrategy) := {
   // Post SpringHib5 upgrade, the following error was thrown on build:
   // deduplicate: different file contents found in the following:
   // [error] .../com.fasterxml/classmate/bundles/classmate-1.5.1.jar:module-info.class
@@ -20,6 +20,6 @@ assemblyMergeStrategy in assembly := {
   // As per https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class , discarding is OK for Java 8
   case "module-info.class" => MergeStrategy.discard
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }

--- a/Source/Plugins/Admin/com.tle.web.adminconsole/jarsrc/build.sbt
+++ b/Source/Plugins/Admin/com.tle.web.adminconsole/jarsrc/build.sbt
@@ -24,9 +24,9 @@ excludeDependencies ++= Seq(
   "org.springframework" % "spring-jcl"
 )
 
-packageOptions in assembly += Package.ManifestAttributes("Permissions" -> "all-permissions")
-assemblyOption in assembly := (assemblyOption in assembly).value
-assemblyMergeStrategy in assembly := {
+(assembly / packageOptions) += Package.ManifestAttributes("Permissions" -> "all-permissions")
+(assembly / assemblyOption) := (assembly / assemblyOption).value
+(assembly / assemblyMergeStrategy) := {
   case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
   // The following three were added when the hibernate-types was added the the hibernate module
   case PathList("javax", "activation", _*)       => MergeStrategy.first
@@ -48,7 +48,7 @@ assemblyMergeStrategy in assembly := {
   // As per https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class , discarding is OK for Java 8
   case "module-info.class" => MergeStrategy.discard
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 dependsOn(platformCommon, platformSwing, platformEquella, LocalProject("com_tle_webstart_admin"))

--- a/Source/Plugins/Applet/com.tle.common.applet/build.sbt
+++ b/Source/Plugins/Applet/com.tle.common.applet/build.sbt
@@ -1,1 +1,1 @@
-unmanagedJars in Compile += file(sys.props("java.home")) / "lib/javaws.jar"
+(Compile / unmanagedJars) += file(sys.props("java.home")) / "lib/javaws.jar"

--- a/Source/Plugins/Applet/com.tle.web.filemanager.applet/appletsrc/build.sbt
+++ b/Source/Plugins/Applet/com.tle.web.filemanager.applet/appletsrc/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
 
 dependsOn(platformSwing, LocalProject("com_tle_common_applet"))
 
-packageOptions in assembly += Package.ManifestAttributes(
+(assembly / packageOptions) += Package.ManifestAttributes(
   "Application-Name"                       -> "EQUELLA File Manager",
   "Permissions"                            -> "all-permissions",
   "Codebase"                               -> "*",
@@ -18,9 +18,9 @@ packageOptions in assembly += Package.ManifestAttributes(
   "Caller-Allowable-Codebase"              -> "*"
 )
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
 
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyMergeStrategy) := {
   case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
   // The following three were added when the hibernate-types was added the the hibernate module
   case PathList("javax", "activation", _*)       => MergeStrategy.first
@@ -42,6 +42,6 @@ assemblyMergeStrategy in assembly := {
   // As per https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class , discarding is OK for Java 8
   case "module-info.class" => MergeStrategy.discard
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }

--- a/Source/Plugins/Applet/com.tle.web.filemanager.applet/build.sbt
+++ b/Source/Plugins/Applet/com.tle.web.filemanager.applet/build.sbt
@@ -1,8 +1,8 @@
 lazy val filemanagerApplet = (project in file("appletsrc"))
 
-resourceGenerators in Compile += Def.task {
-  val outJar  = (resourceManaged in Compile).value / "web/filemanager.jar"
-  val jarFile = (assembly in LocalProject("filemanagerApplet")).value
+(Compile / resourceGenerators) += Def.task {
+  val outJar  = (Compile / resourceManaged).value / "web/filemanager.jar"
+  val jarFile = (LocalProject("filemanagerApplet") / assembly).value
   (jarSigner.value).apply(jarFile, outJar)
   Seq(outJar)
 }.taskValue

--- a/Source/Plugins/Birt/org.eclipse.birt.osgi/build.sbt
+++ b/Source/Plugins/Birt/org.eclipse.birt.osgi/build.sbt
@@ -36,6 +36,8 @@ ivyConfigurations := overrideConfigs(BirtOsgi, CustomCompile)(ivyConfigurations.
   val copied         = IO.copy(pluginJars.pair(flat(outPlugins), errorIfNone = false))
   val birtManifest   = baseDirectory.value / "birt-MANIFEST.MF"
   val manifestPlugin = outPlugins / "org.eclipse.birt.api.jar"
-  IO.zip(Seq(birtManifest -> "META-INF/MANIFEST.MF"), manifestPlugin)
+  IO.zip(Seq(birtManifest -> "META-INF/MANIFEST.MF"),
+         manifestPlugin,
+         Option((ThisBuild / buildTimestamp).value))
   unzipped.toSeq ++ copied :+ manifestPlugin
 }.taskValue

--- a/Source/Plugins/Birt/org.eclipse.birt.osgi/build.sbt
+++ b/Source/Plugins/Birt/org.eclipse.birt.osgi/build.sbt
@@ -24,8 +24,8 @@ resolvers += Resolver.url("my-test-repo",
 
 ivyConfigurations := overrideConfigs(BirtOsgi, CustomCompile)(ivyConfigurations.value)
 
-resourceGenerators in Compile += Def.task {
-  val baseDir  = (resourceManaged in Compile).value
+(Compile / resourceGenerators) += Def.task {
+  val baseDir  = (Compile / resourceManaged).value
   val baseBirt = baseDir / "birt"
   IO.delete(baseBirt)
   val outPlugins = baseBirt / "plugins"

--- a/Source/Plugins/Core/com.equella.core/jarsrc/build.sbt
+++ b/Source/Plugins/Core/com.equella.core/jarsrc/build.sbt
@@ -8,16 +8,16 @@ libraryDependencies ++= Seq(
   "org.springframework" % "spring-aop"   % springVersion
 )
 
-packageOptions in assembly += Package.ManifestAttributes(
+(assembly / packageOptions) += Package.ManifestAttributes(
   "Application-Name"                       -> "EQUELLA In-place File Editor",
   "Permissions"                            -> "all-permissions",
   "Codebase"                               -> "*",
   "Application-Library-Allowable-Codebase" -> "*",
   "Caller-Allowable-Codebase"              -> "*"
 )
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
 
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyMergeStrategy) := {
   case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
   // The following three were added when the hibernate-types was added the the hibernate module
   case PathList("javax", "activation", _*)       => MergeStrategy.first
@@ -39,7 +39,7 @@ assemblyMergeStrategy in assembly := {
   // As per https://stackoverflow.com/questions/54834125/sbt-assembly-deduplicate-module-info-class , discarding is OK for Java 8
   case "module-info.class" => MergeStrategy.discard
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 

--- a/Source/Plugins/Platform/com.tle.platform.equella/build.sbt
+++ b/Source/Plugins/Platform/com.tle.platform.equella/build.sbt
@@ -1,4 +1,4 @@
-resourceGenerators in Compile += Def.task {
-  val base = (resourceManaged in Compile).value
+(Compile / resourceGenerators) += Def.task {
+  val base = (Compile / resourceManaged).value
   IO.copy(Some(versionProperties.value -> base / "version.properties")).toSeq
 }.taskValue

--- a/Source/Server/adminTool/build.sbt
+++ b/Source/Server/adminTool/build.sbt
@@ -14,8 +14,8 @@ libraryDependencies ++= Seq(
   "org.springframework"    % "spring-context"  % springVersion
 )
 
-unmanagedJars in Compile += file(sys.props("java.home")) / "lib/javaws.jar"
+(Compile / unmanagedJars) += file(sys.props("java.home")) / "lib/javaws.jar"
 
-fork in run := true
+(run / fork) := true
 
-mainClass in (Compile, run) := Some("com.tle.client.harness.ClientLauncher")
+(Compile / run / mainClass) := Some("com.tle.client.harness.ClientLauncher")

--- a/Source/Server/conversion/build.sbt
+++ b/Source/Server/conversion/build.sbt
@@ -8,8 +8,8 @@ libraryDependencies ++= Seq(
 )
 
 excludeDependencies += "commons-logging" % "commons-logging"
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
+(assembly / assemblyMergeStrategy) := {
   case PathList("META-INF", "cxf", "bus-extensions.txt") => MergeStrategy.first
 
   // Due to the error: deduplicate: different file contents found in the following:
@@ -38,8 +38,8 @@ assemblyMergeStrategy in assembly := {
   // OK to do in Java 8
   case "module-info.class" => MergeStrategy.discard
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 
-mainClass in assembly := Some("com.tle.conversion.Main")
+(assembly / mainClass) := Some("com.tle.conversion.Main")

--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -458,7 +458,7 @@ additionalPlugins := {
 upgradeZip := {
   val log         = streams.value.log
   val ver         = equellaVersion.value
-  var releaseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+  val releaseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
   val outZip
     : File    = target.value / s"tle-upgrade-${ver.major}.${ver.minor}.r${releaseDate} (${ver.semanticVersion}-${ver.releaseType}).zip"
   val plugVer = ver.fullVersion
@@ -471,7 +471,7 @@ upgradeZip := {
   val pluginJars =
     writeJars.value.map(t => (t.file, s"plugins/${t.group}/${t.pluginId}-$plugVer.jar"))
   log.info(s"Creating upgrade zip ${outZip.absolutePath}")
-  IO.zip(zipFiles ++ pluginJars, outZip)
+  IO.zip(zipFiles ++ pluginJars, outZip, Option((ThisBuild / buildTimestamp).value))
   outZip
 }
 
@@ -484,6 +484,6 @@ writeSourceZip := {
   val outZip  = target.value / "equella-sources.zip"
   val allSrcs = sourcesForZip.all(ScopeFilter(inAggregates(allPlugins))).value.flatten
   sLog.value.info(s"Zipping all sources into $outZip")
-  IO.zip(allSrcs, outZip)
+  IO.zip(allSrcs, outZip, Option((ThisBuild / buildTimestamp).value))
   outZip
 }

--- a/Source/Tools/UpgradeInstallation/build.sbt
+++ b/Source/Tools/UpgradeInstallation/build.sbt
@@ -13,23 +13,23 @@ excludeDependencies ++= Seq(
   "commons-logging" % "commons-logging"
 )
 
-mainClass in assembly := Some("com.tle.upgrade.UpgradeMain")
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+(assembly / mainClass) := Some("com.tle.upgrade.UpgradeMain")
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
 
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyMergeStrategy) := {
   case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 
 val upgradeManager = LocalProject("UpgradeManager")
 
-resourceGenerators in Compile += Def.task {
-  val base = (resourceManaged in Compile).value
+(Compile / resourceGenerators) += Def.task {
+  val base = (Compile / resourceManaged).value
   val files = Seq(
-    (assembly in upgradeManager).value -> base / "manager/manager.jar",
-    versionProperties.value            -> base / "version.properties"
+    (upgradeManager / assembly).value -> base / "manager/manager.jar",
+    versionProperties.value           -> base / "version.properties"
   )
   IO.copy(files)
   files.map(_._2)

--- a/Source/Tools/UpgradeManager/build.sbt
+++ b/Source/Tools/UpgradeManager/build.sbt
@@ -15,6 +15,6 @@ libraryDependencies ++= Seq(
   "commons-codec"        % "commons-codec"      % "1.15"
 )
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
 
 packageOptions += ManifestAttributes(Attributes.Name.CLASS_PATH -> ".")

--- a/autotest/IntegTester/build.sbt
+++ b/autotest/IntegTester/build.sbt
@@ -33,12 +33,12 @@ libraryDependencies ++= Seq(
   "com.nulab-inc" %% "scala-oauth2-core"   % "1.5.0"
 )
 
-resourceGenerators in Compile += Def.task {
+(Compile / resourceGenerators) += Def.task {
   val baseJs = baseDirectory.value / "ps"
   val cached = FileFunction.cached(target.value / "pscache") { files =>
     Common.nodeInstall(baseJs)
     Common.nodeScript("build", baseJs)
-    val outDir       = (resourceManaged in Compile).value / "www"
+    val outDir       = (Compile / resourceManaged).value / "www"
     val baseJsTarget = baseJs / "target/www"
     IO.copy((baseJsTarget ** "*").pair(rebase(baseJsTarget, outDir)))
   }

--- a/autotest/Tests/build.sbt
+++ b/autotest/Tests/build.sbt
@@ -49,7 +49,7 @@ libraryDependencies ++= Seq(
   "com.unboundid"    % "unboundid-ldapsdk"         % "5.1.1"
 )
 
-unmanagedBase in Compile := baseDirectory.value / "lib/adminjars"
+(Compile / unmanagedBase) := baseDirectory.value / "lib/adminjars"
 
 def serialFilter(name: String): Boolean = {
   name endsWith "PropertiesSerial"
@@ -61,14 +61,14 @@ def stdFilter(name: String): Boolean = {
 val commonOptions = Seq(
   sbt.Tests.Argument(TestFrameworks.ScalaCheck, "-s", "1")
 )
-testOptions in Serial := commonOptions
+(Serial / testOptions) := commonOptions
 
-testOptions in Test := commonOptions
+(Test / testOptions) := commonOptions
 
-testOptions in Test += sbt.Tests.Filter(stdFilter)
+(Test / testOptions) += sbt.Tests.Filter(stdFilter)
 
-testOptions in Serial += sbt.Tests.Filter(serialFilter)
+(Serial / testOptions) += sbt.Tests.Filter(serialFilter)
 
-parallelExecution in Serial := false
+(Serial / parallelExecution) := false
 
-parallelExecution in Test := autotestBuildConfig.value.getBoolean("tests.parallel")
+(Test / parallelExecution) := autotestBuildConfig.value.getBoolean("tests.parallel")

--- a/autotest/build.sbt
+++ b/autotest/build.sbt
@@ -249,7 +249,8 @@ collectArtifacts := {
 
   sLog.value.info(s"Collecting test artifacts into ${results.absolutePath}")
   IO.zip(allFiles(Seq(logsDir, scReportDir, oldReportDir, (coverageReport / target).value)),
-         results)
+         results,
+         Option((ThisBuild / buildTimestamp).value))
   results
 }
 

--- a/autotest/build.sbt
+++ b/autotest/build.sbt
@@ -14,7 +14,7 @@ name := "equella-autotests"
 libraryDependencies += "org.jacoco" % "org.jacoco.agent" % "0.8.6" classifier "runtime"
 
 lazy val config = (project in file("config"))
-  .settings(resourceDirectory in Compile := baseDirectory.value / "resources")
+  .settings((Compile / resourceDirectory) := baseDirectory.value / "resources")
 
 lazy val IntegTester = project in file("IntegTester")
 
@@ -22,7 +22,7 @@ lazy val Tests = project in file("Tests")
 
 lazy val OldTests = (project in file("OldTests")).dependsOn(Tests, config)
 
-autotestBuildConfig in ThisBuild := {
+(ThisBuild / autotestBuildConfig) := {
   val defaultConfig = ConfigFactory.parseFile(file("autotest/autotest-defaults.conf"))
   val configFile = file(
     sys.props.getOrElse(
@@ -73,7 +73,7 @@ autotestInstallerZip := {
   val bc                    = autotestBuildConfig.value
   val equellaFullVersion    = equellaVersion.value
   val installerFileName     = s"equella-installer-${equellaFullVersion.semanticVersion}.zip"
-  val installerDirectory    = (target in LocalProject("Installer")).value
+  val installerDirectory    = (LocalProject("Installer") / target).value
   val installerAbsolutePath = installerDirectory / installerFileName
   // If the Installer named as installerFileName exists then return it, otherwise returns the default Installer
   if (installerAbsolutePath.exists) {
@@ -145,8 +145,8 @@ val saxBuilder = {
   sb
 }
 
-sourceDirectory in coverageReport := target.value / "all_srcs"
-target in coverageReport := {
+(coverageReport / sourceDirectory) := target.value / "all_srcs"
+(coverageReport / target) := {
   val cc = autotestBuildConfig.value.getConfig("coverage")
   optPath(cc, "reportdir").getOrElse(target.value / "coverage-report")
 }
@@ -174,9 +174,9 @@ coverageReport := {
   }
 
   val srcZip  = sourceZip.value
-  val allSrcs = (sourceDirectory in coverageReport).value
+  val allSrcs = (coverageReport / sourceDirectory).value
   srcZip.foreach(z => IO.unzip(z, allSrcs))
-  val coverageDir = (target in coverageReport).value
+  val coverageDir = (coverageReport / target).value
   log.info(s"Creating coverage report at ${coverageDir.absolutePath}")
   CoverageReporter.createReport(execLoader,
                                 allPlugins.groupBy(_._1).mapValues(_.map(_._2)).toSeq,
@@ -216,27 +216,27 @@ stopEquella := serviceCommand(installOptions.value, "stop")
 val TestPrj = LocalProject("Tests")
 
 setupForTests := {
-  val run = (runner in (TestPrj, Test)).value
+  val run = (TestPrj / Test / runner).value
   val log = sLog.value
   run
     .run("equellatests.SetupForTests",
-         (fullClasspath in (TestPrj, Test)).value.files,
+         (TestPrj / Test / fullClasspath).value.files,
          spaceDelimited("<arg>").parsed,
          log)
     .get
 }
 
 configureInstall := {
-  val run = (runner in (TestPrj, Test)).value
+  val run = (TestPrj / Test / runner).value
   run
     .run("equellatests.InstallFirstTime",
-         (fullClasspath in (TestPrj, Test)).value.files,
+         (TestPrj / Test / fullClasspath).value.files,
          Seq(),
          sLog.value)
     .get
 }
 
-aggregate in test := false
+(test / aggregate) := false
 
 collectArtifacts := {
   val results = target.value / "test-artifacts.zip"
@@ -244,16 +244,16 @@ collectArtifacts := {
     files.flatMap(f => (f ** "*").pair(rebase(f, f.getName)))
   }
   val logsDir      = installDir.value / "logs"
-  val scReportDir  = (target in LocalProject("Tests")).value / "test-reports"
-  val oldReportDir = file((testNGOutputDirectory in OldTests).value)
+  val scReportDir  = (LocalProject("Tests") / target).value / "test-reports"
+  val oldReportDir = file((OldTests / testNGOutputDirectory).value)
 
   sLog.value.info(s"Collecting test artifacts into ${results.absolutePath}")
-  IO.zip(allFiles(Seq(logsDir, scReportDir, oldReportDir, (target in coverageReport).value)),
+  IO.zip(allFiles(Seq(logsDir, scReportDir, oldReportDir, (coverageReport / target).value)),
          results)
   results
 }
 
-concurrentRestrictions in Global := {
+(Global / concurrentRestrictions) := {
   val testConfig = autotestBuildConfig.value.getConfig("tests")
   if (testConfig.hasPath("maxthreads")) {
     Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -12,11 +12,11 @@ lazy val learningedge_config = project in file("Dev/learningedge-config")
 lazy val allPlugins      = LocalProject("allPlugins")
 lazy val allPluginsScope = ScopeFilter(inAggregates(allPlugins, includeRoot = false))
 val legacyPaths = Seq(
-  javaSource in Compile := baseDirectory.value / "src",
-  javaSource in Test := baseDirectory.value / "test",
-  unmanagedResourceDirectories in Compile := (baseDirectory.value / "resources") :: Nil,
-  unmanagedSourceDirectories in Compile := (javaSource in Compile).value :: Nil,
-  unmanagedSourceDirectories in Test := (javaSource in Test).value :: Nil
+  (Compile / javaSource) := baseDirectory.value / "src",
+  (Test / javaSource) := baseDirectory.value / "test",
+  (Compile / unmanagedResourceDirectories) := (baseDirectory.value / "resources") :: Nil,
+  (Compile / unmanagedSourceDirectories) := (Compile / javaSource).value :: Nil,
+  (Test / unmanagedSourceDirectories) := (Test / javaSource).value :: Nil
 )
 
 lazy val autotest = project in file("autotest")
@@ -67,8 +67,8 @@ lazy val equella = (project in file("."))
 
 checkJavaCodeStyle := {
   import com.etsy.sbt.checkstyle._
-  val rootDirectory       = (baseDirectory in LocalProject("equella")).value
-  val rootTargetDirectory = (target in LocalProject("equella")).value
+  val rootDirectory       = (LocalProject("equella") / baseDirectory).value
+  val rootTargetDirectory = (LocalProject("equella") / target).value
   def countErrorNumber: Int = {
     val outputFile = new File("target/checkstyle-report.xml")
     if (outputFile.exists()) {
@@ -100,7 +100,7 @@ checkJavaCodeStyle := {
   }
 }
 
-bundleOracleDriver in ThisBuild := {
+(ThisBuild / bundleOracleDriver) := {
   val path = "build.bundleOracleDriver"
   if (buildConfig.value.hasPath(path)) {
     buildConfig.value.getBoolean(path)
@@ -108,17 +108,17 @@ bundleOracleDriver in ThisBuild := {
     false
   }
 }
-oracleDriverMavenCoordinate in ThisBuild := Seq("com.oracle.ojdbc" % "ojdbc8" % "19.3.0.0")
+(ThisBuild / oracleDriverMavenCoordinate) := Seq("com.oracle.ojdbc" % "ojdbc8" % "19.3.0.0")
 
-buildConfig in ThisBuild := Common.buildConfig
+(ThisBuild / buildConfig) := Common.buildConfig
 
 name := "Equella"
 
-equellaMajor in ThisBuild := 2021
-equellaMinor in ThisBuild := 2
-equellaPatch in ThisBuild := 0
-equellaStream in ThisBuild := "Alpha"
-equellaBuild in ThisBuild := buildConfig.value.getString("build.buildname")
+(ThisBuild / equellaMajor) := 2021
+(ThisBuild / equellaMinor) := 2
+(ThisBuild / equellaPatch) := 0
+(ThisBuild / equellaStream) := "Alpha"
+(ThisBuild / equellaBuild) := buildConfig.value.getString("build.buildname")
 
 version := {
   val shortCommit = git.gitHeadCommit.value.map { sha =>
@@ -132,9 +132,9 @@ version := {
                  shortCommit).fullVersion
 }
 
-equellaVersion in ThisBuild := EquellaVersion(version.value)
+(ThisBuild / equellaVersion) := EquellaVersion(version.value)
 
-versionProperties in ThisBuild := {
+(ThisBuild / versionProperties) := {
   val eqVersion = equellaVersion.value
   val props     = new Properties
   props.putAll(
@@ -149,7 +149,7 @@ versionProperties in ThisBuild := {
 
 updateLicenses := {
   val ourOrg         = organization.value
-  val serverReport   = (updateLicenses in equellaserver).value
+  val serverReport   = (equellaserver / updateLicenses).value
   val plugsinReports = updateLicenses.all(allPluginsScope).value
   val allLicenses = (plugsinReports.flatMap(_.licenses) ++ serverReport.licenses)
     .groupBy(_.module)
@@ -184,9 +184,9 @@ writeLanguagePack := {
   }
 }
 
-aggregate in dumpLicenseReport := false
+(dumpLicenseReport / aggregate) := false
 
-cancelable in Global := true
+(Global / cancelable) := true
 
 val pluginAndLibs = Def.task {
   val bd      = baseDirectory.value
@@ -220,7 +220,7 @@ mergeJPF := {
 }
 
 writeScriptingJavadoc := {
-  val javadocDir = (doc in Compile).value
+  val javadocDir = (Compile / doc).value
   val ver        = version.value
   val outZip     = target.value / s"scriptingapi-javadoc-$ver.zip"
   sLog.value.info(s"Writing ${outZip.absolutePath}")
@@ -256,12 +256,12 @@ def javadocSources(base: File): PathFinder = {
   || "*ScriptObject.java" || userBeans)
 }
 
-aggregate in (Compile, doc) := false
-sources in (Compile, doc) := {
-  (javadocSources((baseDirectory in LocalProject("com_equella_base")).value)
-    +++ javadocSources((baseDirectory in LocalProject("com_equella_core")).value)).get
+(Compile / doc / aggregate) := false
+(Compile / doc / sources) := {
+  (javadocSources((LocalProject("com_equella_base") / baseDirectory).value)
+    +++ javadocSources((LocalProject("com_equella_core") / baseDirectory).value)).get
 }
-javacOptions in (Compile, doc) := Seq()
+(Compile / doc / javacOptions) := Seq()
 
 lazy val allEquella = ScopeFilter(inAggregates(equella))
 
@@ -272,7 +272,7 @@ devrebuild := {
     .sequential(
       clean.all(allEquella),
       jpfWriteDevJars.all(allPluginsScope),
-      (fullClasspath in Compile).all(allEquella),
+      (Compile / fullClasspath).all(allEquella),
     )
     .value
 }
@@ -283,7 +283,7 @@ cleanrun := {
   Def
     .sequential(
       devrebuild,
-      (run in equellaserver).toTask("")
+      (equellaserver / run).toTask("")
     )
     .value
 }

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -21,6 +21,7 @@ object CommonSettings extends AutoPlugin {
     lazy val oracleDriverMavenCoordinate =
       settingKey[Seq[ModuleID]]("The Maven coordinate of Oracle JDBC")
     lazy val buildConfig           = settingKey[Config]("The build configuration settings")
+    lazy val buildTimestamp        = settingKey[Long]("Timestamp - in seconds - to use for this build")
     lazy val prepareDevConfig      = taskKey[Unit]("Prepare the dev learningedge-config folder")
     lazy val writeSourceZip        = taskKey[File]("Write out a zip containing all sources")
     lazy val langStrings           = taskKey[Seq[LangStrings]]("Fully qualified language strings")

--- a/project/JPFPlugin.scala
+++ b/project/JPFPlugin.scala
@@ -24,20 +24,20 @@ object JPFPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.12.13",
     javacOptions ++= Seq("-source", "1.8"),
-    jpfCodeDirs := Seq((classDirectory in Compile).value),
-    resourceDirectory in Compile := baseDirectory.value / "resources",
-    jpfResourceDirs := (resourceDirectories in Compile).value,
+    jpfCodeDirs := Seq((Compile / classDirectory).value),
+    (Compile / resourceDirectory) := baseDirectory.value / "resources",
+    jpfResourceDirs := (Compile / resourceDirectories).value,
     jpfRuntime := JPFRuntime(baseDirectory.value / "plugin-jpf.xml",
                              jpfCodeDirs.value,
                              jpfResourceDirs.value,
                              jpfLibraryJars.value.files,
                              baseDirectory.value.getParentFile.getName),
     jpfLibraryJars := Seq(),
-    managedClasspath in Compile ++= jpfLibraryJars.value,
-    javaSource in Compile := baseDirectory.value / "src",
-    javaSource in Test := baseDirectory.value / "test/java",
-    resourceDirectory in Test := baseDirectory.value / "test/resources",
-    scalaSource in Compile := baseDirectory.value / "scalasrc",
+    (Compile / managedClasspath) ++= jpfLibraryJars.value,
+    (Compile / javaSource) := baseDirectory.value / "src",
+    (Test / javaSource) := baseDirectory.value / "test/java",
+    (Test / resourceDirectory) := baseDirectory.value / "test/resources",
+    (Compile / scalaSource) := baseDirectory.value / "scalasrc",
     updateOptions := updateOptions.value.withCachedResolution(true),
     jpfWriteDevJars := {
       val outBase = target.value / "jpflibs"
@@ -64,7 +64,7 @@ object JPFPlugin extends AutoPlugin {
             .toMap
           val fp    = paramMap("file")
           val group = paramMap.getOrElse("group", "resource-centre")
-          Common.loadLangProperties((resourceDirectory in Compile).value / fp, pfx, group)
+          Common.loadLangProperties((Compile / resourceDirectory).value / fp, pfx, group)
       }
     }
   )

--- a/project/JPFRunnerPlugin.scala
+++ b/project/JPFRunnerPlugin.scala
@@ -1,17 +1,15 @@
-import java.nio.file.Files
-
-import sbt.Keys._
-import sbt.{Def, _}
-import JPFPlugin.autoImport._
-
-import scala.util.Try
 import Common._
+import CommonSettings.autoImport.buildTimestamp
+import JPFPlugin.autoImport._
 import org.jdom2.Element
 import org.jdom2.output.{Format, XMLOutputter}
-import Path.rebase
-import Path.flatRebase
+import sbt.Keys._
+import sbt._
+import Path.{flatRebase, rebase}
 
+import java.nio.file.Files
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 object JPFRunnerPlugin extends AutoPlugin {
 
@@ -35,9 +33,11 @@ object JPFRunnerPlugin extends AutoPlugin {
           IO.delete(outBase)
           allRuntimes.map {
             r =>
-              val allCode = r.code.flatMap(f => (f ** "*.class").pair(rebase(f, "classes/"), false))
+              val allCode = r.code.flatMap(f =>
+                (f ** "*.class").pair(rebase(f, "classes/"), errorIfNone = false))
               val allResources =
-                r.resources.flatMap(f => (f ** "*").pair(rebase(f, "resources/"), false))
+                r.resources.flatMap(f =>
+                  (f ** "*").pair(rebase(f, "resources/"), errorIfNone = false))
               val allJars = r.jars.flatMap(f => flatRebase("lib/").apply(f).map((f, _)))
               val libs = allCode.headOption.map(_ =>
                 JPFLibrary("code", "code", "classes/", Some("*"))) ++
@@ -49,7 +49,7 @@ object JPFRunnerPlugin extends AutoPlugin {
               IO.withTemporaryFile("jpf", "xml") { tf =>
                 IO.write(tf, manifest)
                 val allFiles = (tf, "plugin-jpf.xml") +: (allCode ++ allResources ++ allJars)
-                IO.zip(allFiles, outJar)
+                IO.zip(allFiles, outJar, Option((ThisBuild / buildTimestamp).value))
               }
               ManifestWritten(outJar, id, r.group)
           }
@@ -57,8 +57,6 @@ object JPFRunnerPlugin extends AutoPlugin {
       )
     }
   }
-
-  import autoImport._
 
   def isDirectoryEmpty(f: File): Boolean = {
     Try {

--- a/project/JPFRunnerPlugin.scala
+++ b/project/JPFRunnerPlugin.scala
@@ -29,7 +29,7 @@ object JPFRunnerPlugin extends AutoPlugin {
       val scope = ScopeFilter(inAggregates(aggregate, includeRoot = false))
       Seq(
         writeJars := {
-          val compileAll  = (fullClasspath in Compile).all(scope).value
+          val compileAll  = (Compile / fullClasspath).all(scope).value
           val allRuntimes = jpfRuntime.all(scope).value ++ additionalPlugins.value
           val outBase     = target.value / "jpfjars"
           IO.delete(outBase)

--- a/project/JPFScanPlugin.scala
+++ b/project/JPFScanPlugin.scala
@@ -97,15 +97,15 @@ object JPFScanPlugin extends AutoPlugin {
               val prj = Project(toSbtPrj(pId), baseDir)
                 .dependsOn(prjDeps: _*)
                 .settings(
-                  managedClasspath in Compile ++= (managedClasspath in (parentForPlugin(pjpf), Compile)).value,
-                  managedClasspath in Compile ++= {
+                  (Compile / managedClasspath) ++= (parentForPlugin(pjpf) / Compile / managedClasspath).value,
+                  (Compile / managedClasspath) ++= {
                     jpfLibraryJars
                       .all(ScopeFilter(
                         inProjects(depsWithExports(deps, Set.empty).map(toLocalProject).toSeq: _*)))
                       .value
                       .flatten
                   },
-                  managedClasspath in Test ++= (managedClasspath in Compile).value
+                  (Test / managedClasspath) ++= (Compile / managedClasspath).value
                 )
                 .enablePlugins(JPFPlugin)
               (a, prj :: l)

--- a/project/JarSignerPlugin.scala
+++ b/project/JarSignerPlugin.scala
@@ -26,31 +26,31 @@ object JarSignerPlugin extends AutoPlugin {
   import autoImport._
 
   override def projectSettings = Seq(
-    (keystore in ThisBuild) := {
+    (ThisBuild / keystore) := {
       val c = buildConfig.value
       if (c.hasPath("signer.keystore")) file(c.getString("signer.keystore"))
       else {
-        (baseDirectory in ThisProject).value / "generated.keystore"
+        (ThisProject / baseDirectory).value / "generated.keystore"
       }
     },
-    (keyAlias in ThisBuild) := {
+    (ThisBuild / keyAlias) := {
       val c = buildConfig.value
       if (c.hasPath("signer.alias")) c.getString("signer.alias") else "genalias"
     },
-    (storePassword in ThisBuild) := {
+    (ThisBuild / storePassword) := {
       val c = buildConfig.value
       if (c.hasPath("signer.storePassword")) c.getString("signer.storePassword") else "genpassword"
     },
-    (keyPassword in ThisBuild) := {
+    (ThisBuild / keyPassword) := {
       val c = buildConfig.value
       if (c.hasPath("signer.keyPassword")) Some(c.getString("signer.keyPassword")) else None
     },
-    (tsaUrl in ThisBuild) := {
+    (ThisBuild / tsaUrl) := {
       val c       = buildConfig.value
       val seconds = c.getInt("signer.tsaDelay")
       if (c.hasPath("signer.tsaUrl")) Some((c.getString("signer.tsaUrl"), seconds)) else None
     },
-    (jarSigner in ThisBuild) := { (inJar, outJar) =>
+    (ThisBuild / jarSigner) := { (inJar, outJar) =>
       val log     = sLog.value
       val keyFile = keystore.value
       val alias   = keyAlias.value

--- a/project/YUICompressPlugin.scala
+++ b/project/YUICompressPlugin.scala
@@ -27,10 +27,10 @@ object YUICompressPlugin extends AutoPlugin {
   }
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    minify in Compile := {
+    (Compile / minify) := {
       val logger  = streams.value.log
-      val baseDir = (resourceManaged in Compile).value
-      yuiResources.value.pair(rebase((resourceDirectory in Compile).value, "")).map {
+      val baseDir = (Compile / resourceManaged).value
+      yuiResources.value.pair(rebase((Compile / resourceDirectory).value, "")).map {
         case (f, path) =>
           IO.reader(f) {
             br =>
@@ -56,6 +56,6 @@ object YUICompressPlugin extends AutoPlugin {
           }
       }
     },
-    resourceGenerators in Compile += (minify in Compile).taskValue
+    (Compile / resourceGenerators) += (Compile / minify).taskValue
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.0
+sbt.version = 1.5.2


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

With PR #2912 we picked up a _whole lot_ of SBT deprecation warnings which you see the first time your run SBT for the project (as it compiles the `**/build.sbt` and `project/*.scala`). There were two main categories of them:

1. Deprecation of the slash syntax as per https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
2. Deprecation of IO.zip and replacing with a new version which takes a third param of type Option[Long] to represent timestamps due to SBTs move to support binary reproducible builds.

You'll see there's one commit for each of these.

I also snuck in:

1. Upgrade to SBT 1.5.2; and
2. A few other minor syntax tweaks here and there as recommended by IntelliJ

As a result of this, clean SBT start-up (after deleting `target` and `project/target`) looks like:

![2021-05-14-114303_1202x933_scrot](https://user-images.githubusercontent.com/43919233/118208128-8f34b180-b4a9-11eb-819d-0e0ed2c5b76b.png)

(Those other warnings should be looked at some other time.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
