### PR TITLE
chore(SBT): Attempt to end CI on checkJavaCodeStyle failure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,9 +94,8 @@ checkJavaCodeStyle := {
   val errorNumber     = countErrorNumber
   val thresholdNumber = 870
   if (errorNumber > thresholdNumber) {
-    println(
+    throw new MessageOnlyException(
       "Checkstyle error threshold (" + thresholdNumber + ") exceeded with error count of " + errorNumber)
-    System.exit(1)
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ checkJavaCodeStyle := {
     streams = streams.value
   )
   val errorNumber     = countErrorNumber
-  val thresholdNumber = 870
+  val thresholdNumber = 864
   if (errorNumber > thresholdNumber) {
     throw new MessageOnlyException(
       "Checkstyle error threshold (" + thresholdNumber + ") exceeded with error count of " + errorNumber)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

It seems that although the check is failing it wasn't stopping the CI - even though `$? != 0`. Maybe doing it with SBT's exception mechanisms will do so.

If this fix works, I expect the GHA build to fail on the build and check job. (Maybe then I'll add additional commits to address the checkstyle issues.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
