### PR TITLE
refactor(server): Replace decompiled MD5 implementation

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/dytech/devlib/Md5.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/dytech/devlib/Md5.java
@@ -16,332 +16,134 @@
  * limitations under the License.
  */
 
-// Decompiled by Jad v1.5.8e. Copyright 2001 Pavel Kouznetsov.
-// Jad home page: http://www.geocities.com/kpdus/jad.html
-// Decompiler options: packimports(3)
-// Source File Name: Md5.java
-
 package com.dytech.devlib;
 
+import static org.apache.commons.codec.digest.MessageDigestAlgorithms.MD5;
+
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
 
-@SuppressWarnings("nls")
+/**
+ * A simple class wrapping MD5 for ease of use.
+ *
+ * <p>It has been around for a long time and originally seems to have simply been from decompiling
+ * some other implementation. That decompiled code was removed in 2021 and now simply wraps standard
+ * implementations.
+ */
 public class Md5 {
-  public static String stringify(byte buf[]) {
-    StringBuilder sb = new StringBuilder(2 * buf.length);
-    for (int i = 0; i < buf.length; i++) {
-      int h = (buf[i] & 0xf0) >> 4;
-      int l = buf[i] & 0xf;
-      sb.append(Character.valueOf((char) (h <= 9 ? 48 + h : (97 + h) - 10)));
-      sb.append(Character.valueOf((char) (l <= 9 ? 48 + l : (97 + l) - 10)));
-    }
 
-    return sb.toString();
+  private InputStream in;
+  private byte[] digest;
+
+  /**
+   * Simple converts an array of bytes to its hexadecimal string representation. Technically has
+   * nothing to do with MD5 and is just a convenience function.
+   *
+   * @param buf The array to convert to a hexadecimal string
+   * @return a hexadecimal string representation of {@code buf}
+   */
+  public static String stringify(byte[] buf) {
+    return Hex.encodeHexString(buf);
   }
 
-  private int f(int x, int y, int z) {
-    return x & y | ~x & z;
-  }
-
-  private int g(int x, int y, int z) {
-    return x & z | y & ~z;
-  }
-
-  private int h(int x, int y, int z) {
-    return x ^ y ^ z;
-  }
-
-  private int i(int x, int y, int z) {
-    return y ^ (x | ~z);
-  }
-
-  private int rotateLeft(int x, int n) {
-    return x << n | x >>> 32 - n;
-  }
-
-  private int ff(int a, int b, int c, int d, int x, int s, int ac) {
-    a += f(b, c, d) + x + ac;
-    a = rotateLeft(a, s);
-    a += b;
-    return a;
-  }
-
-  private int gg(int a, int b, int c, int d, int x, int s, int ac) {
-    a += g(b, c, d) + x + ac;
-    a = rotateLeft(a, s);
-    a += b;
-    return a;
-  }
-
-  private int hh(int a, int b, int c, int d, int x, int s, int ac) {
-    a += h(b, c, d) + x + ac;
-    a = rotateLeft(a, s);
-    a += b;
-    return a;
-  }
-
-  private int ii(int a, int b, int c, int d, int x, int s, int ac) {
-    a += i(b, c, d) + x + ac;
-    a = rotateLeft(a, s);
-    a += b;
-    return a;
-  }
-
-  private void decode(int output[], byte input[], int off, int len) {
-    int i = 0;
-    for (int j = 0; j < len; j += 4) {
-      output[i] =
-          input[off + j] & 0xff
-              | (input[off + j + 1] & 0xff) << 8
-              | (input[off + j + 2] & 0xff) << 16
-              | (input[off + j + 3] & 0xff) << 24;
-      i++;
-    }
-  }
-
-  private void transform(byte block[], int offset) {
-    int a = state[0];
-    int b = state[1];
-    int c = state[2];
-    int d = state[3];
-    int x[] = new int[16];
-    decode(x, block, offset, 64);
-    a = ff(a, b, c, d, x[0], 7, 0xd76aa478);
-    d = ff(d, a, b, c, x[1], 12, 0xe8c7b756);
-    c = ff(c, d, a, b, x[2], 17, 0x242070db);
-    b = ff(b, c, d, a, x[3], 22, 0xc1bdceee);
-    a = ff(a, b, c, d, x[4], 7, 0xf57c0faf);
-    d = ff(d, a, b, c, x[5], 12, 0x4787c62a);
-    c = ff(c, d, a, b, x[6], 17, 0xa8304613);
-    b = ff(b, c, d, a, x[7], 22, 0xfd469501);
-    a = ff(a, b, c, d, x[8], 7, 0x698098d8);
-    d = ff(d, a, b, c, x[9], 12, 0x8b44f7af);
-    c = ff(c, d, a, b, x[10], 17, -42063);
-    b = ff(b, c, d, a, x[11], 22, 0x895cd7be);
-    a = ff(a, b, c, d, x[12], 7, 0x6b901122);
-    d = ff(d, a, b, c, x[13], 12, 0xfd987193);
-    c = ff(c, d, a, b, x[14], 17, 0xa679438e);
-    b = ff(b, c, d, a, x[15], 22, 0x49b40821);
-    a = gg(a, b, c, d, x[1], 5, 0xf61e2562);
-    d = gg(d, a, b, c, x[6], 9, 0xc040b340);
-    c = gg(c, d, a, b, x[11], 14, 0x265e5a51);
-    b = gg(b, c, d, a, x[0], 20, 0xe9b6c7aa);
-    a = gg(a, b, c, d, x[5], 5, 0xd62f105d);
-    d = gg(d, a, b, c, x[10], 9, 0x2441453);
-    c = gg(c, d, a, b, x[15], 14, 0xd8a1e681);
-    b = gg(b, c, d, a, x[4], 20, 0xe7d3fbc8);
-    a = gg(a, b, c, d, x[9], 5, 0x21e1cde6);
-    d = gg(d, a, b, c, x[14], 9, 0xc33707d6);
-    c = gg(c, d, a, b, x[3], 14, 0xf4d50d87);
-    b = gg(b, c, d, a, x[8], 20, 0x455a14ed);
-    a = gg(a, b, c, d, x[13], 5, 0xa9e3e905);
-    d = gg(d, a, b, c, x[2], 9, 0xfcefa3f8);
-    c = gg(c, d, a, b, x[7], 14, 0x676f02d9);
-    b = gg(b, c, d, a, x[12], 20, 0x8d2a4c8a);
-    a = hh(a, b, c, d, x[5], 4, 0xfffa3942);
-    d = hh(d, a, b, c, x[8], 11, 0x8771f681);
-    c = hh(c, d, a, b, x[11], 16, 0x6d9d6122);
-    b = hh(b, c, d, a, x[14], 23, 0xfde5380c);
-    a = hh(a, b, c, d, x[1], 4, 0xa4beea44);
-    d = hh(d, a, b, c, x[4], 11, 0x4bdecfa9);
-    c = hh(c, d, a, b, x[7], 16, 0xf6bb4b60);
-    b = hh(b, c, d, a, x[10], 23, 0xbebfbc70);
-    a = hh(a, b, c, d, x[13], 4, 0x289b7ec6);
-    d = hh(d, a, b, c, x[0], 11, 0xeaa127fa);
-    c = hh(c, d, a, b, x[3], 16, 0xd4ef3085);
-    b = hh(b, c, d, a, x[6], 23, 0x4881d05);
-    a = hh(a, b, c, d, x[9], 4, 0xd9d4d039);
-    d = hh(d, a, b, c, x[12], 11, 0xe6db99e5);
-    c = hh(c, d, a, b, x[15], 16, 0x1fa27cf8);
-    b = hh(b, c, d, a, x[2], 23, 0xc4ac5665);
-    a = ii(a, b, c, d, x[0], 6, 0xf4292244);
-    d = ii(d, a, b, c, x[7], 10, 0x432aff97);
-    c = ii(c, d, a, b, x[14], 15, 0xab9423a7);
-    b = ii(b, c, d, a, x[5], 21, 0xfc93a039);
-    a = ii(a, b, c, d, x[12], 6, 0x655b59c3);
-    d = ii(d, a, b, c, x[3], 10, 0x8f0ccc92);
-    c = ii(c, d, a, b, x[10], 15, 0xffeff47d);
-    b = ii(b, c, d, a, x[1], 21, 0x85845dd1);
-    a = ii(a, b, c, d, x[8], 6, 0x6fa87e4f);
-    d = ii(d, a, b, c, x[15], 10, 0xfe2ce6e0);
-    c = ii(c, d, a, b, x[6], 15, 0xa3014314);
-    b = ii(b, c, d, a, x[13], 21, 0x4e0811a1);
-    a = ii(a, b, c, d, x[4], 6, 0xf7537e82);
-    d = ii(d, a, b, c, x[11], 10, 0xbd3af235);
-    c = ii(c, d, a, b, x[2], 15, 0x2ad7d2bb);
-    b = ii(b, c, d, a, x[9], 21, 0xeb86d391);
-    state[0] += a;
-    state[1] += b;
-    state[2] += c;
-    state[3] += d;
-  }
-
-  public final void update(byte input[], int len) {
-    int index = (int) (count >> 3) & 0x3f;
-    count += len << 3;
-    int partLen = 64 - index;
-    int i = 0;
-    if (len >= partLen) {
-      System.arraycopy(input, 0, buffer, index, partLen);
-      transform(buffer, 0);
-      for (i = partLen; i + 63 < len; i += 64) {
-        transform(input, i);
-      }
-      index = 0;
-    } else {
-      i = 0;
-    }
-    System.arraycopy(input, i, buffer, index, len - i);
-  }
-
-  public byte[] end() {
-    byte bits[] = new byte[8];
-    for (int i = 0; i < 8; i++) {
-      bits[i] = (byte) (int) (count >>> i * 8 & 255L);
-    }
-
-    int index = (int) (count >> 3) & 0x3f;
-    int padlen = index >= 56 ? 120 - index : 56 - index;
-    update(padding, padlen);
-    update(bits, 8);
-    return encode(state, 16);
-  }
-
-  private byte[] encode(int input[], int len) {
-    byte output[] = new byte[len];
-    int i = 0;
-    for (int j = 0; j < len; j += 4) {
-      output[j] = (byte) (input[i] & 0xff);
-      output[j + 1] = (byte) (input[i] >> 8 & 0xff);
-      output[j + 2] = (byte) (input[i] >> 16 & 0xff);
-      output[j + 3] = (byte) (input[i] >> 24 & 0xff);
-      i++;
-    }
-
-    return output;
-  }
-
+  /**
+   * Get an MD5 hash of the value provided during instantiation. Will only calculate the first time
+   * called.
+   *
+   * @return a byte array representation of the resulting hash.
+   * @throws IOException if issues reading provided input from class instantiation
+   */
   public byte[] getDigest() throws IOException {
-    byte buffer[] = new byte[1024];
-    int got = -1;
-    if (digest != null) {
-      return digest;
+    if (digest == null) {
+      digest = new DigestUtils(MD5).digest(in);
     }
-    for (got = in.read(buffer); got > 0; got = in.read(buffer)) {
-      update(buffer, got);
-    }
-    digest = end();
     return digest;
   }
 
-  public byte[] processString() {
-    if (!stringp) {
-      throw new RuntimeException(getClass().getName() + "[processString]" + " not a string.");
-    }
-    try {
-      return getDigest();
-    } catch (IOException e) {
-      throw new RuntimeException(
-          getClass().getName() + "[processString]" + ": implementation error.");
-    }
-  }
-
+  /**
+   * Uses the digest created by {@link #getDigest}, but returns a hexadecimal string representation.
+   *
+   * @return hexadecimal string representation of the resultant MD5 hash
+   */
   public String getStringDigest() {
     if (digest == null) {
       try {
         getDigest();
       } catch (IOException ioe) {
-        throw new RuntimeException("IO error");
+        throw new RuntimeException(
+            "Error when attempting to read the provided input: " + ioe.getMessage());
       }
     }
     return stringify(digest);
   }
 
-  public Md5() {
-    in = null;
-    stringp = false;
-    state = null;
-    count = 0L;
-    buffer = null;
-    digest = null;
-    init();
-  }
-
+  /**
+   * Instantiates with the provided {@code input} which will be parsed to bytes using the specified
+   * string encoding ({@code enc}).
+   *
+   * @param input A string to be hashed
+   * @param enc The encoding of the provided string.
+   */
   public Md5(String input, String enc) {
-    in = null;
-    stringp = false;
-    state = null;
-    count = 0L;
-    buffer = null;
-    digest = null;
-    byte bytes[] = null;
+    byte[] bytes;
     try {
       bytes = input.getBytes(enc);
     } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("no " + enc + " encoding!!!");
+      throw new RuntimeException("Specified encoding method (" + enc + ") is not supported.");
     }
-    initStream(new ByteArrayInputStream(bytes));
-    stringp = true;
+
+    setIn(new ByteArrayInputStream(bytes));
   }
 
-  public Md5(byte bytes[]) {
+  /**
+   * Instantiates with the provided byte array ready for hashing.
+   *
+   * @param bytes the bytes to be hashed.
+   */
+  public Md5(byte[] bytes) {
     this(new ByteArrayInputStream(bytes));
   }
 
+  /**
+   * Instantiates with the provided {@code input} which will be parsed to bytes using the specified
+   * UTF-8 string encoding.
+   *
+   * @param input A string to be hashed
+   */
   public Md5(String input) {
     this(input, "UTF8");
   }
 
+  /**
+   * Instantiates with the provided {@code InputStream} ready for hashing.
+   *
+   * @param in the stream to be hashed.
+   */
   public Md5(InputStream in) {
-    this.in = null;
-    stringp = false;
-    state = null;
-    count = 0L;
-    buffer = null;
+    setIn(in);
+  }
+
+  private void setIn(InputStream in) {
     digest = null;
-    stringp = false;
-    initStream(in);
-  }
-
-  public void initStream(InputStream in) {
     this.in = in;
-    init();
   }
 
-  public void init() {
-    state = new int[4];
-    buffer = new byte[64];
-    count = 0L;
-    state[0] = 0x67452301;
-    state[1] = 0xefcdab89;
-    state[2] = 0x98badcfe;
-    state[3] = 0x10325476;
-  }
-
+  /**
+   * It's unclear if there's a need for this class to be runnable, or whether this just came across
+   * with the decompilation of the original implementation back in the day. For now, keeping just
+   * for good measure.
+   */
   public static void main(String args[]) throws IOException {
     if (args.length != 1) {
       System.out.println("Md5 <file>");
       System.exit(1);
     }
-    Md5 md5 = new Md5(new FileInputStream(new File(args[0])));
-    byte b[] = md5.getDigest();
-    System.out.println(stringify(b));
+    Md5 md5 = new Md5(new FileInputStream(args[0]));
+    System.out.println(stringify(md5.getDigest()));
   }
-
-  private static byte padding[] = {
-    -128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0
-  };
-  private InputStream in;
-  private boolean stringp;
-  private int state[];
-  private long count;
-  private byte buffer[];
-  private byte digest[];
 }

--- a/Platform/Plugins/com.tle.platform.common/test/java/com/dytech/devlib/Md5Test.java
+++ b/Platform/Plugins/com.tle.platform.common/test/java/com/dytech/devlib/Md5Test.java
@@ -1,0 +1,29 @@
+package com.dytech.devlib;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class Md5Test {
+
+  @Test
+  public void simpleDigestGeneration() {
+    assertEquals(
+        "Incorrect digest returned",
+        "702edca0b2181c15d457eacac39de39b",
+        new Md5("This is a test!").getStringDigest());
+  }
+
+  /**
+   * The second most used function of this class, that arguably shouldn't even be specifically in an
+   * MD5 class.
+   */
+  @Test
+  public void stringifyBytes() {
+    assertEquals(
+        "Incorrect string representation of bytes",
+        "205f2d4142432d5f20",
+        Md5.stringify(" _-ABC-_ ".getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ checkJavaCodeStyle := {
     streams = streams.value
   )
   val errorNumber     = countErrorNumber
-  val thresholdNumber = 864
+  val thresholdNumber = 846
   if (errorNumber > thresholdNumber) {
     throw new MessageOnlyException(
       "Checkstyle error threshold (" + thresholdNumber + ") exceeded with error count of " + errorNumber)

--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ checkJavaCodeStyle := {
     streams = streams.value
   )
   val errorNumber     = countErrorNumber
-  val thresholdNumber = 846
+  val thresholdNumber = 847
   if (errorNumber > thresholdNumber) {
     throw new MessageOnlyException(
       "Checkstyle error threshold (" + thresholdNumber + ") exceeded with error count of " + errorNumber)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [x] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
This class (Md5) was the source of the most warnings in the CheckStyle
report. When looking at the class it became obvious it was just a
decompiled MD5 implementation which is rather redundant when there are
many standard offerings out there now. Indeed, even across the oEQ base
although there are many uses of this, there are also uses of others.

So to at least tidy things up, this has been refactored. However
arguably a refactoring to consolidate hashing on a broader scale should
be undertaken. This might be easier now with this one tidied up.

(Added the unit test before the refactor so that I could validate there
was no change.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
