### PR TITLE
Chore/checkstyle unused imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ checkJavaCodeStyle := {
     streams = streams.value
   )
   val errorNumber     = countErrorNumber
-  val thresholdNumber = 622
+  val thresholdNumber = 569
   if (errorNumber > thresholdNumber) {
     throw new MessageOnlyException(
       "Checkstyle error threshold (" + thresholdNumber + ") exceeded with error count of " + errorNumber)

--- a/checkstyle-config.xml
+++ b/checkstyle-config.xml
@@ -107,9 +107,7 @@
     <!--<module name="AvoidStarImport"/>-->
     <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
     <module name="RedundantImport"/>
-    <module name="UnusedImports">
-      <property name="processJavadoc" value="false"/>
-    </module>
+    <module name="UnusedImports"/>
 
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sourceforge.net/config_sizes.html -->

--- a/checkstyle-report-template.xml
+++ b/checkstyle-report-template.xml
@@ -72,21 +72,8 @@
         </style>
       </head>
       <body>
-        <a name="top"></a>
-        <!-- jakarta logo -->
-        <table border="0" cellpadding="0" cellspacing="0" width="100%">
-          <tr>
-            <td class="bannercell" rowspan="2">
-              <!--a href="http://jakarta.apache.org/">
-              <img src="http://jakarta.apache.org/images/jakarta-logo.gif" alt="http://jakarta.apache.org" align="left" border="0"/>
-              </a-->
-            </td>
-            <td class="text-align:right"><h2>CheckStyle Audit</h2></td>
-          </tr>
-          <tr>
-            <td class="text-align:right">Designed for use with <a href='http://checkstyle.sourceforge.net/'>CheckStyle</a>.</td>
-          </tr>
-        </table>
+        <a name="top"/>
+        <h1>CheckStyle Report</h1>
         <hr size="1"/>
 
         <!-- Summary part -->
@@ -105,16 +92,11 @@
             <p/>
             <p/>
           </xsl:if>
-
         </xsl:for-each>
         <hr size="1" width="100%" align="left"/>
-
-
       </body>
     </html>
   </xsl:template>
-
-
 
   <xsl:template match="checkstyle" mode="filelist">
     <h3>Files</h3>
@@ -137,27 +119,27 @@
     </table>
   </xsl:template>
 
-
   <xsl:template match="file">
-    <a name="f-{@name}"></a>
+    <a name="f-{@name}"/>
     <h3>File <xsl:value-of select="@name"/></h3>
 
     <table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
       <tr>
         <th>Error Description</th>
         <th>Line</th>
+        <th>Check</th>
       </tr>
       <xsl:for-each select="error">
           <tr>
             <xsl:call-template name="alternated-row"/>
             <td><xsl:value-of select="@message"/></td>
             <td><xsl:value-of select="@line"/></td>
+            <td><xsl:value-of select="@source"/></td>
           </tr>
       </xsl:for-each>
     </table>
     <a href="#top">Back to top</a>
   </xsl:template>
-
 
   <xsl:template match="checkstyle" mode="summary">
     <h3>Summary</h3>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

As you can see, another quick small tweak to the Checkstyle setup - no changes to actual source code. So if the 'build and check' job passes, this is good to merge.

Turns out 53 errors were just from the way imports were needed to support `#link` statements in JavaDoc. So best to just configure CheckStyle to support that.

Also did a minor tweak tot he XSLT for the HTML report. Should really do more when time permits, to include a summary of the type of errors.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
