### PR TITLE
Refactor `OAuthServerAccess.scala`

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthserver/OAuthServerAccess.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthserver/OAuthServerAccess.scala
@@ -121,8 +121,10 @@ object OAuthServerAccess {
 
     case CloudProviderClient(clientId, _) =>
       // The value of CachedValue is encoded by Base64 so here we need to encode the client ID.
-      val encodedClientId = new Base64().encode(clientId.toString.getBytes(StandardCharsets.UTF_8))
-      Option(LegacyGuice.replicatedCacheDao.getByValue(CloudTokenCache, encodedClientId)) match {
+      val clientIdBytes = clientId.toString.getBytes(StandardCharsets.UTF_8)
+      Option(
+        LegacyGuice.replicatedCacheDao.getByValue(CloudTokenCache,
+                                                  new Base64().encode(clientIdBytes))) match {
         case Some(tokenEntry) =>
           CloudAuthToken(tokenEntry.getKey,
                          Option(tokenEntry.getTtl).map(_.toInstant).getOrElse(Instant.now))
@@ -133,7 +135,7 @@ object OAuthServerAccess {
             CloudTokenCache,
             tokenUuid,
             Date.from(expires),
-            clientId.toString.getBytes()
+            clientIdBytes
           )
           CloudAuthToken(tokenUuid, expires)
       }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthserver/OAuthServerAccess.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthserver/OAuthServerAccess.scala
@@ -122,9 +122,7 @@ object OAuthServerAccess {
     case CloudProviderClient(clientId, _) =>
       // The value of CachedValue is encoded by Base64 so here we need to encode the client ID.
       val clientIdBytes = clientId.toString.getBytes(StandardCharsets.UTF_8)
-      Option(
-        LegacyGuice.replicatedCacheDao.getByValue(CloudTokenCache,
-                                                  new Base64().encode(clientIdBytes))) match {
+      Option(LegacyGuice.replicatedCacheDao.getByValue(CloudTokenCache, clientIdBytes)) match {
         case Some(tokenEntry) =>
           CloudAuthToken(tokenEntry.getKey,
                          Option(tokenEntry.getTtl).map(_.toInstant).getOrElse(Instant.now))

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthserver/OAuthServerAccess.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthserver/OAuthServerAccess.scala
@@ -18,22 +18,23 @@
 
 package com.tle.core.oauthserver
 
+import com.dytech.devlib.Base64
+import com.tle.common.institution.CurrentInstitution
 import java.time.{Duration, Instant}
 import java.util.{Date, UUID}
-
 import com.tle.common.oauth.beans.{OAuthClient, OAuthToken}
-import com.tle.common.usermanagement.user.{ModifiableUserState, SystemUserState, UserState}
+import com.tle.common.usermanagement.user.{ModifiableUserState, UserState}
 import com.tle.core.cloudproviders.{CloudOAuthCredentials, CloudProviderDB, CloudProviderUserState}
 import com.tle.core.db._
-import com.tle.core.db.tables.CachedValue
 import com.tle.core.i18n.CoreStrings
 import com.tle.core.oauth.OAuthConstants
 import com.tle.legacy.LegacyGuice
 import com.tle.web.oauth.OAuthException
 import com.tle.web.oauth.service.OAuthWebService.AuthorisationDetails
 import com.tle.web.oauth.service.{IOAuthClient, IOAuthToken}
+import java.nio.charset.StandardCharsets
 import javax.servlet.http.HttpServletRequest
-import fs2.Stream
+import javax.ws.rs.NotFoundException
 
 object OAuthServerAccess {
 
@@ -43,8 +44,6 @@ object OAuthServerAccess {
   private final val KEY_USER_NOT_FOUND  = "oauth.error.usernotfound"
 
   private final val TokenTimeout = Duration.ofDays(365)
-
-  private val tokenQueries: CachedValueQueries = DBSchema.queries.cachedValueQueries
 
   case class StdOAuthClient(client: OAuthClient) extends IOAuthClient {
     override def getUserId: String = client.getUserId
@@ -114,40 +113,29 @@ object OAuthServerAccess {
                        iclient: IOAuthClient,
                        code: String): IOAuthToken = iclient match {
     case StdOAuthClient(client) =>
-      var username = Option(authDetails.getUsername).getOrElse {
+      val username = Option(authDetails.getUsername).getOrElse {
         LegacyGuice.userService.getInformationForUser(authDetails.getUserId).getUsername
       }
       StdOAuthToken(
         LegacyGuice.oAuthService.getOrCreateToken(authDetails.getUserId, username, client, code))
 
-    case CloudProviderClient(clientId, creds) =>
-      RunWithDB.execute {
-        dbStream { context =>
-          for {
-            existing <- tokenQueries
-              .getForValue((CloudTokenCache, clientId.toString, context.inst))
-              .map { tokenEntry =>
-                CloudAuthToken(tokenEntry.key.value, tokenEntry.ttl.getOrElse(Instant.now))
-              }
-              .last
-            token <- existing match {
-              case Some(already) => Stream(already)
-              case None =>
-                val tokenUuid = UUID.randomUUID().toString
-                val expires   = Instant.now().plus(TokenTimeout)
-                tokenQueries
-                  .insertNew { valueId =>
-                    CachedValue(valueId,
-                                CloudTokenCache,
-                                tokenUuid,
-                                Some(expires),
-                                clientId.toString,
-                                context.inst)
-                  }
-                  .map(_ => CloudAuthToken(tokenUuid, expires))
-            }
-          } yield token
-        }.compile.lastOrError
+    case CloudProviderClient(clientId, _) =>
+      // The value of CachedValue is encoded by Base64 so here we need to encode the client ID.
+      val encodedClientId = new Base64().encode(clientId.toString.getBytes(StandardCharsets.UTF_8))
+      Option(LegacyGuice.replicatedCacheDao.getByValue(CloudTokenCache, encodedClientId)) match {
+        case Some(tokenEntry) =>
+          CloudAuthToken(tokenEntry.getKey,
+                         Option(tokenEntry.getTtl).map(_.toInstant).getOrElse(Instant.now))
+        case None =>
+          val tokenUuid = UUID.randomUUID().toString
+          val expires   = Instant.now().plus(TokenTimeout)
+          LegacyGuice.replicatedCacheDao.put(
+            CloudTokenCache,
+            tokenUuid,
+            Date.from(expires),
+            clientId.toString.getBytes()
+          )
+          CloudAuthToken(tokenUuid, expires)
       }
   }
 
@@ -157,35 +145,41 @@ object OAuthServerAccess {
   }
 
   def lookupCloudToken(tokenData: String,
-                       request: HttpServletRequest): DB[Option[ModifiableUserState]] = {
+                       request: HttpServletRequest): Option[ModifiableUserState] = {
     val (actualToken, impersonateId) = tokenData.indexOf(';') match {
       case -1 => (tokenData, None)
       case i  => (tokenData.substring(0, i), Some(tokenData.substring(i + 1)))
     }
 
-    (for {
-      cpUser <- dbStream { context =>
-        tokenQueries
-          .getForKey((CloudTokenCache, actualToken, context.inst))
-          .map { tokenValue =>
-            new CloudProviderUserState(UUID.fromString(tokenValue.value), context.inst)
-          }
+    val cpUser = Option(LegacyGuice.replicatedCacheDao.get(CloudTokenCache, actualToken))
+      .map(
+        cachedValue =>
+          new CloudProviderUserState(UUID.fromString(new String(cachedValue.getValue)),
+                                     CurrentInstitution.get()))
+
+    def getCloudProviderName: String = {
+      val cloudProvider =
+        cpUser.map(user => CloudProviderDB.getStream(user.providerId).compile.lastOrError)
+
+      cloudProvider match {
+        case Some(cp) => RunWithDB.execute(cp.map(_.name))
+        case None =>
+          throw new NotFoundException(s"Failed to find Cloud provider for token ${tokenData}")
       }
-      provider <- CloudProviderDB.getStream(cpUser.providerId)
-    } yield {
-      impersonateId match {
-        case Some(userid) =>
-          val impUser = Option(LegacyGuice.userService.getInformationForUser(userid)).getOrElse(
-            throw new OAuthException(403,
-                                     OAuthConstants.ERROR_ACCESS_DENIED,
-                                     CoreStrings.text(KEY_USER_NOT_FOUND, userid)))
-          val user =
-            authWithUsername(impUser.getUsername, request).asInstanceOf[ModifiableUserState]
-          user.setImpersonatedBy(provider.name)
-          user
-        case None => cpUser
-      }
-    }).compile.last
+    }
+
+    impersonateId match {
+      case Some(userid) =>
+        val impUser = Option(LegacyGuice.userService.getInformationForUser(userid)).getOrElse(
+          throw new OAuthException(403,
+                                   OAuthConstants.ERROR_ACCESS_DENIED,
+                                   CoreStrings.text(KEY_USER_NOT_FOUND, userid)))
+        val user =
+          authWithUsername(impUser.getUsername, request).asInstanceOf[ModifiableUserState]
+        user.setImpersonatedBy(getCloudProviderName)
+        Option(user)
+      case None => cpUser
+    }
   }
 
   def findUserState(tokenData: String, request: HttpServletRequest): UserState = {
@@ -193,7 +187,7 @@ object OAuthServerAccess {
       .map { token =>
         authWithUsername(token.getUsername, request)
       }
-      .orElse(RunWithDB.execute(lookupCloudToken(tokenData, request)))
+      .orElse(lookupCloudToken(tokenData, request))
       .getOrElse {
         throw new OAuthException(403,
                                  OAuthConstants.ERROR_ACCESS_DENIED,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -50,6 +50,7 @@ import com.tle.core.oauth.service.OAuthService;
 import com.tle.core.plugins.PluginTracker;
 import com.tle.core.powersearch.PowerSearchService;
 import com.tle.core.replicatedcache.ReplicatedCacheService;
+import com.tle.core.replicatedcache.dao.ReplicatedCacheDao;
 import com.tle.core.search.service.impl.SearchPrivilegeTreeProvider;
 import com.tle.core.security.TLEAclManager;
 import com.tle.core.services.FileSystemService;
@@ -218,6 +219,8 @@ public class LegacyGuice extends AbstractModule {
   public static QuickContributeAndVersionSettingsPrivilegeTreeProvider quickContribPrivProvider;
 
   @Inject public static RemoteCachingPrivilegeTreeProvider remoteCachePrivProvider;
+
+  @Inject public static ReplicatedCacheDao replicatedCacheDao;
 
   @Inject public static ReplicatedCacheService replicatedCacheService;
 

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/dao/GenericDaoImpl.java
@@ -23,6 +23,7 @@ import com.tle.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
 import java.util.function.Function;
+import javax.persistence.EntityManager;
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
@@ -100,7 +101,7 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
   @SuppressWarnings("unchecked")
   @Override
   public <A> A findAnyById(Class<A> clazz, Serializable id) {
-    return (A) getHibernateTemplate().get(clazz, id);
+    return getHibernateTemplate().get(clazz, id);
   }
 
   @Override
@@ -155,7 +156,7 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
   @Override
   @SuppressWarnings("unchecked")
   public T findById(ID id) {
-    return (T) getHibernateTemplate().get(getPersistentClass(), id);
+    return getHibernateTemplate().get(getPersistentClass(), id);
   }
 
   /*
@@ -321,14 +322,14 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
   @SuppressWarnings("unchecked")
   @Transactional(propagation = Propagation.MANDATORY)
   public T merge(T entity) {
-    return (T) getHibernateTemplate().merge(entity);
+    return getHibernateTemplate().merge(entity);
   }
 
   @Override
   @SuppressWarnings("unchecked")
   @Transactional(propagation = Propagation.MANDATORY)
   public <O> O mergeAny(O obj) {
-    return (O) getHibernateTemplate().merge(obj);
+    return getHibernateTemplate().merge(obj);
   }
 
   @Override
@@ -377,5 +378,14 @@ public class GenericDaoImpl<T, ID extends Serializable> extends AbstractHibernat
       throw new RuntimeException("Expected unique result by found " + results.size() + " results");
     }
     return results.get(0);
+  }
+
+  /**
+   * Return an EntityManager to help criteria query building.
+   *
+   * @param session An active Hibernate Session
+   */
+  protected EntityManager createEntityManager(Session session) {
+    return session.getEntityManagerFactory().createEntityManager();
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/dao/ReplicatedCacheDao.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/dao/ReplicatedCacheDao.java
@@ -26,6 +26,8 @@ import java.util.Date;
 public interface ReplicatedCacheDao extends GenericDao<CachedValue, Long> {
   CachedValue get(String cacheId, String key);
 
+  CachedValue getByValue(String cacheId, String value);
+
   void put(String cacheId, String key, Date ttl, byte[] value);
 
   void invalidate(String cacheId, String... keys);

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/dao/ReplicatedCacheDao.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/dao/ReplicatedCacheDao.java
@@ -26,7 +26,7 @@ import java.util.Date;
 public interface ReplicatedCacheDao extends GenericDao<CachedValue, Long> {
   CachedValue get(String cacheId, String key);
 
-  CachedValue getByValue(String cacheId, String value);
+  CachedValue getByValue(String cacheId, byte[] value);
 
   void put(String cacheId, String key, Date ttl, byte[] value);
 

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/dao/ReplicatedCacheDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/replicatedcache/dao/ReplicatedCacheDaoImpl.java
@@ -27,8 +27,8 @@ import java.util.Collection;
 import java.util.Date;
 import javax.inject.Singleton;
 import org.hibernate.HibernateException;
-import org.hibernate.Query;
 import org.hibernate.Session;
+import org.hibernate.query.Query;
 import org.springframework.orm.hibernate5.HibernateCallback;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +55,28 @@ public class ReplicatedCacheDaoImpl extends GenericDaoImpl<CachedValue, Long>
                             "FROM CachedValue WHERE key = :key"
                                 + " AND cacheId = :cacheId AND institution = :institution");
                     q.setParameter("key", key);
+                    q.setParameter("cacheId", cacheId);
+                    q.setParameter("institution", CurrentInstitution.get());
+
+                    return q.uniqueResult();
+                  }
+                });
+  }
+
+  @Override
+  @Transactional
+  public CachedValue getByValue(String cacheId, String value) {
+    return (CachedValue)
+        getHibernateTemplate()
+            .execute(
+                new HibernateCallback() {
+                  @Override
+                  public Object doInHibernate(Session session) throws HibernateException {
+                    Query q =
+                        session.createQuery(
+                            "FROM CachedValue WHERE value = :value"
+                                + " AND cacheId = :cacheId AND institution = :institution");
+                    q.setParameter("value", value);
                     q.setParameter("cacheId", cacheId);
                     q.setParameter("institution", CurrentInstitution.get());
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR replaces the Scala `CacheValue` with the Java one and replaces Scala `tokenQuery` with Java `ReplicatedCacheDao` in `OAuthServerAccess`.  The changes are mostly around the feature of Cloud provider. Due to my limited knowledge of Scala monad, I am honestly not 100% confident in whether the simplified code works as exactly the same as how those monads work. But I did run through the feature of Cloud provider locally and every things seem fine.

Unfortunately, we can't remove all the code related to the use of simpleDBA until we rewrite `CloudProviderDB`.

Register a CP.
![image](https://user-images.githubusercontent.com/47203811/118902543-348fcf80-b959-11eb-8d60-4e1ba779b62c.png)


Use a CP  Wizard control.
![image](https://user-images.githubusercontent.com/47203811/118903439-22169580-b95b-11eb-87b5-8ccdcac58d6c.png)
