### PR TITLE
chore(deps): Rollback Apache Curator to 4.3.0

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -20,6 +20,7 @@ val SwaggerVersion   = "1.6.2"
 val TomcatVersion    = "9.0.46"
 val axis2Version     = "1.6.2"
 val circeVersion     = "0.12.1"
+val curatorVersion   = "4.3.0"
 val cxfVersion       = "3.4.1"
 val fs2Version       = "2.4.4"
 val guiceVersion     = "3.0"
@@ -125,9 +126,9 @@ libraryDependencies ++= Seq(
   "org.apache.axis2"          % "axis2-adb"                % axis2Version,
   "org.apache.axis2"          % "axis2-transport-http"     % axis2Version,
   "org.apache.axis2"          % "axis2-transport-local"    % axis2Version,
-  "org.apache.curator"        % "curator-client"           % "5.1.0",
-  "org.apache.curator"        % "curator-framework"        % "5.1.0",
-  "org.apache.curator"        % "curator-recipes"          % "5.1.0",
+  "org.apache.curator"        % "curator-client"           % curatorVersion,
+  "org.apache.curator"        % "curator-framework"        % curatorVersion,
+  "org.apache.curator"        % "curator-recipes"          % curatorVersion,
   "org.apache.cxf"            % "cxf-rt-frontend-jaxws"    % cxfVersion,
   "org.apache.cxf"            % "cxf-rt-transports-http"   % cxfVersion,
   "org.apache.cxf"            % "cxf-rt-databinding-aegis" % cxfVersion,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Unfortunately 5.1.0 requires a newer version of Zk and that version is
not available as a standard debian package yet - so we'd have to change
our CD Zk cluster to test with. But at least 4.3.0 is still
significantly newer that what we had.

Will schedule in time to upgrade our CD environment and then revisit
upgrading to 5.x series.

Note: Just to clarify, the minimum supported Zk version for Apache
Curator is 3.5.x but debian is still on 3.4.13.

For testing I did run up the docker-compose locally with three nodes and confirmed they were all communicating and properly scheduling distributed tasks (like thumb-nailing and indexing).

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
