### PR TITLE
chore(ci): Include ESLint checks for oeq-ts-rest-api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,14 @@ jobs:
           npm run check
           ./sbt headerCheck checkJavaCodeStyle
 
+      # oeq-ts-rest-api has its own ESLint checks seeing the ultimate plan
+      # is that it's moved to its own stand-alone repo. But so here we need
+      # to explicitly run them.
+      - name: Run checks (oeq-ts-rest-api)
+        working-directory: oeq-ts-rest-api
+        run: |
+          npm run lint
+
       - name: Run unit tests (java/scala)
         run: |
           ./sbt test

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -417,8 +417,10 @@ export const search = (
  * @param apiBasePath Base URI to the oEQ institution and API.
  * @param params Query parameters as search criteria.
  */
-export const buildExportUrl = (apiBasePath: string, params: SearchParams) =>
-  apiBasePath + EXPORT_PATH + '?' + stringify(params);
+export const buildExportUrl = (
+  apiBasePath: string,
+  params: SearchParams
+): string => apiBasePath + EXPORT_PATH + '?' + stringify(params);
 
 /**
  * Communicate with REST endpoint 'search2/export' to confirm if an export request is valid.
@@ -429,4 +431,4 @@ export const buildExportUrl = (apiBasePath: string, params: SearchParams) =>
 export const confirmExportRequest = (
   apiBasePath: string,
   params: SearchParams
-) => HEAD(apiBasePath + EXPORT_PATH, params);
+): Promise<boolean> => HEAD(apiBasePath + EXPORT_PATH, params);

--- a/oeq-ts-rest-api/test/schema.test.ts
+++ b/oeq-ts-rest-api/test/schema.test.ts
@@ -66,14 +66,11 @@ describe('Retrieval of a specific schema', () => {
     );
   });
 
-  it('Should result in a 404 when attempting to retrieve an unknown UUID', () => {
-    expect.assertions(2);
-
-    return OEQ.Schema.getSchema(TC.API_PATH, 'fake-uuid').catch(
-      (error: OEQ.Errors.ApiError) => {
-        expect(error.status).toBe(404);
-        expect(error.errorResponse).toBeTruthy();
-      }
+  it('Should result in a 404 when attempting to retrieve an unknown UUID', async () => {
+    await expect(() =>
+      OEQ.Schema.getSchema(TC.API_PATH, 'fake-uuid')
+    ).rejects.toThrow(
+      new OEQ.Errors.ApiError('Request failed with status code 404', 404)
     );
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [ ] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

We seem to be missing these checks, and currently their are a couple of issues. ~~So at first I expect this PR to fail, and then we need to make a few minor commits to address the issues. (But I want to confirm it fails first to ensure I've probably added the new task.)~~

A quick run down of the issues being fixed:

- `Search.ts` : Add missing explicit return types - straightforward enough, and of good value;
- `Utils.ts` : Stop using `any` and replace `unknown` for known objects to `Record<string,unknown>` as per TS best practice. Also as a result add some more explicit run-time type validation to ensure we're working on what we think we are. Which ultimately, is why ESLint raises warnings around `any`.
- `schema.test.ts` : Rework conditional `expect` calls to ensure no false positives. (This file could probably be updated further to use async/await, but that'll do for now to pass ESLint and not blur things.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
