### PR TITLE
Bugfix/jsonb not supported in oracle

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
@@ -80,8 +80,7 @@ public class AuditLogEntry implements AuditLogTable {
 
   @Lob private String data4;
 
-  @Type(type = "jsonb")
-  @Column(columnDefinition = "jsonb")
+  @Type(type = "json_string")
   private String meta;
 
   public AuditLogEntry() {

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/audit/AuditLogEntry.java
@@ -80,7 +80,7 @@ public class AuditLogEntry implements AuditLogTable {
 
   @Lob private String data4;
 
-  @Type(type = "json_string")
+  @Type(type = "json")
   private String meta;
 
   public AuditLogEntry() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
@@ -25,7 +25,6 @@ import com.tle.core.migration.MigrationInfo;
 import com.tle.core.migration.MigrationResult;
 import java.util.List;
 import javax.inject.Singleton;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -79,8 +78,7 @@ public class NewAuditLogColumn extends AbstractHibernateSchemaMigration {
     @GeneratedValue(strategy = GenerationType.AUTO)
     long id;
 
-    @Type(type = "jsonb")
-    @Column(columnDefinition = "jsonb")
+    @Type(type = "json_string")
     private String meta;
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v66/NewAuditLogColumn.java
@@ -78,7 +78,7 @@ public class NewAuditLogColumn extends AbstractHibernateSchemaMigration {
     @GeneratedValue(strategy = GenerationType.AUTO)
     long id;
 
-    @Type(type = "json_string")
+    @Type(type = "json")
     private String meta;
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
@@ -37,8 +37,8 @@ public class HibernateCustomTypes {
       new CustomType(new HibernateCsvType(Types.VARCHAR), new String[] {"csv"});
 
   public static List<BasicType> getCustomTypes(ExtendedDialect dialect) {
-    final CustomType TYPE_JSON_STRING =
-        new CustomType(new JsonStringCustomType(dialect), new String[] {"json_string"});
-    return Arrays.asList(TYPE_JSON_STRING, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM);
+    final CustomType TYPE_JSON =
+        new CustomType(new JsonStringCustomType(dialect), new String[] {"json"});
+    return Arrays.asList(TYPE_JSON, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM);
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/HibernateCustomTypes.java
@@ -18,7 +18,7 @@
 
 package com.tle.core.hibernate.type;
 
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import com.tle.core.hibernate.ExtendedDialect;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
@@ -36,9 +36,9 @@ public class HibernateCustomTypes {
   private static final CustomType TYPE_CSV =
       new CustomType(new HibernateCsvType(Types.VARCHAR), new String[] {"csv"});
 
-  private static final BasicType TYPE_JSONB = new JsonBinaryType(String.class);
-
-  public static List<BasicType> getCustomTypes() {
-    return Arrays.asList(TYPE_JSONB, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM);
+  public static List<BasicType> getCustomTypes(ExtendedDialect dialect) {
+    final CustomType TYPE_JSON_STRING =
+        new CustomType(new JsonStringCustomType(dialect), new String[] {"json_string"});
+    return Arrays.asList(TYPE_JSON_STRING, TYPE_BLANKABLE, TYPE_CSV, TYPE_XSTREAM);
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/JsonStringCustomType.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/JsonStringCustomType.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.hibernate.type;
+
+import com.google.common.base.Objects;
+import com.tle.core.hibernate.ExtendedDialect;
+import com.tle.hibernate.dialect.ExtendedOracle10gDialect;
+import com.tle.hibernate.dialect.ExtendedPostgresDialect;
+import com.tle.hibernate.dialect.SQLServerDialect;
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.usertype.UserType;
+import org.postgresql.util.PGobject;
+
+/**
+ * Provide a custom hibernate type to support JSON String in Postgres, Oracle and SQL Server. For
+ * Postgres, the column type is 'jsonb'. For Oracle, the column type is 'nclob'. For SQL Server, the
+ * column type is 'nvarchar(max)'.
+ */
+public class JsonStringCustomType implements UserType {
+  private final ExtendedDialect dialect;
+
+  public JsonStringCustomType(ExtendedDialect dialect) {
+    this.dialect = dialect;
+  }
+
+  @Override
+  public int[] sqlTypes() {
+    int jsonStringSqlType = Types.OTHER; // Default to 'OTHER' for Postgres.
+
+    if (dialect instanceof SQLServerDialect) {
+      jsonStringSqlType = Types.LONGNVARCHAR;
+    } else if (dialect instanceof ExtendedOracle10gDialect) {
+      jsonStringSqlType = Types.NCLOB;
+    }
+
+    return new int[] {jsonStringSqlType};
+  }
+
+  @Override
+  public Class<?> returnedClass() {
+    return String.class;
+  }
+
+  @Override
+  public boolean equals(Object x, Object y) throws HibernateException {
+    return Objects.equal(x, y);
+  }
+
+  @Override
+  public int hashCode(Object x) throws HibernateException {
+    return x.hashCode();
+  }
+
+  @Override
+  public Object nullSafeGet(
+      ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+      throws HibernateException, SQLException {
+    return StandardBasicTypes.STRING.nullSafeGet(rs, names[0], session);
+  }
+
+  @Override
+  public void nullSafeSet(
+      PreparedStatement st, Object object, int index, SharedSessionContractImplementor session)
+      throws HibernateException, SQLException {
+    String value = object == null ? null : object.toString();
+    // For Postgres, we must use a `PGobject` to save the value since the column type is 'jsonb'.
+    if (dialect instanceof ExtendedPostgresDialect) {
+      PGobject jsonObject = new PGobject();
+      jsonObject.setType("json");
+      jsonObject.setValue(value);
+      st.setObject(index, jsonObject, Types.OTHER);
+      return;
+    }
+    // For other databases, just save as a string.
+    st.setString(index, value);
+  }
+
+  @Override
+  public Object deepCopy(Object value) throws HibernateException {
+    return value;
+  }
+
+  @Override
+  public boolean isMutable() {
+    return false;
+  }
+
+  @Override
+  public Serializable disassemble(Object value) throws HibernateException {
+    return (Serializable) deepCopy(value);
+  }
+
+  @Override
+  public Object assemble(Serializable cached, Object owner) throws HibernateException {
+    return deepCopy(cached);
+  }
+
+  @Override
+  public Object replace(Object original, Object target, Object owner) throws HibernateException {
+    return deepCopy(original);
+  }
+}

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/JsonStringCustomType.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/type/JsonStringCustomType.java
@@ -48,7 +48,7 @@ public class JsonStringCustomType implements UserType {
 
   @Override
   public int[] sqlTypes() {
-    int jsonStringSqlType = Types.OTHER; // Default to 'OTHER' for Postgres.
+    int jsonStringSqlType = ExtendedPostgresDialect.OEQ_JSON;
 
     if (dialect instanceof SQLServerDialect) {
       jsonStringSqlType = Types.LONGNVARCHAR;

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedOracle10gDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedOracle10gDialect.java
@@ -147,7 +147,7 @@ public class ExtendedOracle10gDialect extends Oracle10gDialect implements Extend
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    return ImmutableList.copyOf(HibernateCustomTypes.getCustomTypes());
+    return ImmutableList.copyOf(HibernateCustomTypes.getCustomTypes(this));
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -40,12 +40,13 @@ import org.hibernate.type.TextType;
 public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements ExtendedDialect {
   private static final String URL_SCHEME = "jdbc:postgresql://";
   private final UniqueDelegate uniqueDelegate;
+  public static final int OEQ_JSON = 10000;
 
   public ExtendedPostgresDialect() {
     super();
     uniqueDelegate = new InPlaceUniqueDelegate(this);
     registerColumnType(Types.BLOB, "bytea");
-    registerColumnType(Types.OTHER, "jsonb");
+    registerColumnType(OEQ_JSON, "jsonb");
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/ExtendedPostgresDialect.java
@@ -45,6 +45,7 @@ public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements Exten
     super();
     uniqueDelegate = new InPlaceUniqueDelegate(this);
     registerColumnType(Types.BLOB, "bytea");
+    registerColumnType(Types.OTHER, "jsonb");
   }
 
   @Override
@@ -159,7 +160,7 @@ public class ExtendedPostgresDialect extends PostgreSQL9Dialect implements Exten
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    List<BasicType> customTypes = new ArrayList<>(HibernateCustomTypes.getCustomTypes());
+    List<BasicType> customTypes = new ArrayList<>(HibernateCustomTypes.getCustomTypes(this));
     customTypes.add(new TextClobType());
     return ImmutableList.copyOf(customTypes);
   }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/SQLServerDialect.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/hibernate/dialect/SQLServerDialect.java
@@ -208,7 +208,7 @@ public class SQLServerDialect extends org.hibernate.dialect.SQLServer2005Dialect
 
   @Override
   public Iterable<? extends BasicType> getExtraTypeOverrides() {
-    List<BasicType> customTypes = new ArrayList<>(HibernateCustomTypes.getCustomTypes());
+    List<BasicType> customTypes = new ArrayList<>(HibernateCustomTypes.getCustomTypes(this));
     customTypes.add(new NStringType());
     customTypes.add(new LongNStringType());
     return ImmutableList.copyOf(customTypes);

--- a/Source/Plugins/Generic/org.hibernate/build.sbt
+++ b/Source/Plugins/Generic/org.hibernate/build.sbt
@@ -3,7 +3,6 @@ lazy val CustomCompile = config("compile") extend Hibernate
 val springVersion      = "5.2.9.RELEASE"
 
 libraryDependencies := Seq(
-  "com.vladmihalcea"         % "hibernate-types-52"    % "2.10.4",
   "org.hibernate"            % "hibernate-core"        % "5.4.21.Final",
   "org.hibernate"            % "hibernate-validator"   % "6.1.5.Final",
   "javax.persistence"        % "javax.persistence-api" % "2.2",


### PR DESCRIPTION
#### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Since `jsonb` is a Postgres specific column type, previous testing work found errors when oEQ was installed with SQL Server or Oracle. To fix this issue, a custom hibernate type has been created to support saving JSON strings in databases. This custom type returns type 'nclob' for Oracle, `nvarchar(max)` for SQL Server and `jsonb` for Postgres.


Video for Oracle
https://user-images.githubusercontent.com/47203811/119589398-09542700-be16-11eb-996b-01b4fe000fd1.mp4

Video for Postgres
https://user-images.githubusercontent.com/47203811/119589615-7d8eca80-be16-11eb-937d-ed7ab45e7c64.mp4

Video for SQL Server
https://user-images.githubusercontent.com/47203811/119589751-d2cadc00-be16-11eb-8fd0-a4bf7570fce1.mp4




