### PR TITLE
Exclude `mimeTypes` from a gallery search

### DIFF
--- a/react-front-end/tsrc/modules/GallerySearchModule.ts
+++ b/react-front-end/tsrc/modules/GallerySearchModule.ts
@@ -508,7 +508,7 @@ export const videoGallerySearch = async (
   options: SearchOptions
 ): Promise<OEQ.Search.SearchResult<GallerySearchResultItem>> =>
   gallerySearch(
-    { ...options, musts: videoGalleryMusts },
+    { ...options, musts: videoGalleryMusts, mimeTypes: undefined },
     filterAttachmentsByVideo
   );
 

--- a/react-front-end/tsrc/modules/GallerySearchModule.ts
+++ b/react-front-end/tsrc/modules/GallerySearchModule.ts
@@ -534,4 +534,8 @@ export const listImageGalleryClassifications = async (
 export const listVideoGalleryClassifications = async (
   options: SearchOptions
 ): Promise<Classification[]> =>
-  listClassifications({ ...options, musts: videoGalleryMusts });
+  listClassifications({
+    ...options,
+    musts: videoGalleryMusts,
+    mimeTypes: undefined,
+  });


### PR DESCRIPTION
#2936 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Exclude MIME types in gallery searches, but selected MIME type filters are still kept so that when we switch back to the standard search page, filters still get selected.

Please note that `external MIME types` are still included in gallery searches if they are provided.

