### PR TITLE
Bugfix/default viewer disabled

### DIFF
--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6069,6 +6069,11 @@
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.AddIndexingErrorColumnMigration"/>
     <parameter id="date" value="2020-11-18"/>
   </extension>
+  <extension plugin-id="com.tle.core.migration" point-id="migration" id="EnableDefaultViewerMigration">
+    <parameter id="id" value="com.tle.core.institution.migration.v20211.EnableDefaultViewerMigration"/>
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20211.EnableDefaultViewerMigration"/>
+    <parameter id="date" value="2021-06-01"/>
+  </extension>
   <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="domainObjects">
     <parameter id="class" value="com.tle.core.integration.beans.AuditLogLms" />
   </extension>

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -82,6 +82,7 @@
 /com.tle.core.entity.services.migration.v20202.facetedsearch.classification=Create a new table for faceted search classification
 /com.tle.core.entity.services.migration.v20202.removelastknownuserconstraint=Remove last known user composite constraint (username and institution ID)
 /com.tle.core.entity.services.migration.v20202.indexing.errored=Add column to attachment table to allow indexer to skip individual attachments that have failed.
+/com.tle.core.entity.services.migration.v20211.enable.default.viewer=Enable default viewer
 /com.tle.core.entity.services.query.contains={0} is {1}
 /com.tle.core.entity.services.query.date.after={0} after {1}
 /com.tle.core.entity.services.query.date.before={0} before {1}

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -2747,6 +2747,7 @@ mimetypes.migration.title=Update default MIME Type icons
 mimetypes.settings.description=Display a list of MIME types, where the properties can be edited, including viewer defaults
 mimetypes.settings.title=MIME types
 mimetypes.title=MIME type editor
+mimetypes.default.viewer.not.enabled=Default viewer is not enabled
 missingprivileges=You do not have the required privilege to access this page\: {0}
 moddialog.accepted=Moderators already accepted
 moddialog.and=and

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -82,7 +82,7 @@
 /com.tle.core.entity.services.migration.v20202.facetedsearch.classification=Create a new table for faceted search classification
 /com.tle.core.entity.services.migration.v20202.removelastknownuserconstraint=Remove last known user composite constraint (username and institution ID)
 /com.tle.core.entity.services.migration.v20202.indexing.errored=Add column to attachment table to allow indexer to skip individual attachments that have failed.
-/com.tle.core.entity.services.migration.v20211.enable.default.viewer=Enable default viewer
+/com.tle.core.entity.services.migration.v20211.enable.default.viewer=Ensure configured default viewers are also enabled
 /com.tle.core.entity.services.query.contains={0} is {1}
 /com.tle.core.entity.services.query.date.after={0} after {1}
 /com.tle.core.entity.services.query.date.before={0} before {1}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20211/EnableDefaultViewerMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20211/EnableDefaultViewerMigration.java
@@ -46,6 +46,11 @@ import org.hibernate.annotations.AccessType;
 import org.hibernate.annotations.MapKeyType;
 import org.hibernate.annotations.Type;
 
+/**
+ * Some existing MIME types do not have their default viewers enabled. This results in error
+ * messages showing in the New Search UI. So we use this migration to ensure the default viewer is
+ * in list of enabled viewers.
+ */
 @Bind
 @Singleton
 public class EnableDefaultViewerMigration extends AbstractHibernateDataMigration {
@@ -58,6 +63,9 @@ public class EnableDefaultViewerMigration extends AbstractHibernateDataMigration
     final List<FakeMimeEntry> entries = session.createQuery("FROM MimeEntry").list();
     for (FakeMimeEntry entry : entries) {
       Map<String, String> attributes = entry.attributes;
+      // Calling 'getEnabledViewerList' to fix this issue as the list returned from this function
+      // include the default viewer whereas the one saved in attributes may have default viewer
+      // missing.
       String enabledViewers = mimeTypeService.getEnabledViewerList(attributes);
       if (!Check.isEmpty(enabledViewers)) {
         attributes.put(MimeTypeConstants.KEY_ENABLED_VIEWERS, enabledViewers);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20211/EnableDefaultViewerMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20211/EnableDefaultViewerMigration.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.institution.migration.v20211;
+
+import com.google.inject.Singleton;
+import com.tle.common.Check;
+import com.tle.core.guice.Bind;
+import com.tle.core.hibernate.impl.HibernateMigrationHelper;
+import com.tle.core.migration.AbstractHibernateDataMigration;
+import com.tle.core.migration.MigrationInfo;
+import com.tle.core.migration.MigrationResult;
+import com.tle.core.mimetypes.MimeTypeConstants;
+import com.tle.core.mimetypes.MimeTypeService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.MapKeyColumn;
+import org.hibernate.Session;
+import org.hibernate.annotations.AccessType;
+import org.hibernate.annotations.MapKeyType;
+import org.hibernate.annotations.Type;
+
+@Bind
+@Singleton
+public class EnableDefaultViewerMigration extends AbstractHibernateDataMigration {
+
+  @Inject private MimeTypeService mimeTypeService;
+
+  @Override
+  protected void executeDataMigration(
+      HibernateMigrationHelper helper, MigrationResult result, Session session) throws Exception {
+    final List<FakeMimeEntry> entries = session.createQuery("FROM MimeEntry").list();
+    for (FakeMimeEntry entry : entries) {
+      Map<String, String> attributes = entry.attributes;
+      String enabledViewers = mimeTypeService.getEnabledViewerList(attributes);
+      if (!Check.isEmpty(enabledViewers)) {
+        attributes.put(MimeTypeConstants.KEY_ENABLED_VIEWERS, enabledViewers);
+        session.update(entry);
+        session.flush();
+      }
+    }
+    result.incrementStatus();
+  }
+
+  @Override
+  protected int countDataMigrations(HibernateMigrationHelper helper, Session session) {
+    return 0;
+  }
+
+  @Override
+  protected Class<?>[] getDomainClasses() {
+    return new Class[] {FakeMimeEntry.class};
+  }
+
+  @Override
+  public MigrationInfo createMigrationInfo() {
+    return new MigrationInfo("com.tle.core.entity.services.migration.v20211.enable.default.viewer");
+  }
+
+  @Entity(name = "MimeEntry")
+  @AccessType("field")
+  public static class FakeMimeEntry {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    long id;
+
+    @ElementCollection
+    @Column(name = "element", nullable = false)
+    @CollectionTable(
+        name = "mime_entry_attributes",
+        joinColumns = @JoinColumn(name = "mime_entry_id"))
+    @Lob
+    @MapKeyColumn(name = "mapkey", length = 100, nullable = false)
+    @MapKeyType(@Type(type = "string"))
+    Map<String, String> attributes = new HashMap<String, String>();
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
@@ -90,10 +90,11 @@ public interface MimeTypeService {
 
   /**
    * Return a list of enabled viewers. If the default viewer does not exist in the list, add it to
-   * the list. However, if the default viewer is "file", it will not be included.
+   * the list. However, if the default viewer is "file", it will not be included because "file" is
+   * added to the list dynamically by {@link com.tle.web.mimetypes.section.MimeDefaultViewerSection}
    *
    * @param attributes Configured attributes of MIME type
-   * @return A string representing a list of enabled viewers
+   * @return A string representing a list of enabled viewers in the format of array.
    */
   String getEnabledViewerList(Map<String, String> attributes);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
@@ -94,7 +94,8 @@ public interface MimeTypeService {
    * added to the list dynamically by {@link com.tle.web.mimetypes.section.MimeDefaultViewerSection}
    *
    * @param attributes Configured attributes of MIME type
-   * @return A string representing a list of enabled viewers in the format of array.
+   * @return A string representing a list of enabled viewers and formatted as a JSON array of
+   *     strings (e.g. ["fancy", "toimg"])
    */
   String getEnabledViewerList(Map<String, String> attributes);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeService.java
@@ -26,6 +26,7 @@ import com.tle.core.TextExtracterExtension;
 import com.tle.web.controls.resource.ResourceAttachmentBean;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 @NonNullByDefault
 public interface MimeTypeService {
@@ -86,6 +87,15 @@ public interface MimeTypeService {
 
   @Nullable
   String getMimeEntryForAttachment(Attachment attachment);
+
+  /**
+   * Return a list of enabled viewers. If the default viewer does not exist in the list, add it to
+   * the list. However, if the default viewer is "file", it will not be included.
+   *
+   * @param attributes Configured attributes of MIME type
+   * @return A string representing a list of enabled viewers
+   */
+  String getEnabledViewerList(Map<String, String> attributes);
 
   interface MimeEntryChanges {
     void editMimeEntry(MimeEntry entry);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/MimeTypeServiceImpl.java
@@ -136,13 +136,6 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
   @Override
   public MimeTypesSearchResults searchByMimeType(String mimeType, int offset, int length) {
     String query = (Check.isEmpty(mimeType) ? "" : mimeType.toLowerCase()); // $NON-NLS-1$
-    /*
-     * Map<String, MimeEntry> typeMap =
-     * mimeCache.getCache().getMimeEntries(); List<MimeEntry> mimes = new
-     * ArrayList<MimeEntry>(); for( Entry<String, MimeEntry> entry :
-     * typeMap.entrySet() ) { if( entry.getKey().startsWith(query) ) {
-     * mimes.add(entry.getValue()); } } return mimes;
-     */
     return mimeEntryDao.searchAll(query, offset, length);
   }
 
@@ -393,45 +386,6 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
   @SuppressWarnings("unchecked")
   @Override
   public List<TextExtracterExtension> getTextExtractersForMimeEntry(final MimeEntry mimeEntry) {
-    // Collection<Extension> extensions = textExtracterTracker
-    // .getExtensions(new Filter<Extension>()
-    // {
-    // @Override
-    // public boolean include(Extension t)
-    // {
-    //					Collection<Parameter> mimes = t.getParameters("mimeType"); //$NON-NLS-1$
-    // for( Parameter mime : mimes )
-    // {
-    // String m = mime.valueAsString();
-    // int wildIndex = m.indexOf('*');
-    // if( wildIndex >= 0 )
-    // {
-    // String nonWild = m.substring(0, wildIndex);
-    // if( mimeType.startsWith(nonWild) )
-    // {
-    // return true;
-    // }
-    // }
-    // else
-    // {
-    // if( mimeType.equals(m) )
-    // {
-    // return true;
-    // }
-    // }
-    // }
-    // return false;
-    // }
-    // });
-    //
-    // List<TextExtracterExtension> extracters = new
-    // ArrayList<TextExtracterExtension>();
-    // for( Extension e : extensions )
-    // {
-    // extracters.add(textExtracterTracker.getBeanByExtension(e));
-    // }
-    // return extracters;
-
     List<TextExtracterExtension> extracters = getAllTextExtracters();
     List<TextExtracterExtension> filtered = new ArrayList<TextExtracterExtension>();
     for (TextExtracterExtension extracter : extracters) {
@@ -491,6 +445,29 @@ public class MimeTypeServiceImpl implements MimeTypeService, MimeTypesUpdatedLis
     }
 
     return null;
+  }
+
+  @Override
+  public String getEnabledViewerList(Map<String, String> attributes) {
+    String defaultViewer = attributes.get(MimeTypeConstants.KEY_DEFAULT_VIEWERID);
+    String enabledViewers = attributes.get(MimeTypeConstants.KEY_ENABLED_VIEWERS);
+    // File viewer is handled differently in 'MimeDefaultViewerSection' so there is no need to
+    // add it to the list.
+    if (Check.isEmpty(defaultViewer)
+        || defaultViewer.equals(MimeTypeConstants.VAL_DEFAULT_VIEWERID)) {
+      return enabledViewers;
+    }
+
+    List<String> enabledViewerList = new ArrayList<>();
+    if (!Check.isEmpty(enabledViewers)) {
+      enabledViewerList.addAll(
+          JSONArray.toCollection(JSONArray.fromObject(enabledViewers), String.class));
+    }
+    if (!enabledViewerList.contains(defaultViewer)) {
+      enabledViewerList.add(defaultViewer);
+    }
+
+    return JSONArray.fromObject(enabledViewerList).toString();
   }
 
   private synchronized Map<String, List<Extension>> getExtensionMap() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/institution/MimeEntryConverter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/mimetypes/institution/MimeEntryConverter.java
@@ -27,9 +27,10 @@ import com.tle.core.guice.Bind;
 import com.tle.core.hibernate.equella.service.InitialiserService;
 import com.tle.core.institution.convert.AbstractMigratableConverter;
 import com.tle.core.institution.convert.ConverterParams;
+import com.tle.core.mimetypes.MimeTypeConstants;
+import com.tle.core.mimetypes.MimeTypeService;
 import com.tle.core.mimetypes.dao.MimeEntryDao;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
@@ -43,6 +44,7 @@ public class MimeEntryConverter extends AbstractMigratableConverter<Object> {
 
   @Inject private MimeEntryDao mimeDao;
   @Inject private InitialiserService initialiserService;
+  @Inject private MimeTypeService mimeTypeService;
 
   @Override
   public void doDelete(Institution institution, ConverterParams callback) {
@@ -102,15 +104,14 @@ public class MimeEntryConverter extends AbstractMigratableConverter<Object> {
             @Override
             public void run() {
               MimeEntry mimeEntry = xmlHelper.readXmlFile(mimeFolder, entry);
-
               Map<String, String> attrs = mimeEntry.getAttributes();
-              Iterator<String> iter = attrs.values().iterator();
 
-              while (iter.hasNext()) {
-                if (Check.isEmpty(iter.next())) {
-                  iter.remove();
-                }
+              String enabledViewers = mimeTypeService.getEnabledViewerList(attrs);
+              if (!Check.isEmpty(enabledViewers)) {
+                attrs.put(MimeTypeConstants.KEY_ENABLED_VIEWERS, enabledViewers);
               }
+
+              attrs.values().removeIf(Check::isEmpty);
               mimeEntry.setInstitution(institution);
               mimeEntry.setId(0);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/mimetypes/section/MimeDefaultViewerSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/mimetypes/section/MimeDefaultViewerSection.java
@@ -225,6 +225,12 @@ public class MimeDefaultViewerSection
     }
   }
 
+  public boolean isDefaultViewerEnabled(SectionInfo info) {
+    String defaultViewerId = defaultViewer.getSelectedValueAsString(info);
+    Set<String> enabledViewerList = enabledViewers.getSelectedValuesAsStrings(info);
+    return enabledViewerList.contains(defaultViewerId);
+  }
+
   @Override
   public void saveEntry(SectionInfo info, MimeEntry entry) {
     String viewerId = defaultViewer.getSelectedValueAsString(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/mimetypes/section/MimeDefaultViewerSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/mimetypes/section/MimeDefaultViewerSection.java
@@ -291,6 +291,10 @@ public class MimeDefaultViewerSection
       HtmlBooleanState enabledState = enabledOption.getBooleanState();
       CheckboxRenderer enabledCheck = new CheckboxRenderer(enabledState);
 
+      if (defaultOption.getBooleanState().isChecked()) {
+        enabledState.setChecked(true);
+      }
+
       TextFieldRenderer configField =
           new TextFieldRenderer(viewerConfigs.getValueState(context, viewerId));
       configField.setHidden(true);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/mimetypes/section/MimeTypesEditSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/mimetypes/section/MimeTypesEditSection.java
@@ -67,7 +67,7 @@ import javax.inject.Inject;
 @SuppressWarnings("nls")
 public class MimeTypesEditSection extends AbstractPrototypeSection<MimeTypesEditModel>
     implements HtmlRenderer {
-  private static PluginResourceHelper resources =
+  private static final PluginResourceHelper resources =
       ResourcesService.getResourceHelper(MimeTypesEditSection.class);
   public static final NameValue TAB_DETAILS =
       new BundleNameValue(resources.key("tab.details"), "details");
@@ -79,6 +79,9 @@ public class MimeTypesEditSection extends AbstractPrototypeSection<MimeTypesEdit
 
   @PlugKey("add.pagetitle")
   private static Label ADD_TITLE_LABEL;
+
+  @PlugKey("mimetypes.default.viewer.not.enabled")
+  private static String DEFAULT_VIEWER_NOT_ENABLED;
 
   @PlugKey("edit.parentbreadcrumb.label")
   private static Label PARENT_BREADCRUMB_LABEL;
@@ -129,6 +132,14 @@ public class MimeTypesEditSection extends AbstractPrototypeSection<MimeTypesEdit
   public void save(final SectionInfo info) {
     MimeTypesEditModel model = getModel(info);
     try {
+      MimeDefaultViewerSection mimeDefaultViewerSection =
+          info.lookupSection(MimeDefaultViewerSection.class);
+      if (!mimeDefaultViewerSection.isDefaultViewerEnabled(info)) {
+        throw new InvalidDataException(
+            new ValidationError(
+                "defaultViewer", DEFAULT_VIEWER_NOT_ENABLED, DEFAULT_VIEWER_NOT_ENABLED));
+      }
+
       mimeService.saveOrUpdate(
           model.getEditId(),
           new MimeEntryChanges() {

--- a/oeq-ts-rest-api/src/MimeType.ts
+++ b/oeq-ts-rest-api/src/MimeType.ts
@@ -78,6 +78,7 @@ export type ViewerId =
   | 'qtiTestViewer'
   | 'tohtml'
   | 'toimg'
+  | 'flvViewer'
   | 'save';
 
 /**

--- a/oeq-ts-rest-api/src/MimeType.ts
+++ b/oeq-ts-rest-api/src/MimeType.ts
@@ -71,6 +71,7 @@ export type ViewerId =
   | 'externalToolViewer'
   | 'fancy'
   | 'file'
+  | 'flvViewer'
   | 'googledocviewer'
   | 'htmlFiveViewer'
   | 'kalturaViewer'
@@ -78,7 +79,6 @@ export type ViewerId =
   | 'qtiTestViewer'
   | 'tohtml'
   | 'toimg'
-  | 'flvViewer'
   | 'save';
 
 /**


### PR DESCRIPTION
#2707 

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

When attachment default viewer is not enabled, New Search UI complains that viewer detail is missing. To fix this issue, we need to do three things: 
1. fix existing data by a data migration;
2. fix imported data;
3. prevent users from saving a MIME type which does not enable its default viewer.

So a new function was added to the `MimeTypeService` to build the correct list of enabled viewers, and then this function is used in the new migration `EnableDefaultViewerMigration` and `MimeEntryConverter`. Lastly, UI side changes were made in `MimeDefaultViewerSection`.



Examples:

1. `video/x-flv`
Before migration: 
![image](https://user-images.githubusercontent.com/47203811/120422662-15a72980-c3ac-11eb-8c91-e7a1ff95d605.png)
after:
![image](https://user-images.githubusercontent.com/47203811/120422911-b1d13080-c3ac-11eb-92f8-7e69960353b1.png)


2. `image/jpeg`
Before migration:
![image](https://user-images.githubusercontent.com/47203811/120422819-79315700-c3ac-11eb-8839-4ce97422a6bc.png)
after:
![image](https://user-images.githubusercontent.com/47203811/120422881-a54cd800-c3ac-11eb-8c3b-0ef13714b8b2.png)


Show an error message when save without enabling default viewer.
![image](https://user-images.githubusercontent.com/47203811/120436258-0df27f80-c3c2-11eb-8d74-1c0d4ad53612.png)
