### PR TITLE
Reduce the length of the facetSearchClassificationInstitutionIndex name

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/facetedsearch/bean/FacetedSearchClassification.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/facetedsearch/bean/FacetedSearchClassification.java
@@ -41,7 +41,7 @@ public class FacetedSearchClassification {
 
   @JoinColumn(nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
-  @Index(name = "facetSearchClassificationInstitutionIndex")
+  @Index(name = "FSCInstitutionIndex")
   @XStreamOmitField
   private Institution institution;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
#3021 

This index is longer than 30 characters, which causes problems for Oracle Database 12c Release 1 or earlier. 
When Oracle Database 12c Release 2 was released they increased the character limit to 128. 
This seems to be the only place this index is referred to.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
