### PR TITLE
Feature/navigate attachments in gallery

### DIFF
--- a/react-front-end/__mocks__/GallerySearchModule.mock.ts
+++ b/react-front-end/__mocks__/GallerySearchModule.mock.ts
@@ -476,6 +476,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
           "http://localhost:8080/ian/api/item/fe79c485-a6dd-4743-81e8-52de66494633/1/",
       },
       mainEntry: {
+        id: "40e879db-393b-4256-bfe2-9a78771d6937",
         mimeType: "image/jpeg",
         name: "Kelpie1.jpg",
         thumbnailSmall:
@@ -497,6 +498,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
           "http://localhost:8080/ian/api/item/40e879db-393b-4256-bfe2-9a78771d6937/1/",
       },
       mainEntry: {
+        id: "40e879db-393b-4256-bfe2-9a78771d6932",
         mimeType: "image/jpeg",
         name: "Kelpie2.jpg",
         thumbnailSmall:
@@ -507,6 +509,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
       },
       additionalEntries: [
         {
+          id: "40e879db-393b-4256-bfe2-9a78771d6933",
           mimeType: "image/jpeg",
           name: "Kelpie1.jpg",
           thumbnailSmall:
@@ -528,6 +531,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
           "http://localhost:8080/ian/api/item/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/",
       },
       mainEntry: {
+        id: "40e879db-393b-4256-bfe2-9a78771d6930",
         mimeType: "image/jpeg",
         name: "Wilkie Collins.jpg",
         thumbnailSmall:
@@ -539,6 +543,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
       },
       additionalEntries: [
         {
+          id: "40e879db-393b-4256-bfe2-9a78771d6939",
           mimeType: "image/jpeg",
           name: "Dickens.jpg",
           thumbnailSmall:
@@ -548,6 +553,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
           directUrl: "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Dickens.jpg",
         },
         {
+          id: "40e879db-393b-4256-bfe2-9a78771d6938",
           mimeType: "image/jpeg",
           name: "Conrad.jpg",
           thumbnailSmall:
@@ -557,6 +563,7 @@ export const transformedBasicImageSearchResponse: OEQ.Search.SearchResult<Galler
           directUrl: "file/8d25bfcc-f877-4cb6-84cd-391a79c7c67a/1/Conrad.jpg",
         },
         {
+          id: "40e879db-393b-4256-bfe2-9a78771d6922",
           mimeType: "image/jpeg",
           name: "Eliot.jpg",
           thumbnailSmall:
@@ -587,6 +594,7 @@ export const transformedBasicVideoSearchResponse: OEQ.Search.SearchResult<Galler
           "http://localhost:8080/ian/api/item/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/",
       },
       mainEntry: {
+        id: "40e879db-393b-4256-bfe2-9a78771d6117",
         mimeType: "openequella/youtube",
         name: "6 Tips For Caring for African Violets",
         thumbnailSmall: "https://i.ytimg.com/vi/9VCudo90K5I/default.jpg",
@@ -606,6 +614,7 @@ export const transformedBasicVideoSearchResponse: OEQ.Search.SearchResult<Galler
           "http://localhost:8080/ian/api/item/59139c45-788b-4200-a9cb-e4a39e76ad35/1/",
       },
       mainEntry: {
+        id: "40e879db-393b-4256-bfe2-9a78771d1937",
         mimeType: "video/mp4",
         name: "Quokka-2021-03-24_14.42.37.mp4",
         thumbnailSmall:
@@ -628,6 +637,7 @@ export const transformedBasicVideoSearchResponse: OEQ.Search.SearchResult<Galler
           "http://localhost:8080/ian/api/item/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/",
       },
       mainEntry: {
+        id: "40e879db-393b-4256-bfe2-9a78773d6937",
         mimeType: "openequella/youtube",
         name:
           "These Simple Words Will Help You Through Life's Most Difficult Situations | Ryan Holiday",
@@ -637,6 +647,7 @@ export const transformedBasicVideoSearchResponse: OEQ.Search.SearchResult<Galler
       },
       additionalEntries: [
         {
+          id: "40e879db-393b-4256-bfe2-9a78771d6237",
           mimeType: "openequella/youtube",
           name: "Stoicism and the Art of Resilience | Ryan Holiday | Epictetus",
           thumbnailSmall: "https://i.ytimg.com/vi/6-UQYo1YabY/default.jpg",
@@ -644,6 +655,7 @@ export const transformedBasicVideoSearchResponse: OEQ.Search.SearchResult<Galler
           directUrl: "https://www.youtube.com/watch?v=6-UQYo1YabY",
         },
         {
+          id: "40e879db-393b-4256-bfe2-9a78771d5937",
           mimeType: "openequella/youtube",
           name:
             "Stoicism's Simple Secret To Being Happier | Ryan Holiday | Daily Stoic",

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -30,6 +30,7 @@ const {
   common: {
     action: { openInNewWindow },
   },
+  lightboxComponent: { viewNext, viewPrevious },
 } = languageStrings;
 
 /*
@@ -45,7 +46,7 @@ jest.mock("react-router", () => ({
 
 describe("<GallerySearchResult />", () => {
   const renderGallery = () =>
-    render(<GallerySearchResult items={buildItems(5)} />);
+    render(<GallerySearchResult items={buildItems(5)} />); // 16 entries in total.
 
   it("displays the lightbox when the image is clicked on", () => {
     const { getAllByLabelText, queryAllByLabelText } = renderGallery();
@@ -61,5 +62,25 @@ describe("<GallerySearchResult />", () => {
 
     expect(mockUseHistoryPush).toHaveBeenCalled();
     expect(mockUseHistoryPush.mock.calls[0][0].match("/items/")).toBeTruthy();
+  });
+
+  describe("viewing gallery entries in a loop", () => {
+    it.each([
+      ["first", "next", "last", 15, viewNext],
+      ["last", "previous", "first", 0, viewPrevious],
+    ])(
+      "shows the %s entry when navigate to the %s entry of the %s entry",
+      (
+        currentPosition: string,
+        direction: string,
+        newPosition: string,
+        index: number,
+        arrowButtonLabel: string
+      ) => {
+        const { getAllByLabelText, queryByLabelText } = renderGallery();
+        userEvent.click(getAllByLabelText(ariaLabel)[index]);
+        expect(queryByLabelText(arrowButtonLabel)).toBeInTheDocument();
+      }
+    );
   });
 });

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResultHelpers.ts
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResultHelpers.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../../tsrc/modules/GallerySearchModule";
 
 const buildGalleryEntry = (name: string): GalleryEntry => ({
+  id: "40e879db-393b-4256-bfe2-9a78771d6437",
   mimeType: "image/png",
   name,
   thumbnailSmall: "./placeholder-135x135.png",

--- a/react-front-end/tsrc/components/Lightbox.tsx
+++ b/react-front-end/tsrc/components/Lightbox.tsx
@@ -33,13 +33,7 @@ import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import { pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
 import * as React from "react";
-import {
-  ReactNode,
-  SyntheticEvent,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import { ReactNode, SyntheticEvent, useEffect, useState } from "react";
 import { Literal, match, Unknown } from "runtypes";
 import {
   CustomMimeTypes,
@@ -140,22 +134,17 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
   const [lightBoxConfig, setLightBoxConfig] = useState<LightboxConfig>(config);
   const { src, title, mimeType, onPrevious, onNext } = lightBoxConfig;
 
-  const handleOnPrevious = useCallback(() => {
+  const handleNav = (getLightboxConfig: () => LightboxConfig) => {
     setContent(undefined);
-    onPrevious && setLightBoxConfig(onPrevious());
-  }, [onPrevious]);
-
-  const handleOnNext = useCallback(() => {
-    setContent(undefined);
-    onNext && setLightBoxConfig(onNext());
-  }, [onNext]);
+    setLightBoxConfig(getLightboxConfig());
+  };
 
   useEffect(() => {
     const keyDownHandler = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
-        handleOnPrevious();
-      } else if (e.key === "ArrowRight") {
-        handleOnNext();
+      if (onPrevious && e.key === "ArrowLeft") {
+        handleNav(onPrevious);
+      } else if (onNext && e.key === "ArrowRight") {
+        handleNav(onNext);
       } else if (e.key === "Escape") {
         onClose();
       }
@@ -164,7 +153,7 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
     return () => {
       window.removeEventListener("keydown", keyDownHandler);
     };
-  }, [handleOnPrevious, handleOnNext, onClose]);
+  }, [onPrevious, onNext, onClose]);
 
   // Update content when config is updated.
   useEffect(() => {
@@ -298,7 +287,7 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
               title={viewPreviousString}
               onClick={(e) => {
                 e.stopPropagation();
-                handleOnPrevious();
+                handleNav(onPrevious);
               }}
             >
               <NavigateBeforeIcon className={classes.arrowButton} />
@@ -315,7 +304,7 @@ const Lightbox = ({ open, onClose, config }: LightboxProps) => {
                 title={viewNextString}
                 onClick={(e) => {
                   e.stopPropagation();
-                  handleOnNext();
+                  handleNav(onNext);
                 }}
               >
                 <NavigateNextIcon className={classes.arrowButton} />

--- a/react-front-end/tsrc/modules/GallerySearchModule.ts
+++ b/react-front-end/tsrc/modules/GallerySearchModule.ts
@@ -38,6 +38,10 @@ import * as yt from "./YouTubeModule";
  */
 export interface GalleryEntry {
   /**
+   * The ID of the attachment this points to.
+   */
+  id: string;
+  /**
    * The MIME type for the attachment being represented. Note however that it really only matches
    * the MIME type for `imagePathFull` - as thumbnails generated for small and medium seem to mainly
    * be `image/jpeg` regardless of input type.
@@ -243,6 +247,7 @@ export const buildGalleryEntry = (
   Do(E.either)
     .do(validateAttachmentType(attachment))
     .do(validateThumbnailRequirements(attachment))
+    .bind("id", E.right(attachment.id))
     .bind("mimeType", mimeType(attachment))
     .bind("name", E.right(attachment.description ?? attachment.id))
     .bind("thumbnailSmall", thumbnailLink(attachment, "small"))

--- a/react-front-end/tsrc/modules/ViewerModule.ts
+++ b/react-front-end/tsrc/modules/ViewerModule.ts
@@ -201,7 +201,7 @@ export const getViewerDefinitionForAttachment = (
 };
 
 /**
- * Build a function to handler navigation between Lightbox entries.
+ * Build a function to handle navigation between Lightbox entries.
  * @param entries A list of Attachment or GalleryEntry that can be viewed in Lightbox.
  * @param entryIndex Index of the current lightbox entry.
  * @param isLoopBack `true` to make the navigation looping.

--- a/react-front-end/tsrc/search/components/GallerySearchResult.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchResult.tsx
@@ -32,6 +32,10 @@ import {
   buildSelectionSessionItemSummaryLink,
   isSelectionSessionOpen,
 } from "../../modules/LegacySelectionSessionModule";
+import {
+  buildLightboxNavigationHandler,
+  LightboxEntry,
+} from "../../modules/ViewerModule";
 import { languageStrings } from "../../util/langstrings";
 
 const { ariaLabel, viewItem } = languageStrings.searchpage.gallerySearchResult;
@@ -96,6 +100,18 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
     </GridListTile>
   );
 
+  const lightboxEntries: LightboxEntry[] = items.flatMap(
+    ({ mainEntry, additionalEntries }) =>
+      [mainEntry, ...additionalEntries].map(
+        ({ id, name, mimeType, directUrl }) => ({
+          src: directUrl,
+          title: name,
+          mimeType: mimeType,
+          id,
+        })
+      )
+  );
+
   const mapItemsToTiles = () =>
     items.flatMap(
       ({
@@ -110,7 +126,11 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
           mimeType,
           directUrl: src,
           name,
-        }: GalleryEntry) => () =>
+          id,
+        }: GalleryEntry) => () => {
+          const initialLightboxEntryIndex = lightboxEntries.findIndex(
+            (entry) => entry.id === id
+          );
           setLightboxProps({
             onClose: () => setLightboxProps(undefined),
             open: true,
@@ -118,8 +138,19 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
               src,
               title: name,
               mimeType,
+              onNext: buildLightboxNavigationHandler(
+                lightboxEntries,
+                initialLightboxEntryIndex + 1,
+                true
+              ),
+              onPrevious: buildLightboxNavigationHandler(
+                lightboxEntries,
+                initialLightboxEntryIndex - 1,
+                true
+              ),
             },
           });
+        };
 
         return [
           buildTile(

--- a/react-front-end/tsrc/search/components/GallerySearchResult.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchResult.tsx
@@ -100,6 +100,7 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
     </GridListTile>
   );
 
+  // A list of LightboxEntry which includes all main entries and additional entries.
   const lightboxEntries: LightboxEntry[] = items.flatMap(
     ({ mainEntry, additionalEntries }) =>
       [mainEntry, ...additionalEntries].map(
@@ -112,6 +113,37 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
       )
   );
 
+  const buildOnClickHandler = ({
+    mimeType,
+    directUrl: src,
+    name,
+    id,
+  }: GalleryEntry) => () => {
+    const initialLightboxEntryIndex = lightboxEntries.findIndex(
+      (entry) => entry.id === id
+    );
+
+    setLightboxProps({
+      onClose: () => setLightboxProps(undefined),
+      open: true,
+      config: {
+        src,
+        title: name,
+        mimeType,
+        onNext: buildLightboxNavigationHandler(
+          lightboxEntries,
+          initialLightboxEntryIndex + 1,
+          true
+        ),
+        onPrevious: buildLightboxNavigationHandler(
+          lightboxEntries,
+          initialLightboxEntryIndex - 1,
+          true
+        ),
+      },
+    });
+  };
+
   const mapItemsToTiles = () =>
     items.flatMap(
       ({
@@ -122,35 +154,6 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
         version,
       }: GallerySearchResultItem) => {
         const itemName = name ?? uuid;
-        const buildOnClickHandler = ({
-          mimeType,
-          directUrl: src,
-          name,
-          id,
-        }: GalleryEntry) => () => {
-          const initialLightboxEntryIndex = lightboxEntries.findIndex(
-            (entry) => entry.id === id
-          );
-          setLightboxProps({
-            onClose: () => setLightboxProps(undefined),
-            open: true,
-            config: {
-              src,
-              title: name,
-              mimeType,
-              onNext: buildLightboxNavigationHandler(
-                lightboxEntries,
-                initialLightboxEntryIndex + 1,
-                true
-              ),
-              onPrevious: buildLightboxNavigationHandler(
-                lightboxEntries,
-                initialLightboxEntryIndex - 1,
-                true
-              ),
-            },
-          });
-        };
 
         return [
           buildTile(

--- a/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -55,6 +55,7 @@ import {
   AttachmentAndViewerDefinition,
   buildLightboxNavigationHandler,
   getViewerDefinitionForAttachment,
+  LightboxEntry,
 } from "../../modules/ViewerModule";
 import { languageStrings } from "../../util/langstrings";
 import { ResourceSelector } from "./ResourceSelector";
@@ -176,15 +177,25 @@ export const SearchResultAttachmentsList = ({
         )
       );
 
-      const lightboxAttachments = attachmentsAndViewerDefinitions.filter(
-        ({ viewerDefinition: [viewer] }) => viewer === "lightbox"
-      );
+      const lightboxEntries: LightboxEntry[] = attachmentsAndViewerDefinitions
+        .filter(({ viewerDefinition: [viewer] }) => viewer === "lightbox")
+        .map(
+          ({
+            attachment: { id, description, mimeType },
+            viewerDefinition: [_, src],
+          }) => ({
+            src,
+            title: description,
+            mimeType: mimeType ?? "",
+            id,
+          })
+        );
 
       // Transform AttachmentAndViewerDefinition to AttachmentAndViewerConfig.
       const attachmentsAndConfigs: AttachmentAndViewerConfig[] = attachmentsAndViewerDefinitions.map(
         ({ viewerDefinition: [viewer, viewUrl], attachment }) => {
-          const lightboxAttachmentIndex = lightboxAttachments.findIndex(
-            (a) => a.attachment.id === attachment.id
+          const initialLightboxEntryIndex = lightboxEntries.findIndex(
+            (entry) => entry.id === attachment.id
           );
           return viewer === "lightbox"
             ? {
@@ -196,12 +207,12 @@ export const SearchResultAttachmentsList = ({
                     title: attachment.description,
                     mimeType: attachment.mimeType ?? "",
                     onNext: buildLightboxNavigationHandler(
-                      lightboxAttachments,
-                      lightboxAttachmentIndex + 1
+                      lightboxEntries,
+                      initialLightboxEntryIndex + 1
                     ),
                     onPrevious: buildLightboxNavigationHandler(
-                      lightboxAttachments,
-                      lightboxAttachmentIndex - 1
+                      lightboxEntries,
+                      initialLightboxEntryIndex - 1
                     ),
                   },
                 },


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for viewing previous/next attachments with Lightbox in Gallery mode. The function used to build the handler for `onNext` and `onPrevious` was focused on `Attachment` so it did not support `GalleryEntry` very well. So I refactored this function to support both.

During implementation, Sam found a bug where if you are on the first/last image and you press the left/right arrow button you will see a blank Lightbox. The fix is also added in this PR.


https://user-images.githubusercontent.com/47203811/121481993-052c2a00-ca10-11eb-82f1-182278a90282.mp4



