### PR TITLE
Make dead attachments not draggable

### DIFF
--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -435,6 +435,25 @@ describe("<SearchResult/>", () => {
       });
     });
 
+    it("should not make broken attachments draggable", async () => {
+      updateMockGetRenderData(basicRenderData);
+      await renderSearchResult(mockData.oneDeadOneAliveAttachObj);
+
+      const deadAttachment = mockData.oneDeadOneAliveAttachObj.attachments![0];
+      const intactAttachment = mockData.oneDeadOneAliveAttachObj
+        .attachments![1];
+
+      //expect intact attachment to be draggable
+      expect(
+        getGlobalCourseList().prepareDraggableAndBind
+      ).toHaveBeenCalledWith(`#${intactAttachment.id}`, false);
+
+      //expect dead attachment not to be draggable
+      expect(
+        getGlobalCourseList().prepareDraggableAndBind
+      ).not.toHaveBeenCalledWith(`#${deadAttachment.id}`, false);
+    });
+
     it("should hide All attachment button in Skinny", async () => {
       updateMockGetRenderData(renderDataForSkinny);
       const { queryByLabelText } = await renderSearchResult(

--- a/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -122,12 +122,14 @@ export const SearchResultAttachmentsList = ({
     setAttachmentsAndViewerConfigs,
   ] = useState<AttachmentAndViewerConfig[]>([]);
 
-  // In Selection Session, make each attachment draggable.
+  // In Selection Session, make each intact attachment draggable.
   useEffect(() => {
     if (inStructured) {
-      attachmentsAndViewerConfigs.forEach(({ attachment }) => {
-        prepareDraggable(attachment.id, false);
-      });
+      attachmentsAndViewerConfigs
+        .filter(({ attachment }) => attachment.brokenAttachment === false)
+        .forEach(({ attachment }) => {
+          prepareDraggable(attachment.id, false);
+        });
     }
   }, [attachmentsAndViewerConfigs, inStructured]);
 

--- a/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -126,7 +126,7 @@ export const SearchResultAttachmentsList = ({
   useEffect(() => {
     if (inStructured) {
       attachmentsAndViewerConfigs
-        .filter(({ attachment }) => attachment.brokenAttachment === false)
+        .filter(({ attachment }) => !attachment.brokenAttachment)
         .forEach(({ attachment }) => {
           prepareDraggable(attachment.id, false);
         });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change
#3044 
Caught during testing, we weren't omitting the dead attachments from prepareDraggable, so even though the select button was missing you could still drag n drop a dead attachment in a selection session.
Simply filtered the list that gets passed in to not include dead attachments.

Also surrounded with a Jest Test to ensure this doesn't happen again. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
