### PR TITLE
Update @tinymce/tinymce-react to 3.12.6

### DIFF
--- a/react-front-end/package-lock.json
+++ b/react-front-end/package-lock.json
@@ -3535,7 +3535,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0"
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {
@@ -5239,12 +5240,12 @@
       }
     },
     "@tinymce/tinymce-react": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-3.8.4.tgz",
-      "integrity": "sha512-wk9UTyuopeSs2UPxfMY2t4ZK4094aH7bfbHz+kAoHQ/lAQB01qojM9Khsg9dGwlMg8ZmUcvQdoiAOwYNUztKww==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-3.12.6.tgz",
+      "integrity": "sha512-a7/Ns7uVsSr2N0fCxn+OhDx8f9JqfywTlHbXsgcwlWB6vIBMIjjRBJ6PGo/5H0y2vfzO6fBzd4gc6h05Cm5R7A==",
       "requires": {
         "prop-types": "^15.6.2",
-        "tinymce": "^5.6.2"
+        "tinymce": "^5.5.1"
       }
     },
     "@tootallnate/once": {
@@ -17430,6 +17431,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -23983,7 +23991,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0"
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -34,7 +34,7 @@
     "@material-ui/lab": "4.0.0-alpha.58",
     "@material-ui/pickers": "3.3.10",
     "@openequella/rest-api-client": "file:../oeq-ts-rest-api",
-    "@tinymce/tinymce-react": "3.8.4",
+    "@tinymce/tinymce-react": "3.12.6",
     "axios": "0.21.1",
     "clsx": "1.1.1",
     "es6-object-assign": "1.1.0",

--- a/react-front-end/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/react-front-end/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -239,7 +239,7 @@ class PreLoginNoticeConfigurator extends React.Component<
             <Grid item>
               <React.Suspense fallback={<div>Loading editor...</div>}>
                 <RichTextEditor
-                  htmlInput={this.state.db.notice}
+                  htmlInput={this.state.current.notice}
                   onStateChange={this.handleEditorChange}
                   imageUploadCallBack={uploadPreLoginNoticeImage}
                 />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included (tests already existed and didn't need to change)

##### Description of change
This came from #2435  - since I made a code change I'm making a new PR.
This branch failed because the Editor became completely non-interactible, typing would do nothing. 
This is because the `htmlInput` prop we were using plugs into the Editor's value parameter. In previous versions, 
this would work as an _initial_ value - every edit would run the `onStateChange` callback but `htmlInput` didn't need to change. 

Now, this works as a standard controlled component and `htmlInput` _is_ the value - meaning if it doesn't update, TinyMCE won't either. We were already holding state for this in this.state.current.notice, for `preventNavigation` checks - it just needs feeding back in.

As `this.state.current.notice` is initialized at the same time as `this.state.db.notice`, we don't need to change any of the initializing code. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
