### PR TITLE
chore: include Kaltura Upload control CSS in new UI

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/core/plugins/AbstractPluginService.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/core/plugins/AbstractPluginService.java
@@ -190,6 +190,10 @@ public abstract class AbstractPluginService extends PluginClassResolver implemen
     }
   }
 
+  public boolean isActivated(String pluginId) {
+    return pluginManager.getRegistry().isPluginDescriptorAvailable(pluginId);
+  }
+
   @SuppressWarnings("nls")
   @Override
   public ExtensionPoint getExtensionPoint(String pluginId, String pointId) {

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/core/plugins/PluginService.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/core/plugins/PluginService.java
@@ -52,6 +52,16 @@ public interface PluginService {
 
   void ensureActivated(PluginDescriptor plugin);
 
+  /**
+   * Check if a plugin is activated.
+   *
+   * @param pluginId The ID of plugin
+   * @return `true` if plugin available otherwise false
+   */
+  default boolean isActivated(String pluginId) {
+    throw new UnsupportedOperationException();
+  }
+
   void registerExtensionListener(
       String pluginId, String extensionId, RegistryChangeListener listener);
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -19,14 +19,14 @@
 package com.tle.web.template
 
 import java.util.concurrent.ConcurrentHashMap
-
 import com.tle.common.i18n.{CurrentLocale, LocaleUtils}
 import com.tle.common.settings.standard.QuickContributeAndVersionSettings
 import com.tle.core.i18n.LocaleLookup
+import com.tle.core.plugins.AbstractPluginService
 import com.tle.legacy.LegacyGuice
 import com.tle.web.DebugSettings
 import com.tle.web.freemarker.FreemarkerFactory
-import com.tle.web.resources.ResourcesService
+import com.tle.web.resources.{ResourcesService}
 import com.tle.web.sections._
 import com.tle.web.sections.equella.ScalaSectionRenderable
 import com.tle.web.sections.events._
@@ -36,6 +36,7 @@ import com.tle.web.sections.js.generic.function.IncludeFile
 import com.tle.web.sections.render._
 import com.tle.web.selection.section.RootSelectionSection
 import com.tle.web.integration.IntegrationSection
+import com.tle.web.sections.render.CssInclude.{Priority, include}
 import com.tle.web.selection.section.RootSelectionSection.Layout
 import com.tle.web.settings.UISettings
 import javax.servlet.http.HttpServletRequest
@@ -82,9 +83,22 @@ object RenderNewTemplate {
       supportIEPolyFills(info)
       info.preRender(bundleJs)
       links.foreach(l => info.addCss(r.url(l.attr("href"))))
+      addKalturaCss(info)
       info.addCss(RenderTemplate.CUSTOMER_CSS)
     }
     (prerender, htmlDoc)
+  }
+
+  def addKalturaCss(info: PreRenderContext): Unit = {
+    val kalturaPluginId = "com.tle.web.wizard.controls.kaltura"
+    val pluginService   = AbstractPluginService.get()
+    if (pluginService.isActivated(kalturaPluginId)) {
+      info.addCss(
+        include(
+          ResourcesService
+            .getResourceHelper(kalturaPluginId)
+            .url("js/UploadControlEntry.css")).priority(Priority.LOWEST).make())
+    }
   }
 
   val NewLayoutKey = "NEW_LAYOUT"


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

We only want to include the CSS file when Kaltura Plugin is activated. In order to do this, add a new method to
support checking if a plugin is activated.


When Kaltura is activated: 
![Screenshot from 2021-06-24 12-06-29](https://user-images.githubusercontent.com/47203811/123191531-bdfc6980-d4e4-11eb-8fbc-ffd101137b34.png)

When it is not acitivated:
![Screenshot from 2021-06-24 12-02-22](https://user-images.githubusercontent.com/47203811/123191548-c5237780-d4e4-11eb-814d-a9fcf1c0e9d6.png)

