### PR TITLE
Exclude YouTube preview player from legacy.scss Reset rule

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -334,7 +334,6 @@ body,
 div,
 span,
 applet,
-iframe:not[title="YouTube video player"],
 h1,
 h2,
 h3,
@@ -403,6 +402,19 @@ select {
   background: transparent;
   font-family: "Roboto";
 }
+iframe:not[title="YouTube video player"]{
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+  background: transparent;
+  font-family: "Roboto";
+}
+
 ul {
   list-style: none;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -328,7 +328,7 @@ Animations
   }
 }
 
-//need to explicitly exclude youtube preview iframe
+// need to explicitly exclude youtube preview iframe
 html,
 body,
 div,
@@ -354,6 +354,7 @@ del,
 dfn,
 em,
 font,
+iframe:not(.skip-css-reset),
 ins,
 kbd,
 q,
@@ -391,18 +392,6 @@ tr,
 th,
 td,
 select {
-  width: auto;
-  height: auto;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  outline: 0;
-  font-size: 100%;
-  vertical-align: baseline;
-  background: transparent;
-  font-family: "Roboto";
-}
-iframe:not[title="YouTube video player"] {
   width: auto;
   height: auto;
   margin: 0;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -402,7 +402,7 @@ select {
   background: transparent;
   font-family: "Roboto";
 }
-iframe:not[title="YouTube video player"]{
+iframe:not[title="YouTube video player"] {
   width: auto;
   height: auto;
   margin: 0;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -328,12 +328,13 @@ Animations
   }
 }
 
+//need to explicitly exclude youtube preview iframe
 html,
 body,
 div,
 span,
 applet,
-iframe,
+iframe:not[title="YouTube video player"],
 h1,
 h2,
 h3,

--- a/react-front-end/tsrc/components/YouTubeEmbed.tsx
+++ b/react-front-end/tsrc/components/YouTubeEmbed.tsx
@@ -46,6 +46,7 @@ export interface YouTubeEmbedProps {
  */
 const YouTubeEmbed = ({ dimensions, videoId }: YouTubeEmbedProps) => (
   <iframe
+    className="skip-css-reset"
     width={dimensions?.width ?? 560}
     height={dimensions?.height ?? 315}
     src={`https://www.youtube-nocookie.com/embed/${videoId}`}


### PR DESCRIPTION
Make sure the reset rule in legacy.scss doesn't apply to the youtube preview iframe,
as width:auto and height:auto cause the preview to render incorrectly.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes

##### Description of change
#2934 
The small YouTube preview panel was caused by the "Reset rule" at the top of legacy.scss. This reset rule is designed to unset any rules that apply to common tags and replace them with an openEQUELLA default value.
```css
html,
body,
div,
span,
applet,
iframe,
h1,
h2,
h3,
h4,
h5,
h6,
p,
blockquote,
pre,
a,
abbr,
acronym,
address,
big,
cite,
code,
del,
dfn,
em,
font,
ins,
kbd,
q,
s,
samp,
small,
strike,
strong,
sub,
sup,
tt,
var,
b,
u,
i,
center,
dl,
dt,
dd,
ol,
ul,
li,
fieldset,
form,
label,
legend,
input,
textarea,
table,
caption,
tbody,
tfoot,
thead,
tr,
th,
td,
select {
  width: auto;
  height: auto;
  margin: 0;
  padding: 0;
  border: 0;
  outline: 0;
  font-size: 100%;
  vertical-align: baseline;
  background: transparent;
  font-family: "Roboto";
}
```
 
However - this applied to iframe, causing the YouTube preview player to be styled incorrectly.

Whenever legacy.css is present in the browser at the time of a YouTube preview, it will render incorrectly like this:
![image](https://user-images.githubusercontent.com/24543345/123888147-2d1b0780-d996-11eb-9a69-caa513509060.png)

To avoid this, I have added a className to the YoutubeEmbed iframe `skip-css-reset`, and then I check for this in the CSS Reset rule.
```css
...
iframe:not(.skip-css-reset),
...
```

This fixes the issue. 

![image](https://user-images.githubusercontent.com/24543345/123888455-e2e65600-d996-11eb-9557-c675769da52b.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
