### PR TITLE
Feature/add Item DRM settings to search2 API

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -306,7 +306,7 @@ object SearchHelper {
     for {
       item <- Option(LegacyGuice.itemService.getUnsecureIfExists(itemKey))
       _    <- Option(item.getDrmSettings)
-      termAccepted = LegacyGuice.drmService.hasAcceptedOrRequiresNoAcceptance(item, false, false)
+      termsAccepted = LegacyGuice.drmService.hasAcceptedOrRequiresNoAcceptance(item, false, false)
       isAuthorised = try {
         LegacyGuice.drmService.isAuthorised(item, CurrentUser.getUserState.getIpAddress)
         true
@@ -314,7 +314,7 @@ object SearchHelper {
         case _: DRMException => false
       }
     } yield {
-      DrmStatus(termAccepted, isAuthorised)
+      DrmStatus(termsAccepted, isAuthorised)
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -306,7 +306,12 @@ object SearchHelper {
     for {
       item <- Option(LegacyGuice.itemService.getUnsecureIfExists(itemKey))
       _    <- Option(item.getDrmSettings)
-      termsAccepted = LegacyGuice.drmService.hasAcceptedOrRequiresNoAcceptance(item, false, false)
+      termsAccepted = try {
+        LegacyGuice.drmService.hasAcceptedOrRequiresNoAcceptance(item, false, false)
+      } catch {
+        // This exception is only thrown when the DRM has maximum number of acceptance allowable times.
+        case _: DRMException => false
+      }
       isAuthorised = try {
         LegacyGuice.drmService.isAuthorised(item, CurrentUser.getUserState.getIpAddress)
         true

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -304,7 +304,8 @@ object SearchHelper {
   }
 
   def getItemDrmSettings(itemKey: ItemIdKey): Option[SearchResultItemDrm] = {
-    val item = LegacyGuice.itemService.getItemPack(itemKey).getItem
+    // 'getUnsecure' will throw an ItemNotFoundException if there are no items matching the item key.
+    val item = LegacyGuice.itemService.getUnsecure(itemKey)
     // If an Item is not protected by DRM or the DRM has been accepted, 'requiresAcceptance' returns null.
     Option(LegacyGuice.drmService.requiresAcceptance(item, false, false))
       .map(drm => SearchResultItemDrm(drm))

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -40,7 +40,12 @@ import com.tle.web.api.item.equella.interfaces.beans.{
   FileAttachmentBean
 }
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
-import com.tle.web.api.search.model.{SearchParam, SearchResultAttachment, SearchResultItem}
+import com.tle.web.api.search.model.{
+  SearchParam,
+  SearchResultAttachment,
+  SearchResultItem,
+  SearchResultItemDrm
+}
 import com.tle.web.controls.resource.ResourceAttachmentBean
 import com.tle.web.controls.youtube.YoutubeAttachmentBean
 
@@ -262,6 +267,7 @@ object SearchHelper {
       links = getLinksFromBean(bean),
       bookmarkId = getBookmarkId(key),
       isLatestVersion = isLatestVersion(key),
+      drmSettings = getItemDrmSettings(item.idKey)
     )
   }
 
@@ -295,6 +301,13 @@ object SearchHelper {
             )
           })
           .toList)
+  }
+
+  def getItemDrmSettings(itemKey: ItemIdKey): Option[SearchResultItemDrm] = {
+    val item = LegacyGuice.itemService.getItemPack(itemKey).getItem
+    // If an Item is not protected by DRM or the DRM has been accepted, 'requiresAcceptance' returns null.
+    Option(LegacyGuice.drmService.requiresAcceptance(item, false, false))
+      .map(drm => SearchResultItemDrm(drm))
   }
 
   def getItemComments(key: ItemIdKey): Option[java.util.List[Comment]] =

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -18,12 +18,9 @@
 
 package com.tle.web.api.search.model
 
-import com.tle.beans.item.DrmSettings
 import java.util.Date
 import com.tle.common.interfaces.I18NString
 import com.tle.web.api.item.equella.interfaces.beans.{DisplayField, DisplayOptions}
-import com.tle.web.viewitem.I18nDRM
-import scala.collection.JavaConverters._
 
 /**
   * This model class includes an item's information required in the new Search page.
@@ -45,6 +42,7 @@ import scala.collection.JavaConverters._
   * @param links Item's links.
   * @param bookmarkId ID of Bookmark linking to this Item.
   * @param isLatestVersion True if this version is the latest version.
+  * @param drmStatus Status of Item's DRM, consisting if terms accepted and if authorised
   */
 case class SearchResultItem(
     uuid: String,
@@ -65,7 +63,7 @@ case class SearchResultItem(
     links: java.util.Map[String, String],
     bookmarkId: Option[Long],
     isLatestVersion: Boolean,
-    drmSettings: Option[SearchResultItemDrm]
+    drmStatus: Option[DrmStatus]
 )
 
 /**
@@ -94,43 +92,10 @@ case class SearchResultAttachment(
     filePath: Option[String]
 )
 
-case class DrmParties(attributeOwnersText: String, details: List[String])
-
-case class SearchResultItemDrm(terms: Option[String],
-                               permission1: Option[String],
-                               permission2: Option[String],
-                               educationSector: Option[String],
-                               parties: Option[DrmParties])
-object SearchResultItemDrm {
-  def apply(drmSettings: DrmSettings): SearchResultItemDrm = {
-    val drmI18n = new I18nDRM(drmSettings)
-
-    val terms = Option(drmI18n.getTerms) match {
-      case Some(t) if t.trim.nonEmpty => Option(s"${drmI18n.getTermsText} \n $t")
-      case _                          => None
-    }
-
-    val permission1 = Option(drmI18n.getPermissions1List) match {
-      case Some(p) if p.nonEmpty => Option(s"${drmI18n.getItemMayFreelyBeText} $p")
-      case _                     => None
-    }
-
-    val permission2 = Option(drmI18n.getPermissions2List) match {
-      case Some(p) if p.nonEmpty => Option(s"${drmI18n.getAdditionallyUserMayText} $p")
-      case _                     => None
-    }
-
-    val educationSector =
-      if (drmI18n.isUseEducation) Option(drmI18n.getEducationSectorText) else None
-
-    val parties = if (drmI18n.isAttribution && !drmI18n.getParties.isEmpty) {
-      Option(
-        DrmParties(drmI18n.getAttributeOwnersText,
-                   drmI18n.getParties.asScala.map(p => s"${p.getName} ${p.getEmail}").toList))
-    } else {
-      None
-    }
-
-    SearchResultItemDrm(terms, permission1, permission2, educationSector, parties)
-  }
-}
+/**
+  * Model class providing DRM related status.
+  *
+  * @param termAccepted Whether terms have been accepted or not.
+  * @param isAuthorised Whether user is authorised to access Item or accept DRM.
+  */
+case class DrmStatus(termAccepted: Boolean, isAuthorised: Boolean)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -94,7 +94,7 @@ case class SearchResultAttachment(
     filePath: Option[String]
 )
 
-case class DrmParties(attributeOwnersText: String, parties: List[String])
+case class DrmParties(attributeOwnersText: String, details: List[String])
 
 case class SearchResultItemDrm(terms: Option[String],
                                permission1: Option[String],

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -42,7 +42,7 @@ import com.tle.web.api.item.equella.interfaces.beans.{DisplayField, DisplayOptio
   * @param links Item's links.
   * @param bookmarkId ID of Bookmark linking to this Item.
   * @param isLatestVersion True if this version is the latest version.
-  * @param drmStatus Status of Item's DRM, consisting if terms accepted and if authorised
+  * @param drmStatus Status of Item's DRM, consisting if terms accepted and if authorised, absent if item not DRM controlled.
   */
 case class SearchResultItem(
     uuid: String,
@@ -95,7 +95,7 @@ case class SearchResultAttachment(
 /**
   * Model class providing DRM related status.
   *
-  * @param termAccepted Whether terms have been accepted or not.
+  * @param termsAccepted Whether terms have been accepted or not.
   * @param isAuthorised Whether user is authorised to access Item or accept DRM.
   */
-case class DrmStatus(termAccepted: Boolean, isAuthorised: Boolean)
+case class DrmStatus(termsAccepted: Boolean, isAuthorised: Boolean)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -42,6 +42,7 @@ import com.tle.core.item.edit.attachment.AbstractAttachmentEditor;
 import com.tle.core.item.helper.ItemHelper;
 import com.tle.core.item.serializer.ItemSerializerService;
 import com.tle.core.item.serializer.impl.AttachmentSerializerProvider;
+import com.tle.core.item.service.DrmService;
 import com.tle.core.item.service.ItemService;
 import com.tle.core.item.standard.service.ItemCommentService;
 import com.tle.core.jackson.ObjectMapperService;
@@ -131,6 +132,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static DateFormatSettingsPrivilegeTreeProvider datePrivProvider;
 
   @Inject public static DiagnosticsSettingsPrivilegeTreeProvider diagnosticPrivProvider;
+
+  @Inject public static DrmService drmService;
 
   @Inject public static DynaCollectionService dynaCollectionService;
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -2,6 +2,7 @@ package io.github.openequella.rest;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
@@ -190,6 +191,12 @@ public class Search2ApiTest extends AbstractRestApiTest {
         doSearch(
             200, null, new NameValuePair("musts", "uuid:ab16b5f0-a12e-43f5-9d8b-25870528ad41"));
     assertEquals(getAvailable(result), 1);
+  }
+
+  @Test(description = "Search result should include DRM status for Items that have DRM")
+  public void drmStatus() throws IOException {
+    JsonNode result = doSearch(200, "ItemApiViewTest - DRM and versioning v2");
+    assertNotNull(result.get("results").get(0).get("drmStatus"));
   }
 
   @DataProvider(name = "badMustExpressions")

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -223,38 +223,17 @@ export interface Attachment {
 }
 
 /**
- * Details of an Item's DRM settings.
+ * Status of Item's DRM.
  */
-export interface ItemDrmSettings {
+export interface DrmStatus {
   /**
-   * Terms that users must accept in order to view the Item.
+   * `true` if DRM terms have been accepted.
    */
-  terms?: string;
+  termAccepted: boolean;
   /**
-   * Actions that users are allowed to perform on the Item.
+   * `true` if user is authorised to access Item or accept DRM.
    */
-  permission1?: string;
-  /**
-   * Additional actions that users are allowed to perform.
-   */
-  permission2?: string;
-  /**
-   * Server-side language string describing this item is strictly restricted to the educational sector.
-   */
-  educationSector?: string;
-  /**
-   * A list of parties related to the Item.
-   */
-  parties?: {
-    /**
-     * Server-side Language string for listing DRM parties.
-     */
-    attributeOwnersText: string;
-    /**
-     * A list of party names and email addresses.
-     */
-    details: string[];
-  };
+  isAuthorised: boolean;
 }
 
 /**
@@ -335,9 +314,9 @@ interface SearchResultItemBase {
    */
   isLatestVersion: boolean;
   /**
-   * Item's DRM settings. Undefined when Item doesn't have DRM settings or the DRM has been accepted.
+   * Item's DRM Status.
    */
-  drmSettings?: ItemDrmSettings;
+  drmStatus?: DrmStatus;
 }
 
 /**

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -223,6 +223,41 @@ export interface Attachment {
 }
 
 /**
+ * Details of an Item's DRM settings.
+ */
+export interface ItemDrmSettings {
+  /**
+   * Terms that users must accept in order to view the Item.
+   */
+  terms?: string;
+  /**
+   * Actions that users are allowed to do for the Item.
+   */
+  permission1?: string;
+  /**
+   * Additional actions that users are allowed to do.
+   */
+  permission2?: string;
+  /**
+   * Server-side language string describing this item is strictly restricted to the educational sector.
+   */
+  educationSector?: string;
+  /**
+   * A list of parties related to the Item.
+   */
+  parties?: {
+    /**
+     * Server-side Language string for listing DRM parties.
+     */
+    attributeOwnersText: string;
+    /**
+     * A list of party names and email addresses.
+     */
+    details: string[];
+  };
+}
+
+/**
  * Shared properties or raw and transformed search result item
  */
 interface SearchResultItemBase {
@@ -299,6 +334,10 @@ interface SearchResultItemBase {
    * True if this version is the latest version.
    */
   isLatestVersion: boolean;
+  /**
+   * Item's DRM settings. Undefined when Item doesn't have DRM settings or the DRM has been accepted.
+   */
+  drmSettings?: ItemDrmSettings;
 }
 
 /**

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -231,11 +231,11 @@ export interface ItemDrmSettings {
    */
   terms?: string;
   /**
-   * Actions that users are allowed to do for the Item.
+   * Actions that users are allowed to perform on the Item.
    */
   permission1?: string;
   /**
-   * Additional actions that users are allowed to do.
+   * Additional actions that users are allowed to perform.
    */
   permission2?: string;
   /**

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -229,7 +229,7 @@ export interface DrmStatus {
   /**
    * `true` if DRM terms have been accepted.
    */
-  termAccepted: boolean;
+  termsAccepted: boolean;
   /**
    * `true` if user is authorised to access Item or accept DRM.
    */
@@ -314,7 +314,7 @@ interface SearchResultItemBase {
    */
   isLatestVersion: boolean;
   /**
-   * Item's DRM Status.
+   * Item's DRM Status. Absent if item is not under DRM control
    */
   drmStatus?: DrmStatus;
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds one optional field for Item DRM settings on both server and client. 

On server, I added a couple case classes to represent DRM settings and extended `SearchResultItem` to include DRM settings.

On client, I updated type definitions to match server side changes.

In terms of what specific DRM settings are included, I looked into `terms.ftl` and add whatever this template may render to the new field. Due to my limited experience of DRM, there may be more DRM settings we need to include in future work. 

With this approach, we don't need another endpoint to retrieve terms.


https://user-images.githubusercontent.com/47203811/124223575-5038e900-db47-11eb-926c-5457d492f37c.mp4


