### PR TITLE
chore: migrate husky config to version 7

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:ts-types-source": "tsc --noEmit --project react-front-end/tsconfig.json",
     "check:ts-types-autotest": "tsc --noEmit --project \"autotest/IntegTester/ps/tsconfig.json\"",
     "check": "run-s check:*",
-    "format": "run-s format:*"
+    "format": "run-s format:*",
+    "prepare": "husky install"
   },
   "config": {
     "stylesheet_glob": "Source/Plugins/Core/com.equella.core/{js,resources}/**/*.{css,scss}",
@@ -47,11 +48,6 @@
     "remark-lint-no-dead-urls": "1.1.0",
     "remark-validate-links": "10.0.4",
     "typescript": "4.3.5"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --fix",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

There was a renovate upgrade and automerge of Husky from 4.x to 7.x over
night. However this should've also included a migration of the husky
configuration as the approach has drastically changed.

See more at:

https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v7

(Note: Build status - after checks have passed - is irrelevant for this PR.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
