### PR TITLE
refactor(react-front-end): Break out SearchPage's reducer

### DIFF
--- a/react-front-end/__mocks__/searchOptions.mock.ts
+++ b/react-front-end/__mocks__/searchOptions.mock.ts
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 import { getCollectionMap } from "../__mocks__/getCollectionsResp";
-import type { SearchPageOptions } from "../tsrc/search/SearchPage";
-import { defaultSearchPageOptions } from "../tsrc/search/SearchPageHelper";
+import {
+  defaultSearchPageOptions,
+  SearchPageOptions,
+} from "../tsrc/search/SearchPageHelper";
 import { getMimeTypeFilters } from "./MimeTypeFilter.mock";
 import { users } from "./UserSearch.mock";
 

--- a/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
@@ -48,11 +48,11 @@ import {
   getSearchResultsCustom,
 } from "../../../__mocks__/SearchResult.mock";
 import { getCurrentUserMock } from "../../../__mocks__/UserModule.mock";
-import * as SearchModule from "../../../tsrc/modules/SearchModule";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import * as AdvancedSearchModule from "../../../tsrc/modules/AdvancedSearchModule";
-import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
+import * as BrowserStorageModule from "../../../tsrc/modules/BrowserStorageModule";
 import type { Collection } from "../../../tsrc/modules/CollectionsModule";
+import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import * as FavouriteModule from "../../../tsrc/modules/FavouriteModule";
 import * as GallerySearchModule from "../../../tsrc/modules/GallerySearchModule";
 import { getGlobalCourseList } from "../../../tsrc/modules/LegacySelectionSessionModule";
@@ -61,10 +61,12 @@ import * as RemoteSearchModule from "../../../tsrc/modules/RemoteSearchModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFilterSettingsModule from "../../../tsrc/modules/SearchFilterSettingsModule";
-import * as SearchPageHelper from "../../../tsrc/search/SearchPageHelper";
+import * as SearchModule from "../../../tsrc/modules/SearchModule";
 import * as SearchSettingsModule from "../../../tsrc/modules/SearchSettingsModule";
 import * as UserModule from "../../../tsrc/modules/UserModule";
-import SearchPage, { SearchPageOptions } from "../../../tsrc/search/SearchPage";
+import SearchPage from "../../../tsrc/search/SearchPage";
+import * as SearchPageHelper from "../../../tsrc/search/SearchPageHelper";
+import { SearchPageOptions } from "../../../tsrc/search/SearchPageHelper";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import { updateMockGetBaseUrl } from "../BaseUrlHelper";
 import { queryPaginatorControls } from "../components/SearchPaginationTestHelper";
@@ -85,7 +87,6 @@ import {
   querySearchAttachmentsSelector,
   queryStatusSelector,
 } from "./SearchPageHelper";
-import * as BrowserStorageModule from "../../../tsrc/modules/BrowserStorageModule";
 
 const defaultTheme = createMuiTheme({
   props: { MuiWithWidth: { initialWidth: "md" } },

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -101,8 +101,10 @@ import {
   generateSearchPageOptionsFromQueryString,
   getPartialSearchOptions,
   getRawModeFromStorage,
+  SearchPageOptions,
   writeRawModeToStorage,
 } from "./SearchPageHelper";
+import { reducer, SearchPageSearchResult } from "./SearchPageReducer";
 
 // destructure strings import
 const { searchpage: searchStrings } = languageStrings;
@@ -110,20 +112,6 @@ const { title: dateModifiedSelectorTitle, quickOptionDropdown } =
   searchStrings.lastModifiedDateSelector;
 const { title: collectionSelectorTitle } = searchStrings.collectionSelector;
 const { title: displayModeSelectorTitle } = searchStrings.displayModeSelector;
-
-/**
- * Type of search options that are specific to Search page presentation layer.
- */
-export interface SearchPageOptions extends SearchOptions {
-  /**
-   * Whether to enable Quick mode (true) or to use custom date pickers (false).
-   */
-  dateRangeQuickModeEnabled: boolean;
-  /**
-   * How to display the search results - also determines the type of results.
-   */
-  displayMode: DisplayMode;
-}
 
 /**
  * Structure of data stored in browser history state, to capture the current state of SearchPage
@@ -138,76 +126,6 @@ interface SearchPageHistoryState {
    */
   filterExpansion: boolean;
 }
-
-/**
- * The types of SearchResultItem that we support within an `OEQ.Search.SearchResult`.
- */
-type SearchPageSearchResult =
-  | {
-      from: "item-search";
-      content: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>;
-    }
-  | {
-      from: "gallery-search";
-      content: OEQ.Search.SearchResult<GallerySearchResultItem>;
-    };
-
-type Action =
-  | { type: "init" }
-  | { type: "search"; options: SearchPageOptions; scrollToTop: boolean }
-  | {
-      type: "search-complete";
-      result: SearchPageSearchResult;
-      classifications: Classification[];
-    }
-  | { type: "error"; cause: Error };
-
-type State =
-  | { status: "initialising" }
-  | {
-      status: "searching";
-      options: SearchPageOptions;
-      previousResult?: SearchPageSearchResult;
-      previousClassifications?: Classification[];
-      scrollToTop: boolean;
-    }
-  | {
-      status: "success";
-      result: SearchPageSearchResult;
-      classifications: Classification[];
-    }
-  | { status: "failure"; cause: Error };
-
-const reducer = (state: State, action: Action): State => {
-  switch (action.type) {
-    case "init":
-      return { status: "initialising" };
-    case "search":
-      const prevResults =
-        state.status === "success"
-          ? {
-              previousResult: state.result,
-              previousClassifications: state.classifications,
-            }
-          : {};
-      return {
-        status: "searching",
-        options: action.options,
-        scrollToTop: action.scrollToTop,
-        ...prevResults,
-      };
-    case "search-complete":
-      return {
-        status: "success",
-        result: action.result,
-        classifications: action.classifications,
-      };
-    case "error":
-      return { status: "failure", cause: action.cause };
-    default:
-      throw new TypeError("Unexpected action passed to reducer!");
-  }
-};
 
 const SearchPage = ({ updateTemplate }: TemplateUpdateProps) => {
   const history = useHistory();

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -58,12 +58,25 @@ import {
 } from "../modules/SearchModule";
 import { findUserById } from "../modules/UserModule";
 import { DateRange, isDate } from "../util/Date";
-import type { SearchPageOptions } from "./SearchPage";
 
 /**
  * This helper is intended to assist with processing related to the Presentation Layer -
  * as opposed to the Business Layer which is handled by the Modules.
  */
+
+/**
+ * Type of search options that are specific to Search page presentation layer.
+ */
+export interface SearchPageOptions extends SearchOptions {
+  /**
+   * Whether to enable Quick mode (true) or to use custom date pickers (false).
+   */
+  dateRangeQuickModeEnabled: boolean;
+  /**
+   * How to display the search results - also determines the type of results.
+   */
+  displayMode: DisplayMode;
+}
 
 export const defaultSearchPageOptions: SearchPageOptions = {
   ...defaultSearchOptions,

--- a/react-front-end/tsrc/search/SearchPageReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageReducer.ts
@@ -1,0 +1,91 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import type { GallerySearchResultItem } from "../modules/GallerySearchModule";
+import type { Classification } from "../modules/SearchFacetsModule";
+import type { SearchPageOptions } from "./SearchPageHelper";
+
+/**
+ * The types of SearchResultItem that we support within an `OEQ.Search.SearchResult`.
+ */
+export type SearchPageSearchResult =
+  | {
+      from: "item-search";
+      content: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>;
+    }
+  | {
+      from: "gallery-search";
+      content: OEQ.Search.SearchResult<GallerySearchResultItem>;
+    };
+
+export type Action =
+  | { type: "init" }
+  | { type: "search"; options: SearchPageOptions; scrollToTop: boolean }
+  | {
+      type: "search-complete";
+      result: SearchPageSearchResult;
+      classifications: Classification[];
+    }
+  | { type: "error"; cause: Error };
+
+export type State =
+  | { status: "initialising" }
+  | {
+      status: "searching";
+      options: SearchPageOptions;
+      previousResult?: SearchPageSearchResult;
+      previousClassifications?: Classification[];
+      scrollToTop: boolean;
+    }
+  | {
+      status: "success";
+      result: SearchPageSearchResult;
+      classifications: Classification[];
+    }
+  | { status: "failure"; cause: Error };
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "init":
+      return { status: "initialising" };
+    case "search":
+      const prevResults =
+        state.status === "success"
+          ? {
+              previousResult: state.result,
+              previousClassifications: state.classifications,
+            }
+          : {};
+      return {
+        status: "searching",
+        options: action.options,
+        scrollToTop: action.scrollToTop,
+        ...prevResults,
+      };
+    case "search-complete":
+      return {
+        status: "success",
+        result: action.result,
+        classifications: action.classifications,
+      };
+    case "error":
+      return { status: "failure", cause: action.cause };
+    default:
+      throw new TypeError("Unexpected action passed to reducer!");
+  }
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] (existing) tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Following a pattern I started in openequella/react-kaltura-simpleuploader , this pushes the reducer and supporting types out into a standalone file to assist with managing the size of `SearchPage.tsx` as well as aiding any additional testing etc we may wish to do.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
