### PR TITLE
Feature/integrate DRM Acceptance dialog with Item

### DIFF
--- a/react-front-end/__mocks__/searchresult_mock_data.ts
+++ b/react-front-end/__mocks__/searchresult_mock_data.ts
@@ -289,7 +289,7 @@ const oneDeadOneAliveAttachObj: OEQ.Search.SearchResultItem = {
 const drmAttachObj: OEQ.Search.SearchResultItem = {
   uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
   version: 1,
-  name: "Little Larry",
+  name: "DRM Item",
   description: "A description of a bird",
   status: "live",
   createdDate: new Date("2020-05-26T13:24:00.889+10:00"),
@@ -301,7 +301,7 @@ const drmAttachObj: OEQ.Search.SearchResultItem = {
     {
       attachmentType: "file",
       id: "9e751549-5cba-47dd-bccb-722c48072287",
-      description: "img.png",
+      description: "DRM Attachment",
       preview: false,
       mimeType: "image/png",
       hasGeneratedThumb: true,

--- a/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
@@ -24,7 +24,7 @@ import * as SearchFilterSettingsModule from "../../../tsrc/modules/SearchFilterS
 import type { SearchOptions } from "../../../tsrc/modules/SearchModule";
 import * as UserModule from "../../../tsrc/modules/UserModule";
 import {
-  builderOpenSummaryPageHandler,
+  buildOpenSummaryPageHandler,
   defaultSearchPageOptions,
   generateQueryStringFromSearchPageOptions,
   generateSearchPageOptionsFromQueryString,
@@ -294,14 +294,14 @@ describe("builderOpenSummaryPageHandler", () => {
   const history = createBrowserHistory();
 
   it("build URLS and onClick handlers for normal pages", () => {
-    const { url } = builderOpenSummaryPageHandler(UUID, VERSION, history);
+    const { url } = buildOpenSummaryPageHandler(UUID, VERSION, history);
     expect(url).toBe("/items/369c92fa-ae59-4845-957d-8fcaa22c15e3/1/");
   });
 
   it("build URLS and onClick handlers for Selection Session", () => {
     updateMockGetBaseUrl();
     updateMockGetRenderData(basicRenderData);
-    const { url } = builderOpenSummaryPageHandler(UUID, VERSION, history);
+    const { url } = buildOpenSummaryPageHandler(UUID, VERSION, history);
     expect(url).toBe(
       "http://localhost:8080/vanilla/items/369c92fa-ae59-4845-957d-8fcaa22c15e3/1/?_sl.stateId=1&a=coursesearch"
     );

--- a/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createBrowserHistory } from "history";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
 import { getMimeTypeFilters } from "../../../__mocks__/MimeTypeFilter.mock";
 import { users } from "../../../__mocks__/UserSearch.mock";
@@ -23,6 +24,7 @@ import * as SearchFilterSettingsModule from "../../../tsrc/modules/SearchFilterS
 import type { SearchOptions } from "../../../tsrc/modules/SearchModule";
 import * as UserModule from "../../../tsrc/modules/UserModule";
 import {
+  builderOpenSummaryPageHandler,
   defaultSearchPageOptions,
   generateQueryStringFromSearchPageOptions,
   generateSearchPageOptionsFromQueryString,
@@ -34,6 +36,8 @@ import {
   basicSearchPageOptions,
 } from "../../../__mocks__/searchOptions.mock";
 import type { DateRange } from "../../../tsrc/util/Date";
+import { updateMockGetBaseUrl } from "../BaseUrlHelper";
+import { basicRenderData, updateMockGetRenderData } from "../RenderDataHelper";
 
 describe("newSearchQueryToSearchOptions", () => {
   const mockedResolvedUser = jest.spyOn(UserModule, "resolveUsers");
@@ -281,5 +285,25 @@ describe("generateQueryStringFromSearchPageOptions", () => {
     expect(
       generateQueryStringFromSearchPageOptions(defaultSearchPageOptions)
     ).not.toContain("sortOrder");
+  });
+});
+
+describe("builderOpenSummaryPageHandler", () => {
+  const UUID = "369c92fa-ae59-4845-957d-8fcaa22c15e3";
+  const VERSION = 1;
+  const history = createBrowserHistory();
+
+  it("build URLS and onClick handlers for normal pages", () => {
+    const { url } = builderOpenSummaryPageHandler(UUID, VERSION, history);
+    expect(url).toBe("/items/369c92fa-ae59-4845-957d-8fcaa22c15e3/1/");
+  });
+
+  it("build URLS and onClick handlers for Selection Session", () => {
+    updateMockGetBaseUrl();
+    updateMockGetRenderData(basicRenderData);
+    const { url } = builderOpenSummaryPageHandler(UUID, VERSION, history);
+    expect(url).toBe(
+      "http://localhost:8080/vanilla/items/369c92fa-ae59-4845-957d-8fcaa22c15e3/1/?_sl.stateId=1&a=coursesearch"
+    );
   });
 });

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -99,8 +99,14 @@ describe("<GallerySearchResult />", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
 
     it.each([
-      ["view a DRM Item's summary page", languageStrings.searchpage.gallerySearchResult.viewItem],
-      ["preview an gallery entry protected by DRM", languageStrings.searchpage.gallerySearchResult.ariaLabel],
+      [
+        "view a DRM Item's summary page",
+        languageStrings.searchpage.gallerySearchResult.viewItem,
+      ],
+      [
+        "preview an gallery entry protected by DRM",
+        languageStrings.searchpage.gallerySearchResult.ariaLabel,
+      ],
     ])(
       "shows DRM acceptance dialog when %s",
       async (_: string, galleryEntryLabel: string) => {

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -97,15 +97,22 @@ describe("<GallerySearchResult />", () => {
 
   describe("DRM support", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
-    it("shows DRM acceptance dialog when preview a gallery entry protected by DRM", async () => {
-      const { getByLabelText } = await renderGallery([galleryDrmItem]);
-      userEvent.click(getByLabelText(ariaLabel));
 
-      await waitFor(() => {
-        expect(
-          queryByText(screen.getByRole("dialog"), drmTerms.title)
-        ).toBeInTheDocument();
-      });
-    });
+    it.each([
+      ["view a DRM Item's summary page", languageStrings.searchpage.gallerySearchResult.viewItem],
+      ["preview an gallery entry protected by DRM", languageStrings.searchpage.gallerySearchResult.ariaLabel],
+    ])(
+      "shows DRM acceptance dialog when %s",
+      async (_: string, galleryEntryLabel: string) => {
+        const { getByLabelText } = await renderGallery([galleryDrmItem]);
+        userEvent.click(getByLabelText(galleryEntryLabel));
+
+        await waitFor(() => {
+          expect(
+            queryByText(screen.getByRole("dialog"), drmTerms.title)
+          ).toBeInTheDocument();
+        });
+      }
+    );
   });
 });

--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -519,16 +519,23 @@ describe("<SearchResult/>", () => {
 
   describe("DRM support", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
-    it("shows the DRM Accept dialog when attempting to preview an attachment from a DRM item", async () => {
-      const { drmAttachObj } = mockData;
-      const { getByText } = await renderSearchResult(drmAttachObj);
-      userEvent.click(getByText(drmAttachObj.attachments![0].description!));
 
-      await waitFor(() => {
-        expect(
-          queryByText(screen.getByRole("dialog"), drmTerms.title)
-        ).toBeInTheDocument();
-      });
-    });
+    it.each([
+      ["view a DRM Item's summary page", "DRM Item"],
+      ["preview an attachment from a DRM item", "DRM Attachment"],
+    ])(
+      "shows the DRM Accept dialog %s",
+      async (_: string, linkText: string) => {
+        const { drmAttachObj } = mockData;
+        const { getByText } = await renderSearchResult(drmAttachObj);
+        userEvent.click(getByText(linkText));
+
+        await waitFor(() => {
+          expect(
+            queryByText(screen.getByRole("dialog"), drmTerms.title)
+          ).toBeInTheDocument();
+        });
+      }
+    );
   });
 });

--- a/react-front-end/tsrc/components/ItemAttachmentLink.tsx
+++ b/react-front-end/tsrc/components/ItemAttachmentLink.tsx
@@ -72,10 +72,7 @@ const ItemAttachmentLink = ({
 }: ItemAttachmentLinkProps) => {
   const { attachmentLink } = languageStrings.searchpage.searchResult;
   const [lightBoxProps, setLightBoxProps] = useState<LightboxProps>();
-  const {
-    drmStatus: { isAuthorised, termsAccepted },
-    showDrmAcceptDialog,
-  } = useContext(ItemDrmContext);
+  const { checkDrmPermission } = useContext(ItemDrmContext);
 
   const buildSimpleLink = ({ url }: ViewerLinkConfig): JSX.Element => (
     <Link
@@ -85,10 +82,8 @@ const ItemAttachmentLink = ({
       rel="noreferrer"
       onClick={(event) => {
         event.stopPropagation();
-        if (isAuthorised && !termsAccepted) {
-          event.preventDefault();
-          showDrmAcceptDialog(() => () => window.open(url, "_blank"));
-        }
+        event.preventDefault();
+        checkDrmPermission(() => window.open(url, "_blank"));
       }}
     >
       {children}
@@ -118,10 +113,8 @@ const ItemAttachmentLink = ({
           aria-label={`${attachmentLink} ${description}`}
           component="button"
           onClick={(event: SyntheticEvent) => {
-            isAuthorised && !termsAccepted
-              ? showDrmAcceptDialog(() => openLightbox)
-              : openLightbox();
             event.stopPropagation();
+            checkDrmPermission(openLightbox);
           }}
         >
           {children}

--- a/react-front-end/tsrc/components/ItemAttachmentLink.tsx
+++ b/react-front-end/tsrc/components/ItemAttachmentLink.tsx
@@ -74,7 +74,7 @@ const ItemAttachmentLink = ({
   const [lightBoxProps, setLightBoxProps] = useState<LightboxProps>();
   const {
     drmStatus: { isAuthorised, termsAccepted },
-    setOnDrmAcceptCallback,
+    showDrmAcceptDialog,
   } = useContext(ItemDrmContext);
 
   const buildSimpleLink = ({ url }: ViewerLinkConfig): JSX.Element => (
@@ -87,7 +87,7 @@ const ItemAttachmentLink = ({
         event.stopPropagation();
         if (isAuthorised && !termsAccepted) {
           event.preventDefault();
-          setOnDrmAcceptCallback(() => () => window.open(url, "_blank"));
+          showDrmAcceptDialog(() => () => window.open(url, "_blank"));
         }
       }}
     >
@@ -119,7 +119,7 @@ const ItemAttachmentLink = ({
           component="button"
           onClick={(event: SyntheticEvent) => {
             isAuthorised && !termsAccepted
-              ? setOnDrmAcceptCallback(() => openLightbox)
+              ? showDrmAcceptDialog(() => openLightbox)
               : openLightbox();
             event.stopPropagation();
           }}

--- a/react-front-end/tsrc/components/OEQItemSummaryPageButton.tsx
+++ b/react-front-end/tsrc/components/OEQItemSummaryPageButton.tsx
@@ -19,11 +19,7 @@ import { PropTypes } from "@material-ui/core";
 import InfoIcon from "@material-ui/icons/Info";
 import * as React from "react";
 import { useHistory } from "react-router";
-import { routes } from "../mainui/routes";
-import {
-  buildSelectionSessionItemSummaryLink,
-  isSelectionSessionOpen,
-} from "../modules/LegacySelectionSessionModule";
+import { builderOpenSummaryPageHandler } from "../search/SearchPageHelper";
 import { TooltipIconButton } from "./TooltipIconButton";
 
 export interface OEQItemSummaryPageButtonProps {
@@ -68,14 +64,7 @@ export const OEQItemSummaryPageButton = ({
   color = "default",
 }: OEQItemSummaryPageButtonProps) => {
   const history = useHistory();
-  const openSummaryPage = () => {
-    isSelectionSessionOpen()
-      ? window.open(
-          buildSelectionSessionItemSummaryLink(uuid, version),
-          "_self"
-        )
-      : history.push(routes.ViewItem.to(uuid, version));
-  };
+  const { onClick } = builderOpenSummaryPageHandler(uuid, version, history);
 
   return (
     <TooltipIconButton
@@ -84,9 +73,9 @@ export const OEQItemSummaryPageButton = ({
       onClick={(event) => {
         event.stopPropagation();
         if (checkDrmPermission) {
-          checkDrmPermission(openSummaryPage);
+          checkDrmPermission(onClick);
         } else {
-          openSummaryPage();
+          onClick();
         }
       }}
     >

--- a/react-front-end/tsrc/components/OEQItemSummaryPageButton.tsx
+++ b/react-front-end/tsrc/components/OEQItemSummaryPageButton.tsx
@@ -19,7 +19,7 @@ import { PropTypes } from "@material-ui/core";
 import InfoIcon from "@material-ui/icons/Info";
 import * as React from "react";
 import { useHistory } from "react-router";
-import { builderOpenSummaryPageHandler } from "../search/SearchPageHelper";
+import { buildOpenSummaryPageHandler } from "../search/SearchPageHelper";
 import { TooltipIconButton } from "./TooltipIconButton";
 
 export interface OEQItemSummaryPageButtonProps {
@@ -64,7 +64,7 @@ export const OEQItemSummaryPageButton = ({
   color = "default",
 }: OEQItemSummaryPageButtonProps) => {
   const history = useHistory();
-  const { onClick } = builderOpenSummaryPageHandler(uuid, version, history);
+  const { onClick } = buildOpenSummaryPageHandler(uuid, version, history);
 
   return (
     <TooltipIconButton
@@ -72,11 +72,7 @@ export const OEQItemSummaryPageButton = ({
       title={title}
       onClick={(event) => {
         event.stopPropagation();
-        if (checkDrmPermission) {
-          checkDrmPermission(onClick);
-        } else {
-          onClick();
-        }
+        checkDrmPermission ? checkDrmPermission(onClick) : onClick();
       }}
     >
       <InfoIcon />

--- a/react-front-end/tsrc/components/OEQLink.tsx
+++ b/react-front-end/tsrc/components/OEQLink.tsx
@@ -35,7 +35,8 @@ interface OEQLinkProps {
    */
   muiLinkUrlProvider: () => string;
   /**
-   * Function fired when the link is clicked.
+   * Function typically used to intercept calls before the browser navigates away.
+   *
    */
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }

--- a/react-front-end/tsrc/components/OEQLink.tsx
+++ b/react-front-end/tsrc/components/OEQLink.tsx
@@ -34,6 +34,10 @@ interface OEQLinkProps {
    * A function providing a URL for MUI Link
    */
   muiLinkUrlProvider: () => string;
+  /**
+   * Function fired when the link is clicked.
+   */
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 /**
@@ -44,11 +48,14 @@ export const OEQLink = ({
   children,
   routeLinkUrlProvider,
   muiLinkUrlProvider,
+  onClick,
 }: OEQLinkProps) =>
   isSelectionSessionOpen() ? (
-    <MUILink href={muiLinkUrlProvider()} underline="none">
+    <MUILink href={muiLinkUrlProvider()} underline="none" onClick={onClick}>
       {children}
     </MUILink>
   ) : (
-    <Link to={routeLinkUrlProvider()}>{children}</Link>
+    <Link to={routeLinkUrlProvider()} onClick={onClick}>
+      {children}
+    </Link>
   );

--- a/react-front-end/tsrc/drm/DrmHelper.tsx
+++ b/react-front-end/tsrc/drm/DrmHelper.tsx
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import {
+  acceptDrmTerms,
+  defaultDrmStatus,
+  listDrmTerms,
+} from "../modules/DrmModule";
+import { DrmAcceptanceDialog } from "./DrmAcceptanceDialog";
+import * as OEQ from "@openequella/rest-api-client";
+
+export const createDrmDialog = (
+  uuid: string,
+  version: number,
+  drmStatus: OEQ.Search.DrmStatus,
+  updateDrmStatus: (status: OEQ.Search.DrmStatus) => void,
+  closeDrmDialog: () => void,
+  drmProtectedHandler?: () => void
+): JSX.Element | undefined => {
+  // If there is nothing requiring DRM permission check then return undefined.
+  if (drmProtectedHandler) {
+    const { isAuthorised, termsAccepted } = drmStatus;
+    if (isAuthorised && !termsAccepted) {
+      return (
+        <DrmAcceptanceDialog
+          termsProvider={() => listDrmTerms(uuid, version)}
+          onAccept={() => acceptDrmTerms(uuid, version)}
+          onAcceptCallBack={() => {
+            closeDrmDialog();
+            updateDrmStatus(defaultDrmStatus);
+            drmProtectedHandler();
+          }}
+          onReject={closeDrmDialog}
+          open={!!drmProtectedHandler}
+        />
+      );
+    } else {
+      drmProtectedHandler();
+      return;
+    }
+  }
+
+  return;
+};

--- a/react-front-end/tsrc/drm/DrmHelper.tsx
+++ b/react-front-end/tsrc/drm/DrmHelper.tsx
@@ -24,6 +24,18 @@ import {
 import { DrmAcceptanceDialog } from "./DrmAcceptanceDialog";
 import * as OEQ from "@openequella/rest-api-client";
 
+/**
+ * Given a handler which cannot be used until a DRM check is completed,
+ * this function checks DRM status and based on the result build different DRM dialogs.
+ * The handler will then be used by interacting with the dialog.
+ *
+ * @param uuid Item's UUID.
+ * @param version Item's version.
+ * @param drmStatus Item's DRM status.
+ * @param updateDrmStatus Function to update DRM status on client side. Typically, this is a React state setter.
+ * @param closeDrmDialog Function to close the resultant DRM dialog.
+ * @param drmProtectedHandler Handler that can't be used until a DRM check is completed.
+ */
 export const createDrmDialog = (
   uuid: string,
   version: number,

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -427,11 +427,14 @@ export const deleteRawModeFromStorage = (): void =>
  * @param version Item's version.
  * @param history The History object used in the context, which is typically provided by calling 'useHistory' in components.
  */
-export const builderOpenSummaryPageHandler = (
+export const buildOpenSummaryPageHandler = (
   uuid: string,
   version: number,
   history: History
-) =>
+): {
+  url: string;
+  onClick: () => void;
+} =>
   pipe(
     routes.ViewItem.to(uuid, version),
     E.fromPredicate<string, string>(

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -17,6 +17,7 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
+import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
 import { Location } from "history";
@@ -35,6 +36,7 @@ import {
   Union,
   Unknown,
 } from "runtypes";
+import { routes } from "../mainui/routes";
 import {
   clearDataFromLocalStorage,
   readDataFromLocalStorage,
@@ -44,6 +46,10 @@ import {
   Collection,
   findCollectionsByUuid,
 } from "../modules/CollectionsModule";
+import {
+  buildSelectionSessionItemSummaryLink,
+  isSelectionSessionOpen,
+} from "../modules/LegacySelectionSessionModule";
 import {
   getMimeTypeFiltersById,
   MimeTypeFilter,
@@ -58,6 +64,7 @@ import {
 import { findUserById } from "../modules/UserModule";
 import { DateRange, isDate } from "../util/Date";
 import { simpleMatch } from "../util/match";
+import { History } from "history";
 
 /**
  * This helper is intended to assist with processing related to the Presentation Layer -
@@ -411,3 +418,34 @@ export const writeRawModeToStorage = (value: boolean): void =>
 
 export const deleteRawModeFromStorage = (): void =>
   clearDataFromLocalStorage(RAW_MODE_STORAGE_KEY);
+
+/**
+ * This function returns an object which consists of a URL of Item Summary page and a onClick handler
+ * which is used to open the Summary page.
+ *
+ * @param uuid Item's UUID.
+ * @param version Item's version.
+ * @param history The History object used in the context, which is typically provided by calling 'useHistory' in components.
+ */
+export const builderOpenSummaryPageHandler = (
+  uuid: string,
+  version: number,
+  history: History
+) =>
+  pipe(
+    routes.ViewItem.to(uuid, version),
+    E.fromPredicate<string, string>(
+      () => !isSelectionSessionOpen(),
+      () => buildSelectionSessionItemSummaryLink(uuid, version)
+    ),
+    E.fold(
+      (url) => ({
+        url,
+        onClick: () => window.open(url, "_self"),
+      }),
+      (url) => ({
+        url,
+        onClick: () => history.push(url),
+      })
+    )
+  );

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -439,10 +439,12 @@ export const builderOpenSummaryPageHandler = (
       () => buildSelectionSessionItemSummaryLink(uuid, version)
     ),
     E.fold(
+      // Selection session values
       (url) => ({
         url,
         onClick: () => window.open(url, "_self"),
       }),
+      // Normal page values
       (url) => ({
         url,
         onClick: () => history.push(url),

--- a/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
@@ -100,16 +100,18 @@ export const GallerySearchItemTiles = ({
     setDrmCheckOnSuccessHandler(() => onSuccess);
 
   useEffect(() => {
-    setDrmDialog(
-      createDrmDialog(
-        uuid,
-        version,
-        drmStatus,
-        setDrmStatus,
-        () => setDrmCheckOnSuccessHandler(undefined),
-        drmCheckOnSuccessHandler
-      )
-    );
+    const dialog = drmCheckOnSuccessHandler
+      ? createDrmDialog(
+          uuid,
+          version,
+          drmStatus,
+          setDrmStatus,
+          () => setDrmCheckOnSuccessHandler(undefined),
+          drmCheckOnSuccessHandler
+        )
+      : undefined;
+
+    setDrmDialog(dialog);
   }, [drmCheckOnSuccessHandler, uuid, version, drmStatus]);
 
   // Used to build the onClick event handler for each tile.

--- a/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
@@ -166,7 +166,7 @@ export const GallerySearchItemTiles = ({
           <OEQItemSummaryPageButton
             title={viewItem}
             color="secondary"
-            item={{ uuid, version }}
+            item={{ uuid, version, drm: { drmStatus, setOnDrmAcceptCallback } }}
           />
         }
       />
@@ -199,8 +199,8 @@ export const GallerySearchItemTiles = ({
           onAccept={() => acceptDrmTerms(uuid, version)}
           onAcceptCallBack={() => {
             setDrmStatus(defaultDrmStatus);
-            onDrmAcceptCallback();
             closeDrmDialog();
+            onDrmAcceptCallback();
           }}
           onReject={closeDrmDialog}
           open={!!onDrmAcceptCallback}

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -139,11 +139,19 @@ export interface SearchResultProps {
  * status and update the callback.
  */
 export const ItemDrmContext = React.createContext<{
+  /**
+   * Item's DRM status.
+   */
   drmStatus: OEQ.Search.DrmStatus;
-  setOnDrmAcceptCallback: (_: undefined | (() => void)) => void;
+  /**
+   * Function to open the DRM Acceptance dialog.
+   *
+   * @param onAccept Function which returns another function as the DRM acceptance callback.
+   */
+  showDrmAcceptDialog: (onAccept: () => void) => void;
 }>({
   drmStatus: defaultDrmStatus,
-  setOnDrmAcceptCallback: () => {},
+  showDrmAcceptDialog: () => {},
 });
 
 export default function SearchResult({
@@ -405,7 +413,7 @@ export default function SearchResult({
               <ItemDrmContext.Provider
                 value={{
                   drmStatus,
-                  setOnDrmAcceptCallback,
+                  showDrmAcceptDialog: setOnDrmAcceptCallback,
                 }}
               >
                 <SearchResultAttachmentsList

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -34,9 +34,7 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
 import ReactHtmlParser from "react-html-parser";
-import { pipe } from "fp-ts/function";
 import { useHistory } from "react-router";
-import * as E from "fp-ts/Either";
 import { HashLink } from "react-router-hash-link";
 import { sprintf } from "sprintf-js";
 import { Date as DateDisplay } from "../../components/Date";
@@ -52,7 +50,6 @@ import {
   deleteFavouriteItem,
 } from "../../modules/FavouriteModule";
 import {
-  buildSelectionSessionItemSummaryLink,
   getSearchPageItemClass,
   isSelectionSessionInStructured,
   isSelectionSessionOpen,
@@ -62,6 +59,7 @@ import {
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
+import { builderOpenSummaryPageHandler } from "../SearchPageHelper";
 import { FavouriteItemDialog } from "./FavouriteItemDialog";
 import type {
   FavDialogConfirmToAdd,
@@ -328,22 +326,10 @@ export default function SearchResult({
     const itemTitle = name ? highlightField(name) : uuid;
     // Use Either to build URL and onClick handler. Left is for selection session
     // and Right is for normal page.
-    const { url, onClick } = pipe(
-      routes.ViewItem.to(uuid, version),
-      E.fromPredicate<string, string>(
-        () => !inSelectionSession,
-        () => buildSelectionSessionItemSummaryLink(uuid, version)
-      ),
-      E.fold(
-        (url) => ({
-          url,
-          onClick: () => window.open(url, "_self"),
-        }),
-        (url) => ({
-          url,
-          onClick: () => history.push(url),
-        })
-      )
+    const { url, onClick } = builderOpenSummaryPageHandler(
+      uuid,
+      version,
+      history
     );
 
     return (

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -59,7 +59,7 @@ import {
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
-import { builderOpenSummaryPageHandler } from "../SearchPageHelper";
+import { buildOpenSummaryPageHandler } from "../SearchPageHelper";
 import { FavouriteItemDialog } from "./FavouriteItemDialog";
 import type {
   FavDialogConfirmToAdd,
@@ -190,16 +190,19 @@ export default function SearchResult({
     setDrmCheckOnSuccessHandler(() => onSuccess);
 
   useEffect(() => {
-    setDrmDialog(
-      createDrmDialog(
-        uuid,
-        version,
-        drmStatus,
-        setDrmStatus,
-        () => setDrmCheckOnSuccessHandler(undefined),
-        drmCheckOnSuccessHandler
-      )
-    );
+    // If there is nothing requiring DRM permission check then return undefined.
+    const dialog = drmCheckOnSuccessHandler
+      ? createDrmDialog(
+          uuid,
+          version,
+          drmStatus,
+          setDrmStatus,
+          () => setDrmCheckOnSuccessHandler(undefined),
+          drmCheckOnSuccessHandler
+        )
+      : undefined;
+
+    setDrmDialog(dialog);
   }, [drmCheckOnSuccessHandler, uuid, version, drmStatus]);
 
   const handleSelectResource = (
@@ -324,9 +327,7 @@ export default function SearchResult({
 
   const itemLink = () => {
     const itemTitle = name ? highlightField(name) : uuid;
-    // Use Either to build URL and onClick handler. Left is for selection session
-    // and Right is for normal page.
-    const { url, onClick } = builderOpenSummaryPageHandler(
+    const { url, onClick } = buildOpenSummaryPageHandler(
       uuid,
       version,
       history


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support of showing DRM Acceptance dialog when users attempt to view an Item. On standard list mode, the dialog pops up when an Item link is clicked,  and on gallery mode the dialog pops up when an Info icon is clicked. 

Once the terms are accepted, Item Summary page will be opened by different approaches, depending on whether in Selection Session or not.


https://user-images.githubusercontent.com/47203811/126739698-8e628e1c-e74c-48ff-b687-0971b440d790.mp4


