### PR TITLE
feat: Return Kaltura externalId in search results

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/item/interfaces/beans/AttachmentBean.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/item/interfaces/beans/AttachmentBean.java
@@ -21,6 +21,7 @@ package com.tle.web.api.item.interfaces.beans;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.tle.web.api.interfaces.beans.AbstractExtendableBean;
+import java.util.Optional;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
@@ -90,5 +91,16 @@ public abstract class AttachmentBean extends AbstractExtendableBean {
    */
   public void setErroredIndexing(boolean erroredIndexing) {
     this.erroredIndexing = erroredIndexing;
+  }
+
+  /**
+   * An ID for an attachment which is located on an external platform. Encoding of this value is
+   * specific to the attachment type. For internal oEQ attachments it will be absent.
+   *
+   * @return a possibly encoded reference to an attachment in an external system, or 'empty' if an
+   *     attachment local to this oEQ institution.
+   */
+  public Optional<String> getExternalId() {
+    return Optional.empty();
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentBean.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/youtube/YoutubeAttachmentBean.java
@@ -20,6 +20,7 @@ package com.tle.web.controls.youtube;
 
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
 import java.util.Date;
+import java.util.Optional;
 
 @SuppressWarnings("nls")
 public class YoutubeAttachmentBean extends EquellaAttachmentBean {
@@ -108,5 +109,10 @@ public class YoutubeAttachmentBean extends EquellaAttachmentBean {
 
   public void setCustomParameters(String customParameters) {
     this.customParameters = customParameters;
+  }
+
+  @Override
+  public Optional<String> getExternalId() {
+    return Optional.of(getVideoId());
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This enables for previewing Kaltura media in search results and galleries. And by adding this to `AttachmentBean` also supports work in the future with Summary Pages etc.

Integrating with this will also be a PR over at https://github.com/openequella/openEQUELLA-Kaltura

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
