### PR TITLE
Feature/REST endpoint for DRM errors

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/drm/DrmResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/drm/DrmResource.scala
@@ -20,6 +20,7 @@ package com.tle.web.api.drm
 
 import com.dytech.edge.exceptions.{DRMException, ItemNotFoundException}
 import com.tle.beans.item.{DrmSettings, Item, ItemId}
+import com.tle.common.usermanagement.user.CurrentUser
 import com.tle.exceptions.AccessDeniedException
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.ApiErrorResponse.{
@@ -34,6 +35,11 @@ import javax.ws.rs.core.Response
 import javax.ws.rs.{BadRequestException, GET, NotFoundException, POST, Path, PathParam, Produces}
 import scala.util.control.Exception.allCatch
 import scala.util.{Failure, Success, Try}
+
+/**
+  * Typically used to provide why a DRM Item is unauthorised to view.
+  */
+case class DrmError(cause: String)
 
 @NoCache
 @Path("item/{uuid}/{version}/drm")
@@ -81,6 +87,27 @@ class DrmResource {
       : Item => Unit = drmService.acceptLicenseOrThrow // Explicitly discard the internal DB ID and use Unit instead.
     val result       = allCatch withTry (getItem andThen acceptLicense)(new ItemId(uuid, version))
     respond(result)
+  }
+
+  @GET
+  @Path("/unauthorised")
+  @ApiOperation(
+    value = "List DRM error",
+    notes = "This endpoint is used to List why a DRM Item is unauthorised to view.",
+    response = classOf[DrmError]
+  )
+  def getDrmError(@ApiParam("Item UUID") @PathParam("uuid") uuid: String,
+                  @ApiParam("Item Version") @PathParam("version") version: Int): Response = {
+    val isAuthorised: Item => Unit = (item: Item) =>
+      drmService.isAuthorised(item, CurrentUser.getUserState.getIpAddress)
+
+    Try {
+      (getItem andThen isAuthorised)(new ItemId(uuid, version))
+    } match {
+      case Success(_)               => badRequest(s"Item ${uuid}/${version} is authorised.")
+      case Failure(e: DRMException) => Response.ok().entity(DrmError(e.getMessage)).build()
+      case Failure(e)               => mapException(e)(Seq(e.getMessage))
+    }
   }
 
   // Take a subtype of Throwable and return a function which takes a sequence of string and returns a Response.

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/DrmApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/DrmApiTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 @TestInstitution("fiveo")
 public class DrmApiTest extends AbstractRestApiTest {
   private final String ITEM_UUID = "ea61a83c-b18b-49e2-8096-e6208776be92";
+  private final String UNAUTHORISED_ITEM_UUID = "73b67c33-aa72-419f-87aa-72d919fcf9f0";
   private final int ITEM_VERSION = 1;
 
   @Override
@@ -31,7 +32,7 @@ public class DrmApiTest extends AbstractRestApiTest {
 
   @Test(description = "Failed to accept DRM terms due to unauthorised")
   public void unauthorised() throws IOException {
-    assertEquals(acceptDrm("73b67c33-aa72-419f-87aa-72d919fcf9f0", ITEM_VERSION), 401);
+    assertEquals(acceptDrm(UNAUTHORISED_ITEM_UUID, ITEM_VERSION), 401);
   }
 
   @Test(description = "Successfully accept DRM terms")
@@ -58,6 +59,14 @@ public class DrmApiTest extends AbstractRestApiTest {
     JsonNode agreements = result.get("agreements");
     assertNotNull(agreements);
     assertNotNull(agreements.get("regularPermission"));
+  }
+
+  @Test(description = "List why the DRM Item is unauthorised to view")
+  public void listDrmErrors() throws IOException {
+    final GetMethod method =
+        new GetMethod(buildEndpointPath(UNAUTHORISED_ITEM_UUID, ITEM_VERSION) + "/unauthorised");
+    int statusCode = makeClientRequest(method);
+    assertEquals(statusCode, 200);
   }
 
   private String buildEndpointPath(String uuid, int version) {

--- a/oeq-ts-rest-api/src/Drm.ts
+++ b/oeq-ts-rest-api/src/Drm.ts
@@ -60,6 +60,10 @@ export interface ItemDrmDetails {
   agreements: DrmAgreements;
 }
 
+export interface DrmError {
+  cause: string;
+}
+
 const buildPath = (apiBasePath: string, uuid: string, version: number) =>
   `${apiBasePath}/item/${uuid}/${version}/drm`;
 
@@ -91,3 +95,20 @@ export const acceptDrmTerms = (
   uuid: string,
   version: number
 ): Promise<void> => POST_void(buildPath(apiBasePath, uuid, version));
+
+/**
+ * List an error about why a DRM Item is unauthorised to view.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param uuid UUID of an Item
+ * @param version Version of an Item
+ */
+export const listDrmError = (
+  apiBasePath: string,
+  uuid: string,
+  version: number
+): Promise<DrmError> =>
+  GET(
+    `${buildPath(apiBasePath, uuid, version)}/unauthorised`,
+    (data): data is DrmError => is<DrmError>(data)
+  );

--- a/oeq-ts-rest-api/test/Drm.test.ts
+++ b/oeq-ts-rest-api/test/Drm.test.ts
@@ -16,10 +16,17 @@
  * limitations under the License.
  */
 import * as OEQ from '../src';
-import { acceptDrmTerms, ItemDrmDetails, listDrmTerms } from '../src/Drm';
+import {
+  acceptDrmTerms,
+  DrmError,
+  ItemDrmDetails,
+  listDrmError,
+  listDrmTerms,
+} from '../src/Drm';
 import * as TC from './TestConfig';
 
 const ITEM_UUID = 'ea61a83c-b18b-49e2-8096-e6208776be92';
+const UNAUTHORISED_ITEM_UUID = '73b67c33-aa72-419f-87aa-72d919fcf9f0';
 const ITEM_VERSION = 1;
 
 beforeAll(() => OEQ.Auth.login(TC.API_PATH_FIVEO, TC.USERNAME, TC.PASSWORD));
@@ -41,5 +48,16 @@ describe('acceptDrmTerms', () => {
     await expect(
       acceptDrmTerms(TC.API_PATH_FIVEO, ITEM_UUID, ITEM_VERSION)
     ).resolves.not.toThrow();
+  });
+});
+
+describe('listDrmError', () => {
+  it('supports listing DRM error', async () => {
+    const drmError: DrmError = await listDrmError(
+      TC.API_PATH_FIVEO,
+      UNAUTHORISED_ITEM_UUID,
+      ITEM_VERSION
+    );
+    expect(drmError.cause).toBeTruthy();
   });
 });

--- a/react-front-end/__mocks__/searchresult_mock_data.ts
+++ b/react-front-end/__mocks__/searchresult_mock_data.ts
@@ -289,7 +289,7 @@ const oneDeadOneAliveAttachObj: OEQ.Search.SearchResultItem = {
 const drmAttachObj: OEQ.Search.SearchResultItem = {
   uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
   version: 1,
-  name: "Little Larry",
+  name: "DRM Item",
   description: "A description of a bird",
   status: "live",
   createdDate: new Date("2020-05-26T13:24:00.889+10:00"),
@@ -301,7 +301,7 @@ const drmAttachObj: OEQ.Search.SearchResultItem = {
     {
       attachmentType: "file",
       id: "9e751549-5cba-47dd-bccb-722c48072287",
-      description: "img.png",
+      description: "DRM Attachment",
       preview: false,
       mimeType: "image/png",
       hasGeneratedThumb: true,

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -99,8 +99,14 @@ describe("<GallerySearchResult />", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
 
     it.each([
-      ["view a DRM Item's summary page", languageStrings.searchpage.gallerySearchResult.viewItem],
-      ["preview an gallery entry protected by DRM", languageStrings.searchpage.gallerySearchResult.ariaLabel],
+      [
+        "view a DRM Item's summary page",
+        languageStrings.searchpage.gallerySearchResult.viewItem,
+      ],
+      [
+        "preview an gallery entry protected by DRM",
+        languageStrings.searchpage.gallerySearchResult.ariaLabel,
+      ],
     ])(
       "shows DRM acceptance dialog when %s",
       async (_: string, galleryEntryLabel: string) => {

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -97,15 +97,22 @@ describe("<GallerySearchResult />", () => {
 
   describe("DRM support", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
-    it("shows DRM acceptance dialog when preview a gallery entry protected by DRM", async () => {
-      const { getByLabelText } = await renderGallery([galleryDrmItem]);
-      userEvent.click(getByLabelText(ariaLabel));
 
-      await waitFor(() => {
-        expect(
-          queryByText(screen.getByRole("dialog"), drmTerms.title)
-        ).toBeInTheDocument();
-      });
-    });
+    it.each([
+      ["view a DRM Item's summary page", languageStrings.searchpage.gallerySearchResult.viewItem],
+      ["preview an gallery entry protected by DRM", languageStrings.searchpage.gallerySearchResult.ariaLabel],
+    ])(
+      "shows DRM acceptance dialog when %s",
+      async (_: string, galleryEntryLabel: string) => {
+        const { getByLabelText } = await renderGallery([galleryDrmItem]);
+        userEvent.click(getByLabelText(galleryEntryLabel));
+
+        await waitFor(() => {
+          expect(
+            queryByText(screen.getByRole("dialog"), drmTerms.title)
+          ).toBeInTheDocument();
+        });
+      }
+    );
   });
 });

--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -519,16 +519,23 @@ describe("<SearchResult/>", () => {
 
   describe("DRM support", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
-    it("shows the DRM Accept dialog when attempting to preview an attachment from a DRM item", async () => {
-      const { drmAttachObj } = mockData;
-      const { getByText } = await renderSearchResult(drmAttachObj);
-      userEvent.click(getByText(drmAttachObj.attachments![0].description!));
 
-      await waitFor(() => {
-        expect(
-          queryByText(screen.getByRole("dialog"), drmTerms.title)
-        ).toBeInTheDocument();
-      });
-    });
+    it.each([
+      ["view a DRM Item's summary page", "DRM Item"],
+      ["preview an attachment from a DRM item", "DRM Attachment"],
+    ])(
+      "shows the DRM Accept dialog %s",
+      async (_: string, linkText: string) => {
+        const { drmAttachObj } = mockData;
+        const { getByText } = await renderSearchResult(drmAttachObj);
+        userEvent.click(getByText(linkText));
+
+        await waitFor(() => {
+          expect(
+            queryByText(screen.getByRole("dialog"), drmTerms.title)
+          ).toBeInTheDocument();
+        });
+      }
+    );
   });
 });

--- a/react-front-end/tsrc/components/OEQLink.tsx
+++ b/react-front-end/tsrc/components/OEQLink.tsx
@@ -34,6 +34,10 @@ interface OEQLinkProps {
    * A function providing a URL for MUI Link
    */
   muiLinkUrlProvider: () => string;
+  /**
+   * Function fired when the link is clicked.
+   */
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 /**
@@ -44,11 +48,14 @@ export const OEQLink = ({
   children,
   routeLinkUrlProvider,
   muiLinkUrlProvider,
+  onClick,
 }: OEQLinkProps) =>
   isSelectionSessionOpen() ? (
-    <MUILink href={muiLinkUrlProvider()} underline="none">
+    <MUILink href={muiLinkUrlProvider()} underline="none" onClick={onClick}>
       {children}
     </MUILink>
   ) : (
-    <Link to={routeLinkUrlProvider()}>{children}</Link>
+    <Link to={routeLinkUrlProvider()} onClick={onClick}>
+      {children}
+    </Link>
   );

--- a/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
@@ -166,7 +166,7 @@ export const GallerySearchItemTiles = ({
           <OEQItemSummaryPageButton
             title={viewItem}
             color="secondary"
-            item={{ uuid, version }}
+            item={{ uuid, version, drm: { drmStatus, setOnDrmAcceptCallback } }}
           />
         }
       />
@@ -199,8 +199,8 @@ export const GallerySearchItemTiles = ({
           onAccept={() => acceptDrmTerms(uuid, version)}
           onAcceptCallBack={() => {
             setDrmStatus(defaultDrmStatus);
-            onDrmAcceptCallback();
             closeDrmDialog();
+            onDrmAcceptCallback();
           }}
           onReject={closeDrmDialog}
           open={!!onDrmAcceptCallback}


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds a new REST endpoint to support listing why a DRM Item is not authorised.


![Screenshot from 2021-07-26 13-15-59](https://user-images.githubusercontent.com/47203811/126928602-98cfec80-5baf-4393-a11b-16c0e0370476.png)

Return 400 if use this endpoint for an authorised item.
![Screenshot from 2021-07-26 13-16-20](https://user-images.githubusercontent.com/47203811/126928607-65767d95-7e30-4283-8198-80987658b759.png)

Other general errors.
![Screenshot from 2021-07-26 13-16-31](https://user-images.githubusercontent.com/47203811/126928610-fb6880a2-276a-4c5e-ae07-7b03fbbde84f.png)
