### PR TITLE
Feat/kaltura embed component

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
       "react/jsx-curly-brace-presence": "error",
       "react/jsx-fragments": "error",
       "react/jsx-no-useless-fragment": "error",
-      "react/prefer-stateless-function": "error"
+      "react/prefer-stateless-function": "error",
+      "react-hooks/exhaustive-deps": "error"
     },
     "settings": {
       "jest": {

--- a/react-front-end/__stories__/components/KalturaPlayerEmbed.stories.tsx
+++ b/react-front-end/__stories__/components/KalturaPlayerEmbed.stories.tsx
@@ -1,0 +1,50 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import {
+  KalturaPlayerEmbed,
+  KalturaPlayerEmbedProps,
+} from "../../tsrc/components/KalturaPlayerEmbed";
+
+export default {
+  title: "component/KalturaEmbed",
+  component: KalturaPlayerEmbed,
+} as Meta<KalturaPlayerEmbedProps>;
+
+export const EmbeddedKalturaVideoPlayer: Story<KalturaPlayerEmbedProps> = (
+  args
+) => <KalturaPlayerEmbed {...args} />;
+EmbeddedKalturaVideoPlayer.args = {
+  // These video details were figured out from the publicly accessible demo video at:
+  // http://player.kaltura.com/modules/KalturaSupport/tests/AutoEmbed.html
+  partnerId: 243342,
+  uiconfId: 21099702,
+  entryId: "1_sf5ovm7u",
+};
+
+export const EmbeddedKalturaVideoPlayerLarge: Story<KalturaPlayerEmbedProps> = (
+  args
+) => <KalturaPlayerEmbed {...args} />;
+EmbeddedKalturaVideoPlayerLarge.args = {
+  ...EmbeddedKalturaVideoPlayer.args,
+  dimensions: {
+    width: 1120,
+    height: 630,
+  },
+};

--- a/react-front-end/tsrc/components/KalturaPlayerEmbed.tsx
+++ b/react-front-end/tsrc/components/KalturaPlayerEmbed.tsx
@@ -1,0 +1,113 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useRef, useState } from "react";
+import * as React from "react";
+
+export interface KalturaPlayerEmbedProps {
+  dimensions?: {
+    /**
+     * The height (in pixels) for the embedded Kaltura player.
+     */
+    height: number;
+    /**
+     * The width (in pixels) for the embedded Kaltura player.
+     */
+    width: number;
+  };
+  /**
+   * Kaltura Media Entry ID for the movie, audio, etc to be embedded.
+   */
+  entryId: string;
+  /**
+   * A Kaltura Partner ID for the Kaltura account which holds the content identified by `entryId`.
+   */
+  partnerId: number;
+  /**
+   * The player `uiconf_id` for the player configuration to be used to create the embedded player.
+   */
+  uiconfId: number;
+}
+
+/**
+ * Embeds the specified Kaltura Media Entry (`entryId`) using the specified player configuration
+ * (`uiconf_id`). This is achieved by requesting the `embedIframeJs` script from the Kaltura CDN
+ * using details of the hosting Kaltura account.
+ *
+ * When that script is retrieved and embedded in the page, it is then auto executed through the
+ * use of the `async` flag on the `script` tag. The execution of the script causes a player to
+ * be embedded on the div identified with the `playerId` using `kWidget.embed`.
+ *
+ * Further resources available at:
+ *
+ * - Player (`kWidget`) example doco: http://player.kaltura.com/docs/kwidget
+ * - Older API doco relating to `kWdiget`: http://player.kaltura.com/docs/api
+ *
+ * Note: This method is based on the embed code generated via the KMC share/embed functionality.
+ *       Although there is the newer doco pointing to the PlayerKitJs, on attempting to use that
+ *       a 404 was received. And seeing the KMC is still generating code with embedIframeJs this
+ *       seems the correct way.
+ */
+export const KalturaPlayerEmbed = ({
+  dimensions = { width: 400, height: 333 }, // default to value KMC uses when generating embed codes 400 x 333
+  entryId,
+  partnerId,
+  uiconfId,
+}: KalturaPlayerEmbedProps) => {
+  const divElem = useRef<HTMLElement>();
+  const [playerId] = useState<string>(`kaltura_player_${Date.now()}`);
+
+  useEffect(() => {
+    if (divElem.current) {
+      const src = new URL(
+        `https://cdnapisec.kaltura.com/p/${partnerId}/sp/${partnerId}00/embedIframeJs/uiconf_id/${uiconfId}/partner_id/${partnerId}`
+      );
+      (
+        [
+          ["autoembed", true],
+          ["entry_id", entryId],
+          ["playerId", playerId],
+          ["width", dimensions.width],
+          ["height", dimensions.height],
+        ] as [string, string][]
+      ).forEach(([name, value]) => src.searchParams.set(name, value));
+
+      const script = document.createElement("script");
+      script.async = true;
+      script.src = src.toString();
+      // This will result in a <script> block being added below the playerId <div>. Which wil auto
+      // execute and then add the player to the playerId `<div>`.
+      divElem.current.appendChild(script);
+    }
+  }, [dimensions, entryId, partnerId, playerId, uiconfId]);
+
+  return (
+    <div
+      ref={(e) => {
+        if (e) {
+          divElem.current = e;
+        }
+      }}
+    >
+      {/*Player will be embedded to the below div.*/}
+      <div
+        id={playerId}
+        style={{ width: dimensions.width, height: dimensions.height }}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included (storybook)
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

A slightly odd component. Not much code, but doing a bit of a song and dance to integrate dynamic download of a script that automatically embeds a player into a react component tree. As you'll see, not much code here, but the method is the important bit.

(Also there is some overlap with the `jQueryDiv`, however here we have no need to resort to jQuery so hence it's not used.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
