### PR TITLE
Video Gallery support for Kaltura Media

### DIFF
--- a/react-front-end/__mocks__/GallerySearchModule.mock.ts
+++ b/react-front-end/__mocks__/GallerySearchModule.mock.ts
@@ -258,7 +258,7 @@ export const basicImageSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
 export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem> =
   {
     start: 0,
-    length: 3,
+    length: 4,
     available: 15,
     results: [
       {
@@ -437,6 +437,46 @@ export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
           self: "http://localhost:8080/ian/api/item/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/",
         },
         bookmarkId: 89568,
+        isLatestVersion: true,
+      },
+      {
+        uuid: "91406c5e-e2fe-4528-beac-ab22266e0f50",
+        version: 1,
+        name: "[kaltura] snow drifting",
+        description: "from pexels",
+        status: "live",
+        createdDate: new Date("2021-07-20T16:53:24.434+10:00"),
+        modifiedDate: new Date("2021-07-20T16:53:24.430+10:00"),
+        collectionId: "312be657-ae6a-4c60-b6fa-ced02c955915",
+        starRatings: -1,
+        attachments: [
+          {
+            attachmentType: "custom/kaltura",
+            id: "5673f889-6f72-432d-ad50-29b505a28739",
+            description: "From pexels: pexels-nadezhda-moryak-6530229.mp4",
+            brokenAttachment: false,
+            preview: false,
+            links: {
+              view: "http://localhost:8080/ian/items/91406c5e-e2fe-4528-beac-ab22266e0f50/1/?attachment.uuid=5673f889-6f72-432d-ad50-29b505a28739",
+              thumbnail:
+                "http://localhost:8080/ian/thumbs/91406c5e-e2fe-4528-beac-ab22266e0f50/1/5673f889-6f72-432d-ad50-29b505a28739",
+              externalId: "4211234/48123443/1_d1h8f1dx",
+            },
+          },
+        ],
+        thumbnail: "default",
+        displayFields: [],
+        displayOptions: {
+          attachmentType: "STRUCTURED",
+          disableThumbnail: false,
+          standardOpen: false,
+          integrationOpen: false,
+        },
+        keywordFoundInAttachment: false,
+        links: {
+          view: "http://localhost:8080/ian/items/91406c5e-e2fe-4528-beac-ab22266e0f50/1/",
+          self: "http://localhost:8080/ian/api/item/91406c5e-e2fe-4528-beac-ab22266e0f50/1/",
+        },
         isLatestVersion: true,
       },
     ],

--- a/react-front-end/__tests__/tsrc/FpTsMatchers.ts
+++ b/react-front-end/__tests__/tsrc/FpTsMatchers.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import * as E from "fp-ts/Either";
+import * as O from "fp-ts/Option";
 
 expect.extend({
   /**
@@ -51,6 +52,38 @@ expect.extend({
           pass: false,
           message: () => `expected E.Right but got E.Left(${received.left})`,
         },
+
+  /**
+   * An expect matcher for Jest to confirm the response is O.None.
+   *
+   * @param received The O.Option to validate
+   */
+  toBeNone: (received: O.Option<any>): jest.CustomMatcherResult =>
+    O.isNone(received)
+      ? {
+          pass: true,
+          message: () => `expected ${received} not to be O.None`,
+        }
+      : {
+          pass: false,
+          message: () => `expected O.None but got O.Some: ${received}`,
+        },
+
+  /**
+   * An expect matcher for Jest to confirm the response is O.Some.
+   *
+   * @param received The O.Option to validate
+   */
+  toBeSome: (received: O.Option<any>): jest.CustomMatcherResult =>
+    O.isSome(received)
+      ? {
+          pass: true,
+          message: () => `expected ${received} not to be O.Some`,
+        }
+      : {
+          pass: false,
+          message: () => `expected O.Some but got O.None`,
+        },
 });
 
 declare global {
@@ -58,7 +91,12 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R> {
       toBeLeft(): jest.CustomMatcherResult;
+
       toBeRight(): jest.CustomMatcherResult;
+
+      toBeNone(): jest.CustomMatcherResult;
+
+      toBeSome(): jest.CustomMatcherResult;
     }
   }
 }

--- a/react-front-end/__tests__/tsrc/components/Lightbox.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/Lightbox.test.tsx
@@ -15,6 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import "@testing-library/jest-dom/extend-expect";
+import { queryByText, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import {
@@ -25,10 +27,8 @@ import Lightbox, {
   isLightboxSupportedMimeType,
   LightboxConfig,
 } from "../../../tsrc/components/Lightbox";
-import { queryByText, render } from "@testing-library/react";
 import { CustomMimeTypes } from "../../../tsrc/modules/MimeTypesModule";
 import { languageStrings } from "../../../tsrc/util/langstrings";
-import "@testing-library/jest-dom/extend-expect";
 import { updateMockGetBaseUrl } from "../BaseUrlHelper";
 import { basicRenderData, updateMockGetRenderData } from "../RenderDataHelper";
 
@@ -64,6 +64,7 @@ describe("isLightboxSupportedMimeType", () => {
     ["video/ogg", true],
     ["video/quicktime", false],
     [CustomMimeTypes.YOUTUBE, true],
+    [CustomMimeTypes.KALTURA, true],
   ])("MIME type: %s, supported: %s", (mimeType: string, expected: boolean) =>
     expect(isLightboxSupportedMimeType(mimeType)).toEqual(expected)
   );

--- a/react-front-end/__tests__/tsrc/components/LightboxHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/LightboxHelper.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { flow } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import { buildCustomEmbed } from "../../../tsrc/components/LightboxHelper";
+import { CustomMimeTypes } from "../../../tsrc/modules/MimeTypesModule";
+import { buildViewUrl } from "../../../tsrc/modules/YouTubeModule";
+import "../FpTsMatchers";
+
+describe("buildCustomEmbed", () => {
+  const kalturaAttachmentUrl =
+    "http://localhost:8080/ian/items/91406c5e-e2fe-4528-beac-ab22266e0f50/1/?attachment.uuid=5673f889-6f72-432d-ad50-29b505a28739";
+
+  const getOptionalComponentName: (
+    c: O.Option<JSX.Element>
+  ) => string | undefined = flow(
+    O.map((component) => component.type.name),
+    O.toUndefined
+  );
+
+  it("returns O.none if unknown MIME type provided", () => {
+    expect(buildCustomEmbed("blah/blah", "irrelevant")).toBeNone();
+  });
+
+  it("correctly builds a YouTubeEmbed when correctly specified", () => {
+    const youTubeEmbed = buildCustomEmbed(
+      CustomMimeTypes.YOUTUBE,
+      buildViewUrl("fakeId")
+    );
+    expect(youTubeEmbed).toBeSome();
+    expect(getOptionalComponentName(youTubeEmbed)).toEqual("YouTubeEmbed");
+  });
+
+  it("correctly builds a KalturaPlayerEmbed when correctly specified", () => {
+    const youTubeEmbed = buildCustomEmbed(
+      CustomMimeTypes.KALTURA,
+      `${kalturaAttachmentUrl}&externalId=4211723/48373143/1_d1h8f1dx`
+    );
+    expect(youTubeEmbed).toBeSome();
+    expect(getOptionalComponentName(youTubeEmbed)).toEqual(
+      "KalturaPlayerEmbed"
+    );
+  });
+
+  it.each([
+    [
+      "no YouTube videoId",
+      CustomMimeTypes.YOUTUBE,
+      "https://www.youtube.com/watch",
+    ],
+    ["no Kaltura externalId", CustomMimeTypes.KALTURA, kalturaAttachmentUrl],
+    [
+      "corrupt Kaltura externalId",
+      CustomMimeTypes.KALTURA,
+      `${kalturaAttachmentUrl}&externalId=blah/blah/blah`,
+    ],
+  ])(
+    "returns a LightboxMessage for %s",
+    (_: string, mimeType: string, src: string) => {
+      const component = buildCustomEmbed(mimeType, src);
+      expect(component).toBeSome();
+      expect(getOptionalComponentName(component)).toEqual("LightboxMessage");
+    }
+  );
+});

--- a/react-front-end/__tests__/tsrc/modules/GallerySearchModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/GallerySearchModule.test.ts
@@ -83,10 +83,24 @@ describe("buildGalleryEntry", () => {
       externalId: "z7i9AmmZE2o",
     },
   };
+  const kalturaAttachment: OEQ.Search.Attachment = {
+    attachmentType: "custom/kaltura",
+    id: "0da6100e-332e-4116-bd56-059a114e2130",
+    description: "TeamIT",
+    brokenAttachment: false,
+    preview: false,
+    links: {
+      view: "https://example.com/inst/items/a288b17b-4a6f-416f-9c29-aaad53cf7b23/1/?attachment.uuid=0da6100e-332e-4116-bd56-059a114e2130",
+      thumbnail:
+        "https://example.com/inst/thumbs/a288b17b-4a6f-416f-9c29-aaad53cf7b23/1/0da6100e-332e-4116-bd56-059a114e2130",
+      externalId: "3466623/47988073/1_nd0xv0cp",
+    },
+  };
 
   it.each([
     ["Image", imageAttachment],
     ["YouTube", youtubeAttachment],
+    ["Kaltura", kalturaAttachment],
   ])(
     "builds a gallery entry from a valid %s `Attachment`",
     (_: string, attachment: OEQ.Search.Attachment) => {
@@ -323,7 +337,9 @@ describe("videoGallerySearch", () => {
     expectValidGalleryResult(
       result,
       basicVideoSearchResponse.length,
-      (s) => s.startsWith("video") || s === CustomMimeTypes.YOUTUBE
+      (s) =>
+        s.startsWith("video") ||
+        [CustomMimeTypes.YOUTUBE, CustomMimeTypes.KALTURA].includes(s)
     );
   });
 });

--- a/react-front-end/__tests__/tsrc/modules/KalturaModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/KalturaModule.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  KalturaPlayerDetails,
+  parseExternalId,
+} from "../../../tsrc/modules/KalturaModule";
+
+describe("parseExternalId", () => {
+  it("extracts the player details for a properly formed externalId", () => {
+    const playerDetails: KalturaPlayerDetails = {
+      partnerId: 123,
+      uiconfId: 456,
+      entryId: "1_asdf1234",
+    };
+    const result = parseExternalId(
+      `${playerDetails.partnerId}/${playerDetails.uiconfId}/${playerDetails.entryId}`
+    );
+    expect(result).toStrictEqual(playerDetails);
+  });
+
+  it.each([
+    ["too few parts", "123/456"],
+    ["too many parts", "123/456/789/012"],
+    ["no parts", ""],
+    ["non-numeric partnerId", "text/456/asdf"],
+    ["non-numeric uiconfId", "123/text/asdf"],
+  ])(
+    "throws for malformed externalId inputs - %s",
+    (_: string, testExternalId: string) => {
+      expect(() => parseExternalId(testExternalId)).toThrow(TypeError);
+    }
+  );
+});

--- a/react-front-end/tsrc/components/KalturaPlayerEmbed.tsx
+++ b/react-front-end/tsrc/components/KalturaPlayerEmbed.tsx
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useRef, useState } from "react";
 import * as React from "react";
+import { useEffect, useRef, useState } from "react";
 
 export interface KalturaPlayerEmbedProps {
   dimensions?: {
@@ -111,3 +111,5 @@ export const KalturaPlayerEmbed = ({
     </div>
   );
 };
+
+export default KalturaPlayerEmbed;

--- a/react-front-end/tsrc/components/LightboxHelper.tsx
+++ b/react-front-end/tsrc/components/LightboxHelper.tsx
@@ -1,0 +1,87 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import * as React from "react";
+import { EXTERNAL_ID_PARAM, parseExternalId } from "../modules/KalturaModule";
+import { CustomMimeTypes } from "../modules/MimeTypesModule";
+import { extractVideoId } from "../modules/YouTubeModule";
+import { languageStrings } from "../util/langstrings";
+import { simpleMatchD } from "../util/match";
+import KalturaPlayerEmbed from "./KalturaPlayerEmbed";
+import LightboxMessage from "./LightboxMessage";
+import YouTubeEmbed from "./YouTubeEmbed";
+
+const { kalturaExternalIdIssue, kalturaMissingId, youTubeVideoMissingId } =
+  languageStrings.lightboxComponent;
+
+const buildKaltura = (src: string): O.Option<JSX.Element> =>
+  pipe(
+    new URL(src).searchParams.get(EXTERNAL_ID_PARAM),
+    E.fromNullable(kalturaMissingId),
+    E.chain((externalId) =>
+      E.tryCatch(
+        () => parseExternalId(externalId),
+        (e) => {
+          console.error("Failed to display Kaltura media in Lightbox: " + e);
+          return kalturaExternalIdIssue;
+        }
+      )
+    ),
+    E.fold(
+      (e) => <LightboxMessage message={e} />,
+      (playerDetails) => <KalturaPlayerEmbed {...playerDetails} />
+    ),
+    O.some
+  );
+
+const buildYouTube = (src: string): O.Option<JSX.Element> =>
+  pipe(
+    extractVideoId(src),
+    O.fromNullable,
+    O.map((id) => <YouTubeEmbed videoId={id} />),
+    O.alt(() => O.some(<LightboxMessage message={youTubeVideoMissingId} />))
+  );
+
+/**
+ * Builds the embedded components used by the Lightbox for oEQ custom mimetypes (i.e. those starting
+ * with `openequella/`). It assumes that the mimeType has already been checked to start with
+ * `openequella`.
+ *
+ * @param mimeType The full MIME type pointing to a custom oEQ type - e.g. openequella/youtube.
+ * @param src The src (typically a URL) for the item to embed.
+ *
+ * @return If a match for the `mimeType` is found a `JSX.Element` of either `src` or containing
+ *         processing information will be returned. However if a MIME type match fails, then
+ *         `O.none` is returned.
+ */
+export const buildCustomEmbed = (
+  mimeType: string,
+  src: string
+): O.Option<JSX.Element> =>
+  pipe(
+    mimeType,
+    simpleMatchD<O.Option<JSX.Element>>(
+      [
+        [CustomMimeTypes.KALTURA, () => buildKaltura(src)],
+        [CustomMimeTypes.YOUTUBE, () => buildYouTube(src)],
+      ],
+      () => O.none
+    )
+  );

--- a/react-front-end/tsrc/components/LightboxMessage.tsx
+++ b/react-front-end/tsrc/components/LightboxMessage.tsx
@@ -1,0 +1,41 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, Typography } from "@material-ui/core";
+import * as React from "react";
+
+export interface LightboxMessageProps {
+  /**
+   * The message to be displayed
+   */
+  message: string;
+}
+
+/**
+ * Used for displaying messages in the <Lightbox/>.
+ */
+export const LightboxMessage = ({ message }: LightboxMessageProps) => (
+  <Card>
+    <CardContent>
+      <Typography variant="h5" component="h2">
+        {message}
+      </Typography>
+    </CardContent>
+  </Card>
+);
+
+export default LightboxMessage;

--- a/react-front-end/tsrc/modules/AttachmentsModule.ts
+++ b/react-front-end/tsrc/modules/AttachmentsModule.ts
@@ -21,12 +21,14 @@ import * as OEQ from "@openequella/rest-api-client";
 
 /** `attachmentType` for file attachments. */
 export const ATYPE_FILE = "file";
+/** `attachmentType` for attachments linking to Kaltura media. */
+export const ATYPE_KALTURA = "custom/kaltura";
 /** `attachmentType` for link/URL attachments. */
 export const ATYPE_LINK = "link";
-/** `attachmentType` for attachments linking to YouTube videos. */
-export const ATYPE_YOUTUBE = "custom/youtube";
 /** `attachmentType` for attachments linking to oEQ resources(e.g. Item). */
 export const ATYPE_RESOURCE = "custom/resource";
+/** `attachmentType` for attachments linking to YouTube videos. */
+export const ATYPE_YOUTUBE = "custom/youtube";
 
 /**
  * Build a direct URL to a file attachment.

--- a/react-front-end/tsrc/modules/KalturaModule.ts
+++ b/react-front-end/tsrc/modules/KalturaModule.ts
@@ -18,9 +18,22 @@
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 
+/**
+ * The bare minimum fields to create an embedded player and matches those found over in
+ * `KalturaPlayerEmbedProps`.
+ */
 export interface KalturaPlayerDetails {
+  /**
+   * A Kaltura Partner ID for the Kaltura account which holds the content identified by `entryId`.
+   */
   partnerId: number;
+  /**
+   * The player `uiconf_id` for the player configuration to be used to create the embedded player.
+   */
   uiconfId: number;
+  /**
+   * Kaltura Media Entry ID for the movie, audio, etc to be embedded.
+   */
   entryId: string;
 }
 

--- a/react-front-end/tsrc/modules/KalturaModule.ts
+++ b/react-front-end/tsrc/modules/KalturaModule.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+
+export interface KalturaPlayerDetails {
+  partnerId: number;
+  uiconfId: number;
+  entryId: string;
+}
+
+export const EXTERNAL_ID_PARAM = "externalId";
+
+/**
+ * Given an externalId from a Kaltura attachments in the format of `<partnerId>/<uiconfId>/<entryId>`
+ * splits it into it its parts and returns a representative object. If there are issues with the
+ * format, then a `TypeError` will be thrown.
+ *
+ * @param externalId an externalId property for Kaltura attachments from the oEQ server
+ */
+export const parseExternalId = (externalId: string): KalturaPlayerDetails => {
+  const result: E.Either<string, KalturaPlayerDetails> = pipe(
+    externalId.split("/"),
+    E.fromPredicate(
+      (xs) => xs.length === 3,
+      (xs) => `externalId should have three parts, but has ${xs.length}`
+    ),
+    E.map(([partnerId, uiconfId, entryId]) => ({
+      partnerId: Number.parseInt(partnerId),
+      uiconfId: Number.parseInt(uiconfId),
+      entryId,
+    })),
+    E.filterOrElse(
+      ({ partnerId }) => Number.isInteger(partnerId),
+      () => "partnerId should be a number"
+    ),
+    E.filterOrElse(
+      ({ uiconfId }) => Number.isInteger(uiconfId),
+      () => "uiconfId should be a number"
+    )
+  );
+
+  if (E.isLeft(result)) {
+    throw new TypeError(result.left);
+  }
+  return result.right;
+};

--- a/react-front-end/tsrc/modules/MimeTypesModule.ts
+++ b/react-front-end/tsrc/modules/MimeTypesModule.ts
@@ -23,8 +23,10 @@ export const OEQ_MIMETYPE_TYPE = "openequella";
 /**
  * A collection of custom internal MIME types for openEQUELLA
  */
+const customType = (type: string): string => `${OEQ_MIMETYPE_TYPE}/${type}`;
 export const CustomMimeTypes = {
-  YOUTUBE: `${OEQ_MIMETYPE_TYPE}/youtube`,
+  YOUTUBE: customType("youtube"),
+  KALTURA: customType("kaltura"),
 };
 
 export const getMIMETypesFromServer = (): Promise<

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -314,11 +314,15 @@ export const languageStrings = {
     failedToDelete: "Failed to delete '%s' due to error: %s",
   },
   lightboxComponent: {
+    kalturaExternalIdIssue:
+      "There is an issue with the format of the externalId for the the Kaltura Video",
+    kalturaMissingId:
+      "The provided Kaltura media is missing externalId details",
+    openSummaryPage: "Open Item Summary page",
     unsupportedContent: "Provided content is not supported",
     viewNext: "View next attachment",
     viewPrevious: "View previous attachment",
     youTubeVideoMissingId: "The provided YouTube video is missing a video ID",
-    openSummaryPage: "Open Item Summary page",
   },
   loginnoticepage: {
     title: "Login notice editor",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This PR integrates all the other work and provides support for Kaltura media in the the New Search UI Video Gallery. There will be a subsequent PR which will add similar support for previewing Kaltura media via the lightbox in standard list mode.

Also there is a future piece of work to add support for high-res thumbnails. But that's outside of this PR.

The only area of note of the implementation is how the `externalId` value (containing the the delimited values we need to embed a player) from the search results through to the Lightbox that really only wants a MIME type and a `src`. For this I decided to simply add the `externalId` as a param to the `src` URL and then in the Lightbox pull it off and parse it when needed. Further, there was no issue leaving this in place for the viewing in new tab - oEQ just ignores it.

Here is a video run through (with commentary):

https://user-images.githubusercontent.com/43919233/127462662-d4967def-bd40-4dc3-bfae-946acfc095aa.mp4

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
