### PR TITLE
Feature/show DRM violations in dialog

### DIFF
--- a/react-front-end/__mocks__/Drm.mock.ts
+++ b/react-front-end/__mocks__/Drm.mock.ts
@@ -56,3 +56,6 @@ export const drmTermsRejected = async () => {
   await withDelay();
   return Promise.reject("network error");
 };
+
+export const DRM_VIOLATION =
+  "User is viewing this item outside of the dates that it is restricted to.";

--- a/react-front-end/__mocks__/searchresult_mock_data.ts
+++ b/react-front-end/__mocks__/searchresult_mock_data.ts
@@ -342,6 +342,10 @@ const drmAttachObj: OEQ.Search.SearchResultItem = {
   drmStatus: { isAuthorised: true, termsAccepted: false },
 };
 
+const drmUnauthorisedObj = {
+  ...drmAttachObj,
+  drmStatus: { isAuthorised: false, termsAccepted: false },
+};
 export {
   basicSearchObj,
   attachSearchObj,
@@ -350,4 +354,5 @@ export {
   oneDeadAttachObj,
   oneDeadOneAliveAttachObj,
   drmAttachObj,
+  drmUnauthorisedObj,
 };

--- a/react-front-end/__mocks__/searchresult_mock_data.ts
+++ b/react-front-end/__mocks__/searchresult_mock_data.ts
@@ -286,10 +286,13 @@ const oneDeadOneAliveAttachObj: OEQ.Search.SearchResultItem = {
   isLatestVersion: true,
 };
 
+export const DRM_ITEM_NAME = "DRM Item";
+export const DRM_ATTACHMENT_NAME = "DRM Attachment Item";
+
 const drmAttachObj: OEQ.Search.SearchResultItem = {
   uuid: "72558c1d-8788-4515-86c8-b24a28cc451e",
   version: 1,
-  name: "DRM Item",
+  name: DRM_ITEM_NAME,
   description: "A description of a bird",
   status: "live",
   createdDate: new Date("2020-05-26T13:24:00.889+10:00"),
@@ -301,7 +304,7 @@ const drmAttachObj: OEQ.Search.SearchResultItem = {
     {
       attachmentType: "file",
       id: "9e751549-5cba-47dd-bccb-722c48072287",
-      description: "DRM Attachment",
+      description: DRM_ATTACHMENT_NAME,
       preview: false,
       mimeType: "image/png",
       hasGeneratedThumb: true,

--- a/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
@@ -35,6 +35,7 @@ import { act } from "react-dom/test-utils";
 import { Router } from "react-router-dom";
 import { getAdvancedSearchesFromServerResult } from "../../../__mocks__/AdvancedSearchModule.mock";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
+import { DRM_VIOLATION } from "../../../__mocks__/Drm.mock";
 import {
   transformedBasicImageSearchResponse,
   transformedBasicVideoSearchResponse,
@@ -53,6 +54,7 @@ import * as AdvancedSearchModule from "../../../tsrc/modules/AdvancedSearchModul
 import * as BrowserStorageModule from "../../../tsrc/modules/BrowserStorageModule";
 import type { Collection } from "../../../tsrc/modules/CollectionsModule";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
+import * as DrmModule from "../../../tsrc/modules/DrmModule";
 import * as FavouriteModule from "../../../tsrc/modules/FavouriteModule";
 import * as GallerySearchModule from "../../../tsrc/modules/GallerySearchModule";
 import { getGlobalCourseList } from "../../../tsrc/modules/LegacySelectionSessionModule";
@@ -136,6 +138,10 @@ const mockReadDataFromLocalStorage = jest.spyOn(
   BrowserStorageModule,
   "readDataFromLocalStorage"
 );
+
+jest
+  .spyOn(DrmModule, "listDrmViolations")
+  .mockResolvedValue({ violation: DRM_VIOLATION });
 
 //i tried mocking this using window.navigator.clipboard.writeText = jest.fn(), but the navigator object is undefined
 Object.assign(navigator, {

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -111,14 +111,8 @@ describe("<GallerySearchResult />", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
 
     it.each([
-      [
-        "view a DRM Item's summary page",
-        languageStrings.searchpage.gallerySearchResult.viewItem,
-      ],
-      [
-        "preview an gallery entry protected by DRM",
-        languageStrings.searchpage.gallerySearchResult.ariaLabel,
-      ],
+      ["view a DRM Item's summary page", viewItem],
+      ["preview an gallery entry protected by DRM", ariaLabel],
     ])(
       "shows DRM acceptance dialog when %s",
       async (_: string, galleryEntryLabel: string) => {
@@ -136,8 +130,8 @@ describe("<GallerySearchResult />", () => {
     );
 
     it.each([
-      ["item", languageStrings.searchpage.gallerySearchResult.viewItem],
-      ["attachment", languageStrings.searchpage.gallerySearchResult.ariaLabel],
+      ["item", viewItem],
+      ["attachment", ariaLabel],
     ])(
       "shows a dialog to list DRM violations for %s",
       async (_: string, galleryEntryLabel: string) => {

--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResultHelpers.ts
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResultHelpers.ts
@@ -61,3 +61,8 @@ export const galleryDrmItem: GallerySearchResultItem = {
   mainEntry: buildGalleryEntry("Main Entry #1"),
   additionalEntries: [],
 };
+
+export const galleryDrmUnauthorisedItem = {
+  ...galleryDrmItem,
+  drmStatus: { isAuthorised: false, termsAccepted: false },
+};

--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -32,6 +32,10 @@ import { act } from "react-dom/test-utils";
 import { BrowserRouter } from "react-router-dom";
 import { sprintf } from "sprintf-js";
 import { DRM_VIOLATION, drmTerms } from "../../../../__mocks__/Drm.mock";
+import {
+  DRM_ATTACHMENT_NAME,
+  DRM_ITEM_NAME,
+} from "../../../../__mocks__/searchresult_mock_data";
 import * as mockData from "../../../../__mocks__/searchresult_mock_data";
 import type { RenderData } from "../../../../tsrc/AppConfig";
 import {
@@ -524,8 +528,8 @@ describe("<SearchResult/>", () => {
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
 
     it.each([
-      ["view a DRM Item's summary page", "DRM Item"],
-      ["preview an attachment from a DRM item", "DRM Attachment"],
+      ["view a DRM Item's summary page", DRM_ITEM_NAME],
+      ["preview an attachment from a DRM item", DRM_ATTACHMENT_NAME],
     ])(
       "shows the DRM Accept dialog %s",
       async (_: string, linkText: string) => {
@@ -542,8 +546,8 @@ describe("<SearchResult/>", () => {
     );
 
     it.each([
-      ["item", "DRM Item"],
-      ["attachment", "DRM Attachment"],
+      ["item", DRM_ITEM_NAME],
+      ["attachment", DRM_ATTACHMENT_NAME],
     ])(
       "shows a dialog to list DRM violations for %s",
       async (_: string, linkText: string) => {

--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -31,7 +31,7 @@ import * as React from "react";
 import { act } from "react-dom/test-utils";
 import { BrowserRouter } from "react-router-dom";
 import { sprintf } from "sprintf-js";
-import { drmTerms } from "../../../../__mocks__/Drm.mock";
+import { DRM_VIOLATION, drmTerms } from "../../../../__mocks__/Drm.mock";
 import * as mockData from "../../../../__mocks__/searchresult_mock_data";
 import type { RenderData } from "../../../../tsrc/AppConfig";
 import {
@@ -518,6 +518,9 @@ describe("<SearchResult/>", () => {
   });
 
   describe("DRM support", () => {
+    jest
+      .spyOn(DrmModule, "listDrmViolations")
+      .mockResolvedValue({ violation: DRM_VIOLATION });
     jest.spyOn(DrmModule, "listDrmTerms").mockResolvedValue(drmTerms);
 
     it.each([
@@ -533,6 +536,24 @@ describe("<SearchResult/>", () => {
         await waitFor(() => {
           expect(
             queryByText(screen.getByRole("dialog"), drmTerms.title)
+          ).toBeInTheDocument();
+        });
+      }
+    );
+
+    it.each([
+      ["item", "DRM Item"],
+      ["attachment", "DRM Attachment"],
+    ])(
+      "shows a dialog to list DRM violations for %s",
+      async (_: string, linkText: string) => {
+        const { drmUnauthorisedObj } = mockData;
+        const { getByText } = await renderSearchResult(drmUnauthorisedObj);
+        userEvent.click(getByText(linkText));
+
+        await waitFor(() => {
+          expect(
+            queryByText(screen.getByRole("dialog"), DRM_VIOLATION)
           ).toBeInTheDocument();
         });
       }

--- a/react-front-end/tsrc/drm/DrmHelper.tsx
+++ b/react-front-end/tsrc/drm/DrmHelper.tsx
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 import * as React from "react";
+import MessageDialog from "../components/MessageDialog";
 import {
   acceptDrmTerms,
   defaultDrmStatus,
   listDrmTerms,
+  listDrmViolations,
 } from "../modules/DrmModule";
 import { DrmAcceptanceDialog } from "./DrmAcceptanceDialog";
 import * as OEQ from "@openequella/rest-api-client";
@@ -43,14 +45,14 @@ import * as OEQ from "@openequella/rest-api-client";
  * @param closeDrmDialog Function to close the resultant DRM dialog.
  * @param drmProtectedHandler Handler that can't be used until a DRM check is completed.
  */
-export const createDrmDialog = (
+export const createDrmDialog = async (
   uuid: string,
   version: number,
   drmStatus: OEQ.Search.DrmStatus,
   updateDrmStatus: (status: OEQ.Search.DrmStatus) => void,
   closeDrmDialog: () => void,
   drmProtectedHandler: () => void
-): JSX.Element | undefined => {
+): Promise<JSX.Element | undefined> => {
   const { isAuthorised, termsAccepted } = drmStatus;
   if (isAuthorised && !termsAccepted) {
     return (
@@ -64,6 +66,16 @@ export const createDrmDialog = (
         }}
         onReject={closeDrmDialog}
         open={!!drmProtectedHandler}
+      />
+    );
+  } else if (!isAuthorised) {
+    const { violation } = await listDrmViolations(uuid, version);
+    return (
+      <MessageDialog
+        open
+        title="DRM violations"
+        messages={[violation]}
+        close={closeDrmDialog}
       />
     );
   } else {

--- a/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
@@ -100,18 +100,20 @@ export const GallerySearchItemTiles = ({
     setDrmCheckOnSuccessHandler(() => onSuccess);
 
   useEffect(() => {
-    const dialog = drmCheckOnSuccessHandler
-      ? createDrmDialog(
-          uuid,
-          version,
-          drmStatus,
-          setDrmStatus,
-          () => setDrmCheckOnSuccessHandler(undefined),
-          drmCheckOnSuccessHandler
-        )
-      : undefined;
+    (async () => {
+      const dialog = drmCheckOnSuccessHandler
+        ? await createDrmDialog(
+            uuid,
+            version,
+            drmStatus,
+            setDrmStatus,
+            () => setDrmCheckOnSuccessHandler(undefined),
+            drmCheckOnSuccessHandler
+          )
+        : undefined;
 
-    setDrmDialog(dialog);
+      setDrmDialog(dialog);
+    })();
   }, [drmCheckOnSuccessHandler, uuid, version, drmStatus]);
 
   // Used to build the onClick event handler for each tile.

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -190,19 +190,21 @@ export default function SearchResult({
     setDrmCheckOnSuccessHandler(() => onSuccess);
 
   useEffect(() => {
-    // If there is nothing requiring DRM permission check then return undefined.
-    const dialog = drmCheckOnSuccessHandler
-      ? createDrmDialog(
-          uuid,
-          version,
-          drmStatus,
-          setDrmStatus,
-          () => setDrmCheckOnSuccessHandler(undefined),
-          drmCheckOnSuccessHandler
-        )
-      : undefined;
+    (async () => {
+      // If there is nothing requiring DRM permission check then return undefined.
+      const dialog = drmCheckOnSuccessHandler
+        ? await createDrmDialog(
+            uuid,
+            version,
+            drmStatus,
+            setDrmStatus,
+            () => setDrmCheckOnSuccessHandler(undefined),
+            drmCheckOnSuccessHandler
+          )
+        : undefined;
 
-    setDrmDialog(dialog);
+      setDrmDialog(dialog);
+    })();
   }, [drmCheckOnSuccessHandler, uuid, version, drmStatus]);
 
   const handleSelectResource = (


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for listing DRM violations for unauthorised Items and attachments. The main change is to update the logic of DRM check in `DrmHelper`. This change results in function `createDrmDialog` becoming an async function, and therefore the `useEffect` which uses this function gets slightly changed as well. 

I tried to implement a custom hook `useAsyncEffect` but stopped after a couple hours experiments as I thought the next DRM ticket is more important.


https://user-images.githubusercontent.com/47203811/127578666-fe879e2a-1ea5-4687-9571-f3371a170598.mp4


