### PR TITLE
Feature/only show authorised entries in Lightbox

### DIFF
--- a/react-front-end/tsrc/drm/DrmHelper.tsx
+++ b/react-front-end/tsrc/drm/DrmHelper.tsx
@@ -43,7 +43,7 @@ import * as OEQ from "@openequella/rest-api-client";
  *
  * @param uuid Item's UUID.
  * @param version Item's version.
- * @param drmStatus Item's DRM status.
+ * @param drmStatus Item's DRM status which defaults to authorised and terms accepted.
  * @param updateDrmStatus Function to update DRM status on client side. Typically, this is a React state setter.
  * @param closeDrmDialog Function to close the resultant DRM dialog.
  * @param drmProtectedHandler Handler that can't be used until a DRM check is completed.
@@ -51,7 +51,7 @@ import * as OEQ from "@openequella/rest-api-client";
 export const createDrmDialog = async (
   uuid: string,
   version: number,
-  drmStatus: OEQ.Search.DrmStatus,
+  drmStatus: OEQ.Search.DrmStatus = defaultDrmStatus,
   updateDrmStatus: (status: OEQ.Search.DrmStatus) => void,
   closeDrmDialog: () => void,
   drmProtectedHandler: () => void

--- a/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
@@ -51,8 +51,17 @@ const useStyles = makeStyles({
  * Type for the handler of opening Lightbox from Gallery.
  */
 export type LightboxHandler = (
+  /**
+   * @param uuid Item's UUID.
+   */
   uuid: string,
+  /**
+   * @param version Item's Version.
+   */
   version: number,
+  /**
+   * @param entry A Gallery Entry to be viewed in the Lightbox.
+   */
   entry: GalleryEntry
 ) => void;
 
@@ -84,12 +93,13 @@ export const GallerySearchItemTiles = ({
     name,
     uuid,
     version,
-    drmStatus: initialDrmStatus = defaultDrmStatus,
+    drmStatus: initialDrmStatus,
   } = item;
   const itemName = name ?? uuid;
 
-  const [drmStatus, setDrmStatus] =
-    useState<OEQ.Search.DrmStatus>(initialDrmStatus);
+  const [drmStatus, setDrmStatus] = useState<OEQ.Search.DrmStatus | undefined>(
+    initialDrmStatus
+  );
   const [drmCheckOnSuccessHandler, setDrmCheckOnSuccessHandler] = useState<
     (() => void) | undefined
   >();
@@ -119,13 +129,12 @@ export const GallerySearchItemTiles = ({
 
   // Build a click event handler for each tile.
   const buildOnClickHandler = (entry: GalleryEntry) => () => {
-    checkDrmPermission(() =>
-      updateGalleryItemList({ ...item, drmStatus: defaultDrmStatus })(
-        uuid,
-        version,
-        entry
-      )
-    );
+    checkDrmPermission(() => {
+      const updatedItem = drmStatus
+        ? { ...item, drmStatus: defaultDrmStatus }
+        : item;
+      updateGalleryItemList(updatedItem)(uuid, version, entry);
+    });
   };
 
   const buildTile = (

--- a/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchItemTiles.tsx
@@ -20,7 +20,6 @@ import { makeStyles } from "@material-ui/core/styles";
 import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import { LightboxProps } from "../../components/Lightbox";
 import { OEQItemSummaryPageButton } from "../../components/OEQItemSummaryPageButton";
 import { createDrmDialog } from "../../drm/DrmHelper";
 import { defaultDrmStatus } from "../../modules/DrmModule";
@@ -28,10 +27,6 @@ import {
   GalleryEntry,
   GallerySearchResultItem,
 } from "../../modules/GallerySearchModule";
-import {
-  buildLightboxNavigationHandler,
-  LightboxEntry,
-} from "../../modules/ViewerModule";
 import { languageStrings } from "../../util/langstrings";
 
 const { ariaLabel, viewItem } = languageStrings.searchpage.gallerySearchResult;
@@ -52,39 +47,45 @@ const useStyles = makeStyles({
   },
 });
 
+/**
+ * Type for the handler of opening Lightbox from Gallery.
+ */
+export type LightboxHandler = (
+  uuid: string,
+  version: number,
+  entry: GalleryEntry
+) => void;
+
 export interface GallerySearchTileProps {
   /**
    * The Item to be displayed in the gallery.
    */
   item: GallerySearchResultItem;
   /**
-   * A list of Lightbox viewable resources.
-   */
-  lightboxEntries: LightboxEntry[];
-  /**
-   * Function to determine whether to open Lightbox or not.
+   * Function to update the list of Items in GallerySearchResult and return a LightboxHandler. Typically used
+   * as a callback of successfully accepting DRM terms.
    *
-   * @param props Props that will be passed to Lightbox, or `undefined` to close Lightbox.
+   * @param item Updated Item which typically only has DRM status changed.
    */
-  setLightboxProps: (props: LightboxProps | undefined) => void;
+  updateGalleryItemList: (item: GallerySearchResultItem) => LightboxHandler;
 }
 
 /**
  * Component which builds a list of 'GridListTile' for all gallery entries of an Item.
  */
 export const GallerySearchItemTiles = ({
-  item: {
+  item,
+  updateGalleryItemList,
+}: GallerySearchTileProps) => {
+  const classes = useStyles();
+  const {
     mainEntry,
     additionalEntries,
     name,
     uuid,
     version,
     drmStatus: initialDrmStatus = defaultDrmStatus,
-  },
-  lightboxEntries,
-  setLightboxProps,
-}: GallerySearchTileProps) => {
-  const classes = useStyles();
+  } = item;
   const itemName = name ?? uuid;
 
   const [drmStatus, setDrmStatus] =
@@ -116,45 +117,15 @@ export const GallerySearchItemTiles = ({
     })();
   }, [drmCheckOnSuccessHandler, uuid, version, drmStatus]);
 
-  // Used to build the onClick event handler for each tile.
-  const lightboxHandler = ({
-    mimeType,
-    directUrl: src,
-    name,
-    id,
-  }: GalleryEntry) => {
-    const initialLightboxEntryIndex = lightboxEntries.findIndex(
-      (entry) => entry.id === id
-    );
-
-    return setLightboxProps({
-      onClose: () => setLightboxProps(undefined),
-      open: true,
-      item: {
-        uuid,
-        version,
-      },
-      config: {
-        src,
-        title: name,
-        mimeType,
-        onNext: buildLightboxNavigationHandler(
-          lightboxEntries,
-          initialLightboxEntryIndex + 1,
-          true
-        ),
-        onPrevious: buildLightboxNavigationHandler(
-          lightboxEntries,
-          initialLightboxEntryIndex - 1,
-          true
-        ),
-      },
-    });
-  };
-
   // Build a click event handler for each tile.
   const buildOnClickHandler = (entry: GalleryEntry) => () => {
-    checkDrmPermission(() => lightboxHandler(entry));
+    checkDrmPermission(() =>
+      updateGalleryItemList({ ...item, drmStatus: defaultDrmStatus })(
+        uuid,
+        version,
+        entry
+      )
+    );
   };
 
   const buildTile = (

--- a/react-front-end/tsrc/search/components/GallerySearchResult.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchResult.tsx
@@ -41,8 +41,16 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
   >();
 
   // A list of LightboxEntry which includes all main entries and additional entries.
-  const lightboxEntries: LightboxEntry[] = items.flatMap(
-    ({ mainEntry, additionalEntries }) =>
+  const lightboxEntries: LightboxEntry[] = items
+    .filter(({ drmStatus }) => {
+      if (drmStatus) {
+        const { isAuthorised, termsAccepted } = drmStatus;
+        return isAuthorised && termsAccepted;
+      }
+      // If no a DRM Item, keep it.
+      return true;
+    })
+    .flatMap(({ mainEntry, additionalEntries }) =>
       [mainEntry, ...additionalEntries].map(
         ({ id, name, mimeType, directUrl }) => ({
           src: directUrl,
@@ -51,7 +59,7 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
           id,
         })
       )
-  );
+    );
 
   const mapItemsToTiles = () =>
     items.map((item) => (

--- a/react-front-end/tsrc/search/components/GallerySearchResult.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchResult.tsx
@@ -19,9 +19,18 @@ import { GridList } from "@material-ui/core";
 import * as React from "react";
 import { useState } from "react";
 import Lightbox, { LightboxProps } from "../../components/Lightbox";
-import { GallerySearchResultItem } from "../../modules/GallerySearchModule";
-import { LightboxEntry } from "../../modules/ViewerModule";
-import { GallerySearchItemTiles } from "./GallerySearchItemTiles";
+import {
+  GalleryEntry,
+  GallerySearchResultItem,
+} from "../../modules/GallerySearchModule";
+import {
+  buildLightboxNavigationHandler,
+  LightboxEntry,
+} from "../../modules/ViewerModule";
+import {
+  GallerySearchItemTiles,
+  LightboxHandler,
+} from "./GallerySearchItemTiles";
 
 export interface GallerySearchResultProps {
   /**
@@ -40,33 +49,84 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
     LightboxProps | undefined
   >();
 
-  // A list of LightboxEntry which includes all main entries and additional entries.
-  const lightboxEntries: LightboxEntry[] = items
-    .filter(({ drmStatus }) => {
-      if (drmStatus) {
-        const { isAuthorised, termsAccepted } = drmStatus;
-        return isAuthorised && termsAccepted;
-      }
-      // If no a DRM Item, keep it.
-      return true;
-    })
-    .flatMap(({ mainEntry, additionalEntries }) =>
-      [mainEntry, ...additionalEntries].map(
-        ({ id, name, mimeType, directUrl }) => ({
-          src: directUrl,
-          title: name,
-          mimeType: mimeType,
-          id,
-        })
-      )
+  const [galleryItems, setGalleryItems] =
+    useState<GallerySearchResultItem[]>(items);
+
+  // Function to update the Item list, rebuild the Lightbox entry list and return a lightboxHandler.
+  const updateGalleryItemList = (
+    newItem: GallerySearchResultItem
+  ): LightboxHandler => {
+    const newItems = galleryItems.map((i) =>
+      i.uuid === newItem.uuid && i.version === newItem.version ? newItem : i
     );
+    setGalleryItems(newItems);
+
+    // A list of LightboxEntry which includes all main entries and additional entries.
+    const lightboxEntries: LightboxEntry[] = newItems
+      .filter(({ drmStatus }) => {
+        if (drmStatus) {
+          const { isAuthorised, termsAccepted } = drmStatus;
+          return isAuthorised && termsAccepted;
+        }
+        // If no a DRM Item, keep it.
+        return true;
+      })
+      .flatMap(({ mainEntry, additionalEntries }) =>
+        [mainEntry, ...additionalEntries].map(
+          ({ id, name, mimeType, directUrl }) => ({
+            src: directUrl,
+            title: name,
+            mimeType: mimeType,
+            id,
+          })
+        )
+      );
+
+    return (uuid: string, version: number, entry: GalleryEntry) =>
+      lightboxHandler(lightboxEntries, uuid, version, entry);
+  };
+
+  // Handler for opening the Lightbox
+  const lightboxHandler = (
+    lightboxEntries: LightboxEntry[],
+    uuid: string,
+    version: number,
+    { mimeType, directUrl: src, name, id }: GalleryEntry
+  ) => {
+    const initialLightboxEntryIndex = lightboxEntries.findIndex(
+      (entry) => entry.id === id
+    );
+
+    return setLightboxProps({
+      onClose: () => setLightboxProps(undefined),
+      open: true,
+      item: {
+        uuid,
+        version,
+      },
+      config: {
+        src,
+        title: name,
+        mimeType,
+        onNext: buildLightboxNavigationHandler(
+          lightboxEntries,
+          initialLightboxEntryIndex + 1,
+          true
+        ),
+        onPrevious: buildLightboxNavigationHandler(
+          lightboxEntries,
+          initialLightboxEntryIndex - 1,
+          true
+        ),
+      },
+    });
+  };
 
   const mapItemsToTiles = () =>
     items.map((item) => (
       <GallerySearchItemTiles
         item={item}
-        lightboxEntries={lightboxEntries}
-        setLightboxProps={setLightboxProps}
+        updateGalleryItemList={updateGalleryItemList}
         key={`${item.uuid}/${item.version}`}
       />
     ));

--- a/react-front-end/tsrc/search/components/GallerySearchResult.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchResult.tsx
@@ -52,40 +52,6 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
   const [galleryItems, setGalleryItems] =
     useState<GallerySearchResultItem[]>(items);
 
-  // Function to update the Item list, rebuild the Lightbox entry list and return a lightboxHandler.
-  const updateGalleryItemList = (
-    newItem: GallerySearchResultItem
-  ): LightboxHandler => {
-    const newItems = galleryItems.map((i) =>
-      i.uuid === newItem.uuid && i.version === newItem.version ? newItem : i
-    );
-    setGalleryItems(newItems);
-
-    // A list of LightboxEntry which includes all main entries and additional entries.
-    const lightboxEntries: LightboxEntry[] = newItems
-      .filter(({ drmStatus }) => {
-        if (drmStatus) {
-          const { isAuthorised, termsAccepted } = drmStatus;
-          return isAuthorised && termsAccepted;
-        }
-        // If no a DRM Item, keep it.
-        return true;
-      })
-      .flatMap(({ mainEntry, additionalEntries }) =>
-        [mainEntry, ...additionalEntries].map(
-          ({ id, name, mimeType, directUrl }) => ({
-            src: directUrl,
-            title: name,
-            mimeType: mimeType,
-            id,
-          })
-        )
-      );
-
-    return (uuid: string, version: number, entry: GalleryEntry) =>
-      lightboxHandler(lightboxEntries, uuid, version, entry);
-  };
-
   // Handler for opening the Lightbox
   const lightboxHandler = (
     lightboxEntries: LightboxEntry[],
@@ -120,6 +86,40 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
         ),
       },
     });
+  };
+
+  // Function to update the Item list, rebuild the Lightbox entry list and return a lightboxHandler.
+  const updateGalleryItemList = (
+    newItem: GallerySearchResultItem
+  ): LightboxHandler => {
+    const updatedItems = galleryItems.map((i) =>
+      i.uuid === newItem.uuid && i.version === newItem.version ? newItem : i
+    );
+    setGalleryItems(updatedItems);
+
+    // A list of LightboxEntry which includes all main entries and additional entries.
+    const lightboxEntries: LightboxEntry[] = updatedItems
+      .filter(({ drmStatus }) => {
+        if (drmStatus) {
+          const { isAuthorised, termsAccepted } = drmStatus;
+          return isAuthorised && termsAccepted;
+        }
+        // If not a DRM Item, keep it.
+        return true;
+      })
+      .flatMap(({ mainEntry, additionalEntries }) =>
+        [mainEntry, ...additionalEntries].map(
+          ({ id, name, mimeType, directUrl }) => ({
+            src: directUrl,
+            title: name,
+            mimeType: mimeType,
+            id,
+          })
+        )
+      );
+
+    return (uuid: string, version: number, entry: GalleryEntry) =>
+      lightboxHandler(lightboxEntries, uuid, version, entry);
   };
 
   const mapItemsToTiles = () =>


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR includes two parts. 
1. Only show gallery entries that have been accepted DRM terms and authorised.
2. Add the gallery entry that has just been accepted to the Lightbox entry list.


https://user-images.githubusercontent.com/47203811/127603321-e7dbe9e5-f2a4-46e0-bbe9-b0bff7267800.mp4

