### PR TITLE
feat(react-front-end): preview kaltura videos in list-mode search

### DIFF
--- a/react-front-end/__tests__/tsrc/modules/AttachmentsModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/AttachmentsModule.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { updateAttachmentForCustomInfo } from "../../../tsrc/modules/AttachmentsModule";
+import { CustomMimeTypes } from "../../../tsrc/modules/MimeTypesModule";
+
+describe("updateAttachmentForCustomInfo", () => {
+  const fileAttachment: OEQ.Search.Attachment = {
+    attachmentType: "file",
+    id: "e82207be-a9f2-442a-a17f-5c834d5b36cc",
+    description: "DailyStoicLogo.jpeg",
+    preview: false,
+    mimeType: "image/jpeg",
+    hasGeneratedThumb: true,
+    brokenAttachment: false,
+    links: {
+      view: "http://localhost:8080/ian/items/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/?attachment.uuid=e82207be-a9f2-442a-a17f-5c834d5b36cc",
+      thumbnail:
+        "http://localhost:8080/ian/thumbs/9d5112d4-87b6-4ac1-b773-ceaa4a6c5205/1/e82207be-a9f2-442a-a17f-5c834d5b36cc",
+    },
+    filePath: "DailyStoicLogo.jpeg",
+  };
+
+  const kalturaAttachment: OEQ.Search.Attachment = {
+    attachmentType: "custom/kaltura",
+    id: "5673f889-6f72-432d-ad50-29b505a28739",
+    description: "From pexels: pexels-nadezhda-moryak-6530229.mp4",
+    brokenAttachment: false,
+    preview: false,
+    links: {
+      view: "http://localhost:8080/ian/items/91406c5e-e2fe-4528-beac-ab22266e0f50/1/?attachment.uuid=5673f889-6f72-432d-ad50-29b505a28739",
+      thumbnail:
+        "http://localhost:8080/ian/thumbs/91406c5e-e2fe-4528-beac-ab22266e0f50/1/5673f889-6f72-432d-ad50-29b505a28739",
+      externalId: "4211234/48123443/1_d1h8f1dx",
+    },
+  };
+
+  const youTubeAttachment: OEQ.Search.Attachment = {
+    attachmentType: "custom/youtube",
+    id: "398dbef0-7d12-4b72-af3d-095dd70b019d",
+    description: "6 Tips For Caring for African Violets",
+    preview: false,
+    brokenAttachment: false,
+    links: {
+      view: "http://localhost:8080/ian/items/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/?attachment.uuid=398dbef0-7d12-4b72-af3d-095dd70b019d",
+      thumbnail:
+        "http://localhost:8080/ian/thumbs/de8fcb0b-0b1c-4c34-9173-a83d1b0be6b5/1/398dbef0-7d12-4b72-af3d-095dd70b019d",
+      externalId: "9VCudo90K5I",
+    },
+  };
+
+  it("updates Kaltura attachments", () => {
+    const updated = updateAttachmentForCustomInfo(kalturaAttachment);
+    expect(updated.mimeType).toEqual(CustomMimeTypes.KALTURA);
+    expect(updated.links.view).toEqual(
+      "http://localhost:8080/ian/items/91406c5e-e2fe-4528-beac-ab22266e0f50/1/?attachment.uuid=5673f889-6f72-432d-ad50-29b505a28739&externalId=4211234%2F48123443%2F1_d1h8f1dx"
+    );
+  });
+
+  it("updates YouTube attachments", () => {
+    const updated = updateAttachmentForCustomInfo(youTubeAttachment);
+    expect(updated.mimeType).toEqual(CustomMimeTypes.YOUTUBE);
+    expect(updated.links.view).toEqual(
+      "https://www.youtube.com/watch?v=9VCudo90K5I"
+    );
+  });
+
+  it("leaves 'normal' attachments alone", () => {
+    expect(updateAttachmentForCustomInfo(fileAttachment)).toStrictEqual(
+      fileAttachment
+    );
+  });
+});

--- a/react-front-end/__tests__/tsrc/modules/ViewerModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/ViewerModule.test.ts
@@ -17,6 +17,14 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import {
+  ATYPE_KALTURA,
+  ATYPE_YOUTUBE,
+} from "../../../tsrc/modules/AttachmentsModule";
+import {
+  CustomMimeTypes,
+  getMimeTypeDefaultViewerDetails,
+} from "../../../tsrc/modules/MimeTypesModule";
+import {
   buildAttachmentsAndViewerDefinitions,
   buildViewerConfigForAttachments,
   determineAttachmentViewUrl,
@@ -112,6 +120,24 @@ describe("determineViewer()", () => {
           mimeTypeViewerId
         )
       ).toEqual(["lightbox", fileViewUrl])
+  );
+
+  it.each([
+    [ATYPE_KALTURA, CustomMimeTypes.KALTURA],
+    [ATYPE_YOUTUBE, CustomMimeTypes.YOUTUBE],
+  ])(
+    "determines lightbox for known special attachment types [%s]",
+    async (attachmentType: string, mimeType: string) => {
+      const testUrl = "https://some.url/";
+      expect(
+        determineViewer(
+          attachmentType,
+          testUrl,
+          mimeType,
+          (await getMimeTypeDefaultViewerDetails(mimeType)).viewerId
+        )
+      ).toEqual(["lightbox", testUrl]);
+    }
   );
 });
 

--- a/react-front-end/tsrc/modules/GallerySearchModule.ts
+++ b/react-front-end/tsrc/modules/GallerySearchModule.ts
@@ -28,7 +28,7 @@ import {
   ATYPE_YOUTUBE,
   buildFileAttachmentUrl,
 } from "./AttachmentsModule";
-import { EXTERNAL_ID_PARAM } from "./KalturaModule";
+import * as kaltura from "./KalturaModule";
 import { CustomMimeTypes, getImageMimeTypes } from "./MimeTypesModule";
 import { Classification, listClassifications } from "./SearchFacetsModule";
 import { searchItems, SearchOptions } from "./SearchModule";
@@ -236,11 +236,9 @@ const directUrl = (
               E.fromNullable(
                 `Kaltura attachment ${id} is missing an 'externalId'.`
               ),
-              E.map((externalId) => {
-                const u = new URL(links.view);
-                u.searchParams.set(EXTERNAL_ID_PARAM, externalId);
-                return u.toString();
-              })
+              E.map((externalId) =>
+                kaltura.buildViewUrl(links.view, externalId)
+              )
             ),
         ],
         [

--- a/react-front-end/tsrc/modules/KalturaModule.ts
+++ b/react-front-end/tsrc/modules/KalturaModule.ts
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as OEQ from "@openequella/rest-api-client";
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
+import { CustomMimeTypes } from "./MimeTypesModule";
 
 /**
  * The bare minimum fields to create an embedded player and matches those found over in
@@ -72,4 +74,37 @@ export const parseExternalId = (externalId: string): KalturaPlayerDetails => {
     throw new TypeError(result.left);
   }
   return result.right;
+};
+
+/**
+ * Build a URL which embeds the externalId in a fashion commonly used by the Lightbox.
+ */
+export const buildViewUrl = (
+  attachmentViewLink: string,
+  externalId: string
+): string => {
+  const u = new URL(attachmentViewLink);
+  u.searchParams.set(EXTERNAL_ID_PARAM, externalId);
+  return u.toString();
+};
+
+/**
+ * Update Kaltura Media Attachment with Custom MIME type and View URL.
+ *
+ * @param attachment A Kaltura media attachment
+ */
+export const updateKalturaAttachment = (
+  attachment: OEQ.Search.Attachment
+): OEQ.Search.Attachment => {
+  const { links } = attachment;
+  const { externalId } = links;
+  if (externalId) {
+    return {
+      ...attachment,
+      mimeType: CustomMimeTypes.KALTURA,
+      links: { ...links, view: buildViewUrl(links.view, externalId) },
+    };
+  }
+
+  throw new Error("Missing Kaltura media attachment external ID.");
 };

--- a/react-front-end/tsrc/modules/MimeTypesModule.ts
+++ b/react-front-end/tsrc/modules/MimeTypesModule.ts
@@ -57,7 +57,7 @@ export const getMimeTypeViewerConfiguration: (
 export const getMimeTypeDefaultViewerDetails = async (
   mimeType: string
 ): Promise<OEQ.MimeType.MimeTypeViewerDetail> => {
-  if (mimeType === CustomMimeTypes.YOUTUBE) {
+  if ([CustomMimeTypes.KALTURA, CustomMimeTypes.YOUTUBE].includes(mimeType)) {
     return { viewerId: "htmlFiveViewer" };
   }
 

--- a/react-front-end/tsrc/modules/ViewerModule.ts
+++ b/react-front-end/tsrc/modules/ViewerModule.ts
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
+import { Do } from "fp-ts-contrib/Do";
 import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
 import { flow, pipe } from "fp-ts/function";
-import { Do } from "fp-ts-contrib/Do";
 import * as O from "fp-ts/Option";
 import * as TE from "fp-ts/TaskEither";
 import {
@@ -28,6 +28,7 @@ import {
 } from "../components/Lightbox";
 import {
   ATYPE_FILE,
+  ATYPE_KALTURA,
   ATYPE_RESOURCE,
   ATYPE_YOUTUBE,
   buildFileAttachmentUrl,
@@ -119,10 +120,11 @@ export const determineViewer = (
 ): ViewerDefinition => {
   const simpleLinkView: ViewerDefinition = ["link", viewUrl];
   // For an attachment that is not one of the following, refer to the link provided by the server.
-  // 1. File
-  // 2. Custom resource
-  // 3. YouTube Video
-  if (![ATYPE_FILE, ATYPE_RESOURCE, ATYPE_YOUTUBE].includes(attachmentType)) {
+  if (
+    ![ATYPE_FILE, ATYPE_KALTURA, ATYPE_RESOURCE, ATYPE_YOUTUBE].includes(
+      attachmentType
+    )
+  ) {
     return simpleLinkView;
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds the ability to preview Kaltura videos in the Lightbox of the new Search UI when in list mode. This is similar to that provided by #3237 

Noticeably there were tests missing around the YouTube support for this, so I had to add some basic new ones to cover both.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
