### PR TITLE
Bugfix/show DRM acceptance page before viewing content in full screen

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -264,12 +264,19 @@ class LegacyContentApi {
     // Parse the given URL and return a Tuple2 where First is ItemKey and Second is a string representing
     // file name of the content to be viewed.
     def parseItemViewerPath(p: String): (ItemKey, Option[String]) = {
-      // Regex for the URL of viewing content which consists of Item UUID, Item version, keyword 'viewcontent' and content ID.
-      // For example: ef1c6d7d-7aec-4743-9126-f847913de3f2/1/viewcontent/42eead4b-cfac-46df-8927-f8e58f4cd491
-      val viewContentPattern = "(.+)/(\\d)/(viewcontent/.+)".r
+      // Regex for the URL of viewing content which has 4 groups.
+      // 1. Item UUID
+      // 2. Item version
+      // 3. Content file name which is 'viewcontent/uuid' or 'viewims.jsp'.
+      // 4. additional query strings
+
+      // Examples:
+      // For normal content: ef1c6d7d-7aec-4743-9126-f847913de3f2/1/viewcontent/42eead4b-cfac-46df-8927-f8e58f4cd491
+      // For IMS package: 677a4bbc-defc-4dc1-b68e-4e2473b66a6a/1/viewims.jsp?viewMethod=download
+      val viewContentPattern = "(.+)/(\\d)/(viewcontent/.+|viewims.jsp)(.*)".r
 
       p match {
-        case viewContentPattern(itemUUID, itemVersion, fileName) =>
+        case viewContentPattern(itemUUID, itemVersion, fileName, _) =>
           (new ItemId(itemUUID, itemVersion.toInt), Option(fileName))
         case _ => (ItemTaskId.parse(p), None)
       }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -202,6 +202,8 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
 
   val RedirectedAttr = "REDIRECTED"
 
+  val DISABLE_LEGACY_CSS = "DISABLE_LEGACY_CSS"
+
   override protected def getTreeForPath(path: String): SectionTree =
     LegacyGuice.treeRegistry.getTreeForPath(path)
 
@@ -602,15 +604,14 @@ class LegacyContentApi {
     // Below three pages don't need 'legacy.css' so load CSS from server side
     val pagePattern = ".+/(apidocs|editoradmin|reports)\\.do".r
 
-    val useLegacyCss = uri match {
-      case pagePattern(_) => false
-      case _              => true
+    val disableLegacyCss = uri match {
+      case pagePattern(_) => true
+      case _              => false
     }
 
-    val openTreeViewerFromNewUI =
-      context.getBooleanAttribute(AbstractTreeViewerSection.VIEW_FROM_NEW_UI)
-
-    if (openTreeViewerFromNewUI || !useLegacyCss) {
+    // If the context has a boolean attribute saying legacy CSS should be disabled, or the URL matches
+    // above pattern, use CSS provided by the context.
+    if (context.getBooleanAttribute(LegacyContentController.DISABLE_LEGACY_CSS) || disableLegacyCss) {
       Option(getCssFromContext)
     } else {
       None

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/treeviewer/AbstractTreeViewerSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/treeviewer/AbstractTreeViewerSection.java
@@ -63,6 +63,7 @@ import com.tle.web.sections.standard.Link;
 import com.tle.web.sections.standard.annotations.Component;
 import com.tle.web.template.Decorations;
 import com.tle.web.template.Decorations.FullScreen;
+import com.tle.web.template.RenderNewTemplate;
 import com.tle.web.viewable.ViewableItem;
 import com.tle.web.viewitem.section.RootItemFileSection;
 import com.tle.web.viewitem.treeviewer.js.TreeLibrary;
@@ -113,6 +114,8 @@ public abstract class AbstractTreeViewerSection<M extends AbstractTreeViewerMode
   @Component
   @PlugKey(value = "navbar.last", icon = Icon.JUMP_TO_LAST)
   private Button last;
+
+  public static final String VIEW_FROM_NEW_UI = "view_from_new_ui";
 
   protected interface NodeUrlGenerator {
     @Nullable
@@ -179,6 +182,12 @@ public abstract class AbstractTreeViewerSection<M extends AbstractTreeViewerMode
     model.setHideTree(oneAttachment);
     model.setHideNavControls(oneAttachment);
     model.setDefinition(getTreeDef(info, tree, new HashSet<String>()));
+
+    // If this section is used in new UI, set a flag to tell LegacyContentApi NOT to use
+    // 'Legacy.css'.
+    if (RenderNewTemplate.isNewUIEnabled()) {
+      info.setAttribute(VIEW_FROM_NEW_UI, true);
+    }
     return viewFactory.createTemplateResult("treeviewer.ftl", this);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/treeviewer/AbstractTreeViewerSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/treeviewer/AbstractTreeViewerSection.java
@@ -34,6 +34,7 @@ import com.tle.common.NameValue;
 import com.tle.common.i18n.CurrentLocale;
 import com.tle.core.i18n.BundleCache;
 import com.tle.core.url.URLCheckerService;
+import com.tle.web.api.LegacyContentController;
 import com.tle.web.freemarker.FreemarkerFactory;
 import com.tle.web.freemarker.annotations.ViewFactory;
 import com.tle.web.integration.service.IntegrationService;
@@ -115,8 +116,6 @@ public abstract class AbstractTreeViewerSection<M extends AbstractTreeViewerMode
   @PlugKey(value = "navbar.last", icon = Icon.JUMP_TO_LAST)
   private Button last;
 
-  public static final String VIEW_FROM_NEW_UI = "view_from_new_ui";
-
   protected interface NodeUrlGenerator {
     @Nullable
     String getUrlForNode(ItemNavigationNode node);
@@ -186,7 +185,7 @@ public abstract class AbstractTreeViewerSection<M extends AbstractTreeViewerMode
     // If this section is used in new UI, set a flag to tell LegacyContentApi NOT to use
     // 'Legacy.css'.
     if (RenderNewTemplate.isNewUIEnabled()) {
-      info.setAttribute(VIEW_FROM_NEW_UI, true);
+      info.setAttribute(LegacyContentController.DISABLE_LEGACY_CSS(), true);
     }
     return viewFactory.createTemplateResult("treeviewer.ftl", this);
   }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
@@ -51,24 +51,21 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to " + name)
             .getResult(1)
             .viewSummary();
-    // Remove when #1160 is fixed. Currently a bug exists that prevents
-    // viewFullScreen in the new UI.
-    if (!item.usingNewUI()) {
-      PackageViewer pack =
-          item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
-      testItem(pack, name, allowComp);
-      logon("AutoTest", "automated");
 
-      item =
-          new SearchPage(context)
-              .load()
-              .setSort("rank")
-              .exactQuery("Link to " + name)
-              .getResult(1)
-              .viewSummary();
-      pack = item.attachments().viewFullscreen(getAgree()).preview(pack);
-      testItem2(pack, name, allowComp);
-    }
+    PackageViewer pack =
+        item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
+    testItem(pack, name, allowComp);
+    logon("AutoTest", "automated");
+
+    item =
+        new SearchPage(context)
+            .load()
+            .setSort("rank")
+            .exactQuery("Link to " + name)
+            .getResult(1)
+            .viewSummary();
+    pack = item.attachments().viewFullscreen(getAgree()).preview(pack);
+    testItem2(pack, name, allowComp);
   }
 
   @Test(dataProvider = "items")
@@ -83,26 +80,23 @@ public class DRMTest extends AbstractSessionTest {
             .getResult(1)
             .viewSummary(getAgree())
             .preview(new SummaryPage(context));
-    // Remove when #1160 is fixed. Currently a bug exists that prevents
-    // viewFullScreen in the new UI.
-    if (!item.usingNewUI()) {
-      PackageViewer pack = item.attachments().viewFullscreen();
 
-      testItem(pack, name, allowComp);
+    PackageViewer pack = item.attachments().viewFullscreen();
 
-      logon("AutoTest", "automated");
-      item =
-          new SearchPage(context)
-              .load()
-              .setSort("rank")
-              .exactQuery("Summary DRM - Link to " + name)
-              .getResult(1)
-              .viewSummary(getAgree())
-              .preview(item);
-      pack = item.attachments().viewFullscreen();
+    testItem(pack, name, allowComp);
 
-      testItem2(pack, name, allowComp);
-    }
+    logon("AutoTest", "automated");
+    item =
+        new SearchPage(context)
+            .load()
+            .setSort("rank")
+            .exactQuery("Summary DRM - Link to " + name)
+            .getResult(1)
+            .viewSummary(getAgree())
+            .preview(item);
+    pack = item.attachments().viewFullscreen();
+
+    testItem2(pack, name, allowComp);
   }
 
   @Test(dataProvider = "items")
@@ -115,35 +109,31 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to Summary of " + name)
             .getResult(1)
             .viewSummary();
-    // Remove when #1160 is fixed. Currently a bug exists that prevents
-    // viewFullScreen in the new UI.
-    if (!item.usingNewUI()) {
-      PackageViewer pack =
-          item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
-      pack = pack.clickAttachment(name);
 
-      if (summary && !allowComp) {
-        pack.switchToSelectedAttachment(getAgree()).preview(new SummaryPage(context));
-        pack.returnToPackageViewer();
-      }
+    PackageViewer pack =
+        item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
+    pack = pack.clickAttachment(name);
 
-      assertTrue(pack.selectedAttachmentContainsText("Music History - The Beatles"));
-
-      AttachmentsPage attachments = pack.switchToSelectedAttachment(new AttachmentsPage(context));
-      attachments.attachmentExists("Music History - The Beatles");
-
-      if (!allowComp && !summary) {
-        pack =
-            attachments
-                .viewAttachment("Music History - The Beatles", getDialogAgree())
-                .preview(new PackageViewer(context));
-      } else {
-        pack =
-            attachments.viewAttachment("Music History - The Beatles", new PackageViewer(context));
-      }
-      assertTrue(
-          pack.selectedAttachmentContainsText("The Beatles were an English rock band, formed in"));
+    if (summary && !allowComp) {
+      pack.switchToSelectedAttachment(getAgree()).preview(new SummaryPage(context));
+      pack.returnToPackageViewer();
     }
+
+    assertTrue(pack.selectedAttachmentContainsText("Music History - The Beatles"));
+
+    AttachmentsPage attachments = pack.switchToSelectedAttachment(new AttachmentsPage(context));
+    attachments.attachmentExists("Music History - The Beatles");
+
+    if (!allowComp && !summary) {
+      pack =
+          attachments
+              .viewAttachment("Music History - The Beatles", getDialogAgree())
+              .preview(new PackageViewer(context));
+    } else {
+      pack = attachments.viewAttachment("Music History - The Beatles", new PackageViewer(context));
+    }
+    assertTrue(
+        pack.selectedAttachmentContainsText("The Beatles were an English rock band, formed in"));
   }
 
   private void testItem(PackageViewer pack, String name, boolean allowComp) {
@@ -221,19 +211,15 @@ public class DRMTest extends AbstractSessionTest {
     assertTrue(
         summaryPage.attachments().attachmentExists("Start: Biscuit factory: complex ratios"));
     // Viewing attachments shows acceptance
-    if (!summaryPage
-        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
-      // viewFullScreen in the new UI.
-      summaryPage
-          .attachments()
-          .viewAttachment("Start: Biscuit factory: complex ratios", getDialogAgree())
-          .preview(
-              new VerifyableAttachment(
-                  context, "Curriculum Corporation, 2006, except where indicated"));
+    summaryPage
+        .attachments()
+        .viewAttachment("Start: Biscuit factory: complex ratios", getDialogAgree())
+        .preview(
+            new VerifyableAttachment(
+                context, "Curriculum Corporation, 2006, except where indicated"));
 
-      // Check that URL is attachment URL
-      Assert.assertEquals(getUrl(), context.getBaseUrl() + ATTACHMENT_URL);
-    }
+    // Check that URL is attachment URL
+    Assert.assertEquals(getUrl(), context.getBaseUrl() + ATTACHMENT_URL);
     // Logout
     logout();
 
@@ -286,13 +272,11 @@ public class DRMTest extends AbstractSessionTest {
 
     HomePage loginPage = logon("AutoTest", "automated");
     openUrl(IMS_DOWNLOAD_URL);
-    if (!loginPage.usingNewUI()) {
-      DownloadFilePage dlfPage =
-          getAgree().preview(new DownloadFilePage(context, "Biscuit factory complex ratios.zip"));
-      Assert.assertEquals(getUrl(), context.getBaseUrl() + IMS_DOWNLOAD_URL);
-      assertTrue(dlfPage.fileIsDownloaded());
-      assertTrue(dlfPage.deleteFile());
-    }
+    DownloadFilePage dlfPage =
+        getAgree().preview(new DownloadFilePage(context, "Biscuit factory complex ratios.zip"));
+    Assert.assertEquals(getUrl(), context.getBaseUrl() + IMS_DOWNLOAD_URL);
+    assertTrue(dlfPage.fileIsDownloaded());
+    assertTrue(dlfPage.deleteFile());
   }
 
   private void openUrl(String url) {

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/DRMAgreementPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/viewitem/DRMAgreementPage.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class DRMAgreementPage extends AbstractPage<DRMAgreementPage> {
   @FindBy(id = "drm_acceptButton")
@@ -24,6 +25,7 @@ public class DRMAgreementPage extends AbstractPage<DRMAgreementPage> {
   }
 
   public <T extends PageObject> T preview(WaitingPageObject<T> targetPage) {
+    waiter.until(ExpectedConditions.elementToBeClickable(previewButton));
     previewButton.click();
     return targetPage.get();
   }


### PR DESCRIPTION
#1160 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This bug was firstly caused by `LegacyContentApi` failing to parse the URL, which resulted in Item version being -1.

After above issue was fixed, the next issue was the page stayed in Summary page rather than going to the DRM acceptance page. After lots of investigations, I found the key thing is to make sure `RootItemFileModel` has a proper file name which can be extracted from the URL and is used to determine what viewers to be used in the full screen mode.

After fixing the second issue, there was a third issue. Once DRM terms had been accepted, although the page showing contents was opened, the page looked very bad because CSS styles applied to this page were never included in `Legacy.scss`.

Once the third issue was fixed, this bug was completed fixed. So I reverted workaround added in DRMTest.

