### PR TITLE
bugfix: ensure gallery entries are consistent with gallery mode

### DIFF
--- a/react-front-end/tsrc/search/components/GallerySearchResult.tsx
+++ b/react-front-end/tsrc/search/components/GallerySearchResult.tsx
@@ -17,7 +17,7 @@
  */
 import { GridList } from "@material-ui/core";
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Lightbox, { LightboxProps } from "../../components/Lightbox";
 import {
   GalleryEntry,
@@ -51,6 +51,11 @@ const GallerySearchResult = ({ items }: GallerySearchResultProps) => {
 
   const [galleryItems, setGalleryItems] =
     useState<GallerySearchResultItem[]>(items);
+
+  // Ensure gallery entries are consistent with gallery mode.
+  useEffect(() => {
+    setGalleryItems(items);
+  }, [items]);
 
   // Handler for opening the Lightbox
   const lightboxHandler = (


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

A bug was found during testing work for the feature of filtering out gallery entries that are not authorised to view.
When switching between gallery modes, the previous gallery entries were not cleared out. As a result, images were displayed in the Lightbox when Search page was in Video mode.

So this PR fixes this issue by adding a `useEffect` which updates the state of gallery entries when the mode is changed. 
