### PR TITLE
build: attempt to stop renovate errors for react-front-end

### DIFF
--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -13,6 +13,9 @@
     "parcelEntryFiles": "entrypoint/*.html entrypoint/scripts/*.js",
     "tools": "target/tools"
   },
+  "engines": {
+    "npm": "^7.19.1"
+  },
   "scripts": {
     "prepare": "cross-env-shell \"cd ../oeq-ts-rest-api && npm ci build\"",
     "install": "cross-env-shell \"mkdirp ${npm_package_config_devlang} ${npm_package_config_buildlang}\"",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Since upgrading to node 16 / npm 7 the renovate updates have been
failing due to renovate-checks. The checks are throwing up all kinds of
NPM errors which the CI pipelines don't experience.

This is based on the PR by @HonkingGoose over at:
https://github.com/renovatebot/renovate/pull/8559

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
