### PR TITLE
chore: change the default text of Collection Selector

### DIFF
--- a/react-front-end/tsrc/search/components/CollectionSelector.tsx
+++ b/react-front-end/tsrc/search/components/CollectionSelector.tsx
@@ -47,6 +47,8 @@ interface CollectionSelectorProps {
   value?: Collection[];
 }
 
+const { title, noOptions } = languageStrings.searchpage.collectionSelector;
+
 /**
  * As a refine search control, this component is used to filter search results by collections.
  * The initially selected collections are either provided through props or an empty array.
@@ -56,8 +58,6 @@ export const CollectionSelector = ({
   onSelectionChange,
   value,
 }: CollectionSelectorProps) => {
-  const collectionSelectorStrings =
-    languageStrings.searchpage.collectionSelector;
   const [collections, setCollections] = useState<Collection[]>([]);
   const handleError = useError(onError);
 
@@ -105,12 +105,13 @@ export const CollectionSelector = ({
           {collection.name}
         </>
       )}
+      noOptionsText={noOptions}
       renderInput={(params) => (
         <TextField
           {...params}
           variant="outlined"
-          label={collectionSelectorStrings.title}
-          placeholder={collectionSelectorStrings.title}
+          label={title}
+          placeholder={title}
         />
       )}
     />

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -414,6 +414,7 @@ export const languageStrings = {
       modeGalleryVideo: "Video Gallery",
     },
     collectionSelector: {
+      noOptions: "All",
       title: "Collections",
     },
     filterLast: {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Use `All` as the default text of Collection Selector when there is no collection available.

![Screenshot from 2021-08-04 14-02-51](https://user-images.githubusercontent.com/47203811/128120397-be5c0355-9edb-4e88-a14e-6257247c8262.png)

