### PR TITLE
bugfix: don't include Bootstrap.css when open legacy DRM dialog in new UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -203,6 +203,7 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
   val RedirectedAttr = "REDIRECTED"
 
   val DISABLE_LEGACY_CSS = "DISABLE_LEGACY_CSS"
+  val SKIP_BOOTSTRAP     = "skip_bootstrap";
 
   override protected def getTreeForPath(path: String): SectionTree =
     LegacyGuice.treeRegistry.getTreeForPath(path)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/ButtonRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/ButtonRenderer.java
@@ -19,6 +19,7 @@
 package com.tle.web.sections.equella.render;
 
 import com.tle.common.Check;
+import com.tle.web.api.LegacyContentController;
 import com.tle.web.sections.SectionUtils;
 import com.tle.web.sections.SectionWriter;
 import com.tle.web.sections.events.PreRenderContext;
@@ -132,7 +133,7 @@ public class ButtonRenderer extends AbstractElementRenderer implements JSDisable
 
   @Override
   public void preRender(PreRenderContext info) {
-    if (!info.getBooleanAttribute(SKIP_BOOTSTRAP)) {
+    if (!info.getBooleanAttribute(LegacyContentController.SKIP_BOOTSTRAP())) {
       info.preRender(Bootstrap.PRERENDER);
     }
     super.preRender(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/ButtonRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/render/ButtonRenderer.java
@@ -132,7 +132,9 @@ public class ButtonRenderer extends AbstractElementRenderer implements JSDisable
 
   @Override
   public void preRender(PreRenderContext info) {
-    info.preRender(Bootstrap.PRERENDER);
+    if (!info.getBooleanAttribute(SKIP_BOOTSTRAP)) {
+      info.preRender(Bootstrap.PRERENDER);
+    }
     super.preRender(info);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Map;
 
 public abstract class AbstractElementRenderer extends AbstractComponentRenderer {
+  public static final String SKIP_BOOTSTRAP = "skip_bootstrap";
 
   public AbstractElementRenderer(HtmlComponentState state) {
     super(state);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/standard/renderers/AbstractElementRenderer.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.util.Map;
 
 public abstract class AbstractElementRenderer extends AbstractComponentRenderer {
-  public static final String SKIP_BOOTSTRAP = "skip_bootstrap";
-
   public AbstractElementRenderer(HtmlComponentState state) {
     super(state);
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/filter/DRMLicenseDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/filter/DRMLicenseDialog.java
@@ -43,6 +43,8 @@ import com.tle.web.sections.render.SectionRenderable;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.annotations.Component;
 import com.tle.web.sections.standard.dialog.model.DialogModel;
+import com.tle.web.sections.standard.renderers.AbstractElementRenderer;
+import com.tle.web.template.RenderNewTemplate;
 import com.tle.web.viewitem.DRMFilter;
 import com.tle.web.viewitem.I18nDRM;
 import com.tle.web.viewitem.section.RootItemFileSection;
@@ -101,6 +103,13 @@ public class DRMLicenseDialog extends EquellaDialog<DRMDialogModel> {
 
   @Override
   protected SectionRenderable getRenderableContents(RenderContext context) {
+    // In New UI, this dialog is usually NOT opened by 'LegacyContent.tsx'. As a result, CSS files
+    // included in this dialog will be added to the whole page. Given this context, we must exclude
+    // Bootstrap.css from this dialog's three buttons because Bootstrap.css will result in the three
+    // buttons having inconsistent UI and breaking other new UI components.
+    if (RenderNewTemplate.isNewUIEnabled()) {
+      context.setAttribute(AbstractElementRenderer.SKIP_BOOTSTRAP, true);
+    }
     Item item = rootFileSection.getViewableItem(context).getItem();
     DrmSettings rights = drmService.requiresAcceptance(item, false, false);
     DRMDialogModel model = getModel(context);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/filter/DRMLicenseDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/filter/DRMLicenseDialog.java
@@ -23,6 +23,7 @@ import com.tle.beans.item.DrmSettings;
 import com.tle.beans.item.Item;
 import com.tle.core.guice.Bind;
 import com.tle.core.item.service.DrmService;
+import com.tle.web.api.LegacyContentController;
 import com.tle.web.freemarker.FreemarkerFactory;
 import com.tle.web.freemarker.annotations.ViewFactory;
 import com.tle.web.sections.SectionInfo;
@@ -43,7 +44,6 @@ import com.tle.web.sections.render.SectionRenderable;
 import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.annotations.Component;
 import com.tle.web.sections.standard.dialog.model.DialogModel;
-import com.tle.web.sections.standard.renderers.AbstractElementRenderer;
 import com.tle.web.template.RenderNewTemplate;
 import com.tle.web.viewitem.DRMFilter;
 import com.tle.web.viewitem.I18nDRM;
@@ -108,7 +108,7 @@ public class DRMLicenseDialog extends EquellaDialog<DRMDialogModel> {
     // Bootstrap.css from this dialog's three buttons because Bootstrap.css will result in the three
     // buttons having inconsistent UI and breaking other new UI components.
     if (RenderNewTemplate.isNewUIEnabled()) {
-      context.setAttribute(AbstractElementRenderer.SKIP_BOOTSTRAP, true);
+      context.setAttribute(LegacyContentController.SKIP_BOOTSTRAP(), true);
     }
     Item item = rootFileSection.getViewableItem(context).getItem();
     DrmSettings rights = drmService.requiresAcceptance(item, false, false);


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

In new UI, the legacy DRM acceptance dialog is usually NOT open by `LegacyContent.tsx`, which means additional CSS files will be added to the whole page once the dialog is opened. One of those additional CSS files is `Bootstrap.css` which can break new UI components like buttons. So this PR adds a fix which allows the DRM dialog to include this CSS file only in Old UI.

Before: 
![image](https://user-images.githubusercontent.com/47203811/128668241-1e6930c8-977b-4312-8a6a-37f3eb898b73.png)

After:
![image](https://user-images.githubusercontent.com/47203811/128667964-d6cdaa6c-8b38-4c54-b0c1-0e8c53a5b7f8.png)

Before: 
![image](https://user-images.githubusercontent.com/47203811/128668274-cebf53ab-b031-4d94-a2ca-4b45392b5bab.png)

After:
![image](https://user-images.githubusercontent.com/47203811/128667992-2e8d76d9-bfe3-4c96-9803-eaf6fb6ab269.png)
