### PR TITLE
chore(deps): upgrade to HikariCP 4.0.3

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -95,7 +95,7 @@ libraryDependencies ++= Seq(
   "io.swagger"                % "swagger-annotations"      % SwaggerVersion,
   "io.swagger"                % "swagger-jaxrs"            % SwaggerVersion,
   "io.swagger"                %% "swagger-scala-module"    % "1.0.6",
-  "com.zaxxer"                % "HikariCP"                 % "3.4.5",
+  "com.zaxxer"                % "HikariCP"                 % "4.0.3",
   "commons-beanutils"         % "commons-beanutils"        % "1.9.4",
   "commons-codec"             % "commons-codec"            % "1.15",
   "commons-collections"       % "commons-collections"      % "3.2.2",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Major upgrade to the last Java 8 supported version. (5 is now available, but only for 11+.)

Came to my attention due to #3316 

Rebuilt fine locally and passed really quick smoke test - which confirmed DB access.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
