### PR TITLE
Feature/wizard definition endpoint

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/language/LanguageStringHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/language/LanguageStringHelper.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.api.language
+
+import com.tle.beans.entity.LanguageBundle
+import com.tle.common.i18n.{CurrentLocale, LangUtils}
+
+object LanguageStringHelper {
+
+  /**
+    * Read language string from a bundle with current locale.
+    *
+    * @param bundle A language string bundle that may have multiple strings for different locale.
+    * @return The string or None.
+    */
+  def getStringFromCurrentLocale(bundle: LanguageBundle): Option[String] = {
+    Option(LangUtils.getString(bundle, CurrentLocale.getLocale, null))
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
@@ -68,7 +68,8 @@ class AdvancedSearchResource {
   @Path("{uuid}")
   @ApiOperation(
     value = "Get Advanced Search definition",
-    notes = "This endpoint is used to retrieve Wizard definition of an Advanced Search by UUID.",
+    notes =
+      "This endpoint is used to retrieve an Advanced Search's name, description, Collections and Wizard definition by UUID.",
     response = classOf[AdvancedSearch],
   )
   def getAdvancedSearchWizardDefinition(@PathParam("uuid") uuid: String): Response = {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.wizard
 
 import com.dytech.edge.wizard.TargetNode

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -1,0 +1,151 @@
+package com.tle.web.api.wizard
+
+import com.dytech.edge.wizard.TargetNode
+import com.dytech.edge.wizard.beans.control.{WizardControl, WizardControlItem}
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.tle.beans.entity.LanguageBundle
+import com.tle.common.i18n.{CurrentLocale, LangUtils}
+import scala.collection.JavaConverters._
+
+/** Data structure for Wizard Control option
+  *
+  * @param text Text of the option. None in some components like Calendar.
+  * @param value  Value of the option.
+  */
+case class WizardControlOption(text: Option[String], value: String)
+
+object WizardControlOption {
+  def apply(item: WizardControlItem): WizardControlOption = {
+    WizardControlOption(
+      text = Option(item.getName).map(name => LangUtils.getString(name)),
+      value = item.getValue,
+    )
+  }
+}
+
+// This trait is used to support the union type of different Wizard control types.
+// We can probably remove it trait once we can use Scala 3.
+sealed trait WizardControlDefinition
+
+/**
+  * Data structure for key information of 'com.dytech.edge.wizard.beans.control.WizardControl'.
+  *
+  * @param mandatory Whether the control must have a value.
+  * @param reload Whether to reload all controls after this control has different selection. This may affect how scripting works.
+  * @param include #todo
+  * @param size1 #todo
+  * @param size2 #todo
+  * @param customName The controls' customised name.
+  * @param title Title of the control.
+  * @param description Description of the control.
+  * @param visibilityScript Script running on Client to control the visibility of the control.
+  * @param targetNodes Schema nodes that the control targets to.
+  * @param options Options available for selection.
+  * @param powerSearchFriendlyName #todo
+  * @param controlType Type of the control.
+  */
+case class WizardBasicControl(
+    mandatory: Boolean,
+    reload: Boolean,
+    include: Boolean,
+    size1: Int,
+    size2: Int,
+    customName: Option[String],
+    title: Option[String],
+    description: Option[String],
+    visibilityScript: Option[String],
+    targetNodes: List[TargetNode],
+    options: List[WizardControlOption],
+    powerSearchFriendlyName: Option[String],
+    controlType: String
+) extends WizardControlDefinition
+
+object WizardBasicControl {
+  def getLanguageString(bundle: LanguageBundle): String = {
+    LangUtils.getString(bundle, CurrentLocale.getLocale, null)
+  }
+
+  def apply(control: WizardControl): WizardBasicControl = {
+    WizardBasicControl(
+      mandatory = control.isMandatory,
+      reload = control.isReload,
+      include = control.isInclude,
+      size1 = control.getSize1,
+      size2 = control.getSize2,
+      customName = Option(control.getCustomName),
+      title = Option(getLanguageString(control.getTitle)),
+      description = Option(getLanguageString(control.getDescription)),
+      visibilityScript = Option(control.getScript),
+      targetNodes = control.getTargetnodes.asScala.toList,
+      options = control.getItems.asScala.map(i => WizardControlOption(i)).toList,
+      powerSearchFriendlyName = Option(getLanguageString(control.getPowerSearchFriendlyName)),
+      controlType = control.getClassType
+    )
+  }
+}
+
+/**
+  * Data structure for Calendar control.
+  *
+  * @param basicControl The basic control providing common fields.
+  * @param isRange Whether to support a date range.
+  */
+case class WizardCalendarControl(@JsonUnwrapped
+                                 basicControl: WizardBasicControl,
+                                 isRange: Boolean)
+    extends WizardControlDefinition
+
+/**
+  * Data structure for ShuffleList control.
+  *
+  * @param basicControl The basic control providing common fields.
+  * @param isTokenise Whether to tokenise the value.
+  * @param isForceUnique Whether each value must be unique.
+  * @param isCheckDuplication Whether to check duplicated values.
+  */
+case class WizardShuffleListControl(
+    @JsonUnwrapped
+    basicControl: WizardBasicControl,
+    isTokenise: Boolean,
+    isForceUnique: Boolean,
+    isCheckDuplication: Boolean
+) extends WizardControlDefinition
+
+/**
+  * Data structure for EditBox control.
+  *
+  * @param basicControl The basic control providing common fields.
+  * @param isAllowLinks Whether to allow links.
+  * @param isNumber Whether to use numbers only.
+  * @param isAllowMultiLang Whether to allow multiple lines.
+  * @param isForceUnique Whether each value must be unique.
+  * @param isCheckDuplication Whether to check duplicated values.
+  */
+case class WizardEditBoxControl(
+    @JsonUnwrapped
+    basicControl: WizardBasicControl,
+    isAllowLinks: Boolean,
+    isNumber: Boolean,
+    isAllowMultiLang: Boolean,
+    isForceUnique: Boolean,
+    isCheckDuplication: Boolean,
+) extends WizardControlDefinition
+
+/**
+  * Data structure for Custom Wizard control.
+  *
+  * @param basicControl The basic control providing common fields.
+  * @param attributes Custom attributes
+  */
+case class WizardCustomControl(
+    @JsonUnwrapped
+    basicControl: WizardBasicControl,
+    attributes: Map[Object, Object]
+) extends WizardControlDefinition
+
+/**
+  * Data structure for unknown Wizard control.
+  */
+case class UnknownWizardControl() extends WizardControlDefinition {
+  val controlType: String = "unknown"
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -21,8 +21,8 @@ package com.tle.web.api.wizard
 import com.dytech.edge.wizard.TargetNode
 import com.dytech.edge.wizard.beans.control.{WizardControl, WizardControlItem}
 import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.tle.beans.entity.LanguageBundle
-import com.tle.common.i18n.{CurrentLocale, LangUtils}
+import com.tle.common.i18n.{LangUtils}
+import com.tle.web.api.language.LanguageStringHelper.getStringFromCurrentLocale
 import scala.collection.JavaConverters._
 
 /** Data structure for Wizard Control option
@@ -79,10 +79,6 @@ case class WizardBasicControl(
 ) extends WizardControlDefinition
 
 object WizardBasicControl {
-  def getLanguageString(bundle: LanguageBundle): String = {
-    LangUtils.getString(bundle, CurrentLocale.getLocale, null)
-  }
-
   def apply(control: WizardControl): WizardBasicControl = {
     WizardBasicControl(
       mandatory = control.isMandatory,
@@ -91,12 +87,12 @@ object WizardBasicControl {
       size1 = control.getSize1,
       size2 = control.getSize2,
       customName = Option(control.getCustomName),
-      title = Option(getLanguageString(control.getTitle)),
-      description = Option(getLanguageString(control.getDescription)),
+      title = getStringFromCurrentLocale(control.getTitle),
+      description = getStringFromCurrentLocale(control.getDescription),
       visibilityScript = Option(control.getScript),
       targetNodes = control.getTargetnodes.asScala.toList,
       options = control.getItems.asScala.map(i => WizardControlOption(i)).toList,
-      powerSearchFriendlyName = Option(getLanguageString(control.getPowerSearchFriendlyName)),
+      powerSearchFriendlyName = getStringFromCurrentLocale(control.getPowerSearchFriendlyName),
       controlType = control.getClassType
     )
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardControlHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardControlHelper.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.api.wizard
+
+import com.dytech.edge.wizard.beans.control.{
+  Calendar,
+  CheckBoxGroup,
+  CustomControl,
+  EditBox,
+  Html,
+  ListBox,
+  RadioGroup,
+  ShuffleBox,
+  ShuffleList,
+  WizardControl
+}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+object WizardControlHelper {
+  private val LOGGER = LoggerFactory.getLogger(getClass)
+
+  /**
+    * Convert a list of `com.dytech.edge.wizard.beans.control.WizardControl` to a list of `WizardControlDefinition`
+    *
+    * @param controls The list of Java Wizard controls.
+    */
+  def wizardControlConverter(controls: List[WizardControl]): List[WizardControlDefinition] = {
+    controls.map {
+      // These controls do not have special fields
+      case c @ (_: ListBox | _: CheckBoxGroup | _: RadioGroup | _: ShuffleBox | _: Html) =>
+        WizardBasicControl(c)
+      case c: Calendar => WizardCalendarControl(WizardBasicControl(c), c.isRange)
+      case c: ShuffleList =>
+        WizardShuffleListControl(WizardBasicControl(c),
+                                 c.isTokenise,
+                                 c.isForceUnique,
+                                 c.isCheckDuplication)
+      case c: EditBox =>
+        WizardEditBoxControl(WizardBasicControl(c),
+                             c.isAllowLinks,
+                             c.isNumber,
+                             c.isAllowMultiLang,
+                             c.isForceUnique,
+                             c.isCheckDuplication)
+      case c: CustomControl =>
+        WizardCustomControl(WizardBasicControl(c), c.getAttributes.asScala.toMap)
+      case _ =>
+        LOGGER.error("Unknown Wizard Control type")
+        UnknownWizardControl()
+    }
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardControlHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardControlHelper.scala
@@ -50,18 +50,20 @@ object WizardControlHelper {
       case c: Calendar => WizardCalendarControl(WizardBasicControl(c), c.isRange)
       case c: ShuffleList =>
         WizardShuffleListControl(WizardBasicControl(c),
-                                 c.isTokenise,
-                                 c.isForceUnique,
-                                 c.isCheckDuplication)
+                                 ControlUniqueConstraints(c.isForceUnique, c.isCheckDuplication),
+                                 c.isTokenise)
       case c: EditBox =>
         WizardEditBoxControl(WizardBasicControl(c),
                              c.isAllowLinks,
                              c.isNumber,
                              c.isAllowMultiLang,
-                             c.isForceUnique,
-                             c.isCheckDuplication)
+                             ControlUniqueConstraints(c.isForceUnique, c.isCheckDuplication))
       case c: CustomControl =>
-        WizardCustomControl(WizardBasicControl(c), c.getAttributes.asScala.toMap)
+        // The attribute map in Java is (Object -> Object), but all the keys are actually String, so
+        // here we convert the map to (String -> Object) by calling `toString`.
+        val attributes: Map[Object, Object] = c.getAttributes.asScala.toMap
+        val convertedAttributes             = attributes.map { case (key, value) => (key.toString -> value) }
+        WizardCustomControl(WizardBasicControl(c), convertedAttributes)
       case _ =>
         LOGGER.error("Unknown Wizard Control type")
         UnknownWizardControl()

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
@@ -44,8 +44,8 @@ public class AdvancedSearchApiTest extends AbstractRestApiTest {
         new GetMethod(ADVANCEDSEARCH_API_ENDPOINT + "/" + ADVANCED_SEARCH_UUID);
     assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
     JsonNode result = mapper.readTree(method.getResponseBody());
-    // This Advanced Search has 12 controls.
-    assertEquals(12, result.size());
+    // This Advanced Search has 13 controls.
+    assertEquals(13, result.size());
     result.forEach(
         control -> {
           assertNotNull(control.get("controlType"));

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
@@ -1,6 +1,7 @@
 package io.github.openequella.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.tle.webtests.framework.TestConfig;
 import com.tle.webtests.framework.TestInstitution;
@@ -10,6 +11,7 @@ import java.util.List;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.type.TypeReference;
 import org.testng.annotations.Test;
 
@@ -33,6 +35,21 @@ public class AdvancedSearchApiTest extends AbstractRestApiTest {
         "The number of returned advanced searches should match the institution total.",
         3,
         searches.size());
+  }
+
+  @Test(description = "list all Wizard controls of an Sdvanced search")
+  public void testRetrieveWizardDefinition() throws IOException {
+    final String ADVANCED_SEARCH_UUID = "c9fd1ae8-0dc1-ab6f-e923-1f195a22d537";
+    final HttpMethod method =
+        new GetMethod(ADVANCEDSEARCH_API_ENDPOINT + "/" + ADVANCED_SEARCH_UUID);
+    assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
+    JsonNode result = mapper.readTree(method.getResponseBody());
+    // This Advanced Search has 12 controls.
+    assertEquals(12, result.size());
+    result.forEach(
+        control -> {
+          assertNotNull(control.get("controlType"));
+        });
   }
 
   private List<BaseEntitySummary> getAdvancedSearches() throws IOException {

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
@@ -1,6 +1,7 @@
 package io.github.openequella.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.tle.webtests.framework.TestConfig;
@@ -37,8 +38,10 @@ public class AdvancedSearchApiTest extends AbstractRestApiTest {
         searches.size());
   }
 
-  @Test(description = "list all Wizard controls of an Sdvanced search")
-  public void testRetrieveWizardDefinition() throws IOException {
+  @Test(
+      description =
+          "Get the name, description, Collections and Wizard definition of an Advanced search.")
+  public void testRetrieveAdvancedSearch() throws IOException {
     final String ADVANCED_SEARCH_UUID = "c9fd1ae8-0dc1-ab6f-e923-1f195a22d537";
     final HttpMethod method =
         new GetMethod(ADVANCEDSEARCH_API_ENDPOINT + "/" + ADVANCED_SEARCH_UUID);
@@ -50,13 +53,15 @@ public class AdvancedSearchApiTest extends AbstractRestApiTest {
     // This Advanced Search only covers one Collection.
     assertEquals(1, result.get("collections").size());
 
-    // This Advanced Search has 13 controls.
+    // This Advanced Search has 13 controls and none of them is the control type of `unknown`.
     assertEquals(13, result.get("controls").size());
     result
         .get("controls")
         .forEach(
             control -> {
-              assertNotNull(control.get("controlType"));
+              String controlType = control.get("controlType").asText();
+              assertNotNull(controlType);
+              assertNotEquals("unknown", controlType);
             });
   }
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/AdvancedSearchApiTest.java
@@ -44,12 +44,20 @@ public class AdvancedSearchApiTest extends AbstractRestApiTest {
         new GetMethod(ADVANCEDSEARCH_API_ENDPOINT + "/" + ADVANCED_SEARCH_UUID);
     assertEquals(HttpStatus.SC_OK, makeClientRequest(method));
     JsonNode result = mapper.readTree(method.getResponseBody());
+
+    assertEquals("All Controls Power Search", result.get("name").asText());
+
+    // This Advanced Search only covers one Collection.
+    assertEquals(1, result.get("collections").size());
+
     // This Advanced Search has 13 controls.
-    assertEquals(13, result.size());
-    result.forEach(
-        control -> {
-          assertNotNull(control.get("controlType"));
-        });
+    assertEquals(13, result.get("controls").size());
+    result
+        .get("controls")
+        .forEach(
+            control -> {
+              assertNotNull(control.get("controlType"));
+            });
   }
 
   private List<BaseEntitySummary> getAdvancedSearches() throws IOException {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds a REST endpoint for retrieving Advanced search wizard definition. Several data models are created to represent controls that wizard controls. 

The initial idea was to use inheritance - create a basic control to provide common fields and then those having special fields just extend the basic one. I tried `trait` and `abstract class` both of them can produce lots of duplication. 

So I went to composition which works well, but I am not so sure if this is the best choice.

![Screenshot from 2021-08-26 15-10-52](https://user-images.githubusercontent.com/47203811/130904493-ea86df95-48ac-499a-9d58-9959c08b723e.png)


I have attached a full json file.
[controls.zip](https://github.com/openequella/openEQUELLA/files/7051791/controls.zip)


