### PR TITLE
refactor: ensure new versions of SearchPage for different routes

### DIFF
--- a/react-front-end/tsrc/mainui/IndexPage.tsx
+++ b/react-front-end/tsrc/mainui/IndexPage.tsx
@@ -36,7 +36,6 @@ import { defaultNavMessage, NavAwayDialog } from "./PreventNavigation";
 import {
   BaseOEQRouteComponentProps,
   isNewUIRoute,
-  NEW_ADVANCED_SEARCH_PATH,
   NEW_SEARCH_PATH,
   OEQRouteNewUI,
   OLD_SEARCH_PATH,
@@ -137,9 +136,13 @@ export default function IndexPage() {
             key={ind}
             path={oeqRoute.path}
             render={(p) => {
+              removeLegacyCss();
+
               const oeqProps = mkRouteProps(p);
               if (oeqRoute.component) {
-                return <oeqRoute.component {...oeqProps} />;
+                return (
+                  <oeqRoute.component key={p.location.pathname} {...oeqProps} />
+                );
               }
               return oeqRoute.render?.(oeqProps);
             }}
@@ -179,7 +182,7 @@ export default function IndexPage() {
         </Route>
         {newUIRoutes}
         <Route
-          path={[NEW_SEARCH_PATH, OLD_SEARCH_PATH, NEW_ADVANCED_SEARCH_PATH]}
+          path={[NEW_SEARCH_PATH, OLD_SEARCH_PATH]}
           render={(p) => {
             const newSearchEnabled: boolean =
               typeof renderData !== "undefined" && renderData?.newSearch;

--- a/react-front-end/tsrc/mainui/routes.tsx
+++ b/react-front-end/tsrc/mainui/routes.tsx
@@ -17,6 +17,7 @@
  */
 import { LocationDescriptor } from "history";
 import * as React from "react";
+import SearchPage from "../search/SearchPage";
 import { TemplateUpdate } from "./Template";
 
 const ThemePage = React.lazy(() => import("../theme/ThemePage"));
@@ -63,7 +64,7 @@ interface OEQRouteTo<T = string | ToFunc | ToVersionFunc> {
 
 interface Routes {
   OldAdvancedSearch: OEQRouteTo<ToFunc>; // Need this route to support using Advanced Search in Selection Session.
-  NewAdvancedSearch: OEQRouteTo<ToFunc>;
+  NewAdvancedSearch: OEQRouteNewUI & OEQRouteTo<ToFunc>;
   CloudProviders: OEQRouteNewUI;
   ContentIndexSettings: OEQRouteNewUI;
   FacetedSearchSetting: OEQRouteNewUI;
@@ -115,6 +116,8 @@ export const routes: Routes = {
   },
   NewAdvancedSearch: {
     to: (uuid: string) => `${NEW_ADVANCED_SEARCH_PATH}/${uuid}`,
+    path: `${NEW_ADVANCED_SEARCH_PATH}/:advancedSearchId`,
+    component: SearchPage,
   },
   CloudProviders: {
     path: "/page/cloudprovider",

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -29,7 +29,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useHistory, useLocation } from "react-router";
+import { useHistory, useLocation, useParams } from "react-router";
 import { getBaseUrl } from "../AppConfig";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import MessageInfo, { MessageInfoVariant } from "../components/MessageInfo";
@@ -133,7 +133,7 @@ export const SearchPageRenderErrorContext = React.createContext<{
   handleError: () => {},
 });
 
-interface SearchPageProps extends TemplateUpdateProps {
+interface AdvancedSearchParams {
   /**
    * ID of the currently selected Advanced Search. When it's defined, the component is in
    * Advanced Search mode, or normal Search page mode otherwise.
@@ -141,9 +141,19 @@ interface SearchPageProps extends TemplateUpdateProps {
   advancedSearchId?: string;
 }
 
-const SearchPage = ({ updateTemplate }: SearchPageProps) => {
+type SearchPageProps = TemplateUpdateProps & AdvancedSearchParams;
+
+const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const history = useHistory();
   const location = useLocation();
+
+  // Retrieve any AdvancedSearchId from the Router
+  const { advancedSearchId: advancedSearchIdParam } =
+    useParams<AdvancedSearchParams>();
+
+  // If an Advanced Search ID has been provided, use that otherwise check to see if one
+  // was passed in by the Router.
+  advancedSearchId = advancedSearchId ?? advancedSearchIdParam;
 
   const [state, dispatch] = useReducer(reducer, { status: "initialising" });
   const defaultSearchPageHistory: SearchPageHistoryState = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

The initial implementation for Advanced Search routing was not actually resulting in a fresh SearchPage instance. So by adding a `key` to the SearchPage JSX we can ensure a new one is created for each unique Advanced Search.

Further, this highlighted we could move the Advanced Search routing into the New Routes paradigm.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
