### PR TITLE
bugfix: do not update SearchResult state when it is unmounted

### DIFF
--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -190,6 +190,7 @@ export default function SearchResult({
     setDrmCheckOnSuccessHandler(() => onSuccess);
 
   useEffect(() => {
+    let mounted = true;
     (async () => {
       // If there is nothing requiring DRM permission check then return undefined.
       const dialog = drmCheckOnSuccessHandler
@@ -203,8 +204,14 @@ export default function SearchResult({
           )
         : undefined;
 
-      setDrmDialog(dialog);
+      if (mounted) {
+        setDrmDialog(dialog);
+      }
     })();
+
+    return () => {
+      mounted = false;
+    };
   }, [drmCheckOnSuccessHandler, uuid, version, drmStatus]);
 
   const handleSelectResource = (


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Due to the support for DRM, we need to update state to show or hide the DRM
dialog. However, when a non-DRM item is clicked, the page just navigates to
Summary page, which unmounts the component. In this case, we should skip the
state update.