### PR TITLE
bugfix: ensure clicking the caret icon can show the bulk action list

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -506,7 +506,7 @@ select[multiple="multiple"] {
   @include curvedCorners;
   font-size: 16px;
   border: 1px solid #f5f5f5;
-  padding: $doubleMargin;
+  padding: $doubleMargin 0 $doubleMargin $doubleMargin;
   width: auto;
   min-width: 204px;
   float: none;


### PR DESCRIPTION
#2918 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR fixes the issue where clicking the caret icon (as a background image) of bulk action list does not show the list. The issue was caused by a 'padding-right' which moved where the icon was supposed to be. Although there were no visual differences, the position of the icon was indeed moved.

Before: 
![Screenshot from 2021-09-07 13-32-21](https://user-images.githubusercontent.com/47203811/132280151-baf75af0-01e7-43c4-b455-146e144c6d56.png)


After: 
![Screenshot from 2021-09-07 13-32-29](https://user-images.githubusercontent.com/47203811/132280122-86ed23b3-c19b-4393-9eee-9ab1c21363de.png)


 
