### PR TITLE
Feature/refactor advanced search selector

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/advancedsearch/NewAdvancedSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/advancedsearch/NewAdvancedSearchPage.java
@@ -1,0 +1,80 @@
+package io.github.openequella.pages.advancedsearch;
+
+import com.tle.webtests.framework.PageContext;
+import io.github.openequella.pages.search.NewSearchPage;
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+
+public class NewAdvancedSearchPage extends NewSearchPage {
+
+  public NewAdvancedSearchPage(PageContext context) {
+    super(context);
+  }
+
+  public void selectAdvancedSearch(String name) {
+    WebElement input = getAdvancedSearchInput();
+    input.sendKeys(name);
+    WebElement option = driver.findElement(By.xpath("//li[contains(text(), '" + name + "')]"));
+    option.click();
+  }
+
+  public String getSelection() {
+    WebElement input = getAdvancedSearchInput();
+    return input.getAttribute("value");
+  }
+
+  public void deleteSelection() {
+    WebElement input = getAdvancedSearchInput();
+    // Click the input to display the Clear icon button.
+    input.click();
+
+    WebElement clearButton =
+        input.findElement(By.xpath("./following-sibling::div/button[@title='Clear']"));
+    clearButton.click();
+  }
+
+  public WebElement getAdvancedSearchFilterIcon() {
+    List<WebElement> buttons =
+        driver.findElements(By.xpath(".//button[@title='Show advanced search filter']"));
+    if (buttons.size() > 0) {
+      return buttons.get(0);
+    }
+
+    return null;
+  }
+
+  public WebElement getAdvancedSearchPanel() {
+    List<WebElement> divs = driver.findElements(By.id("advanced-search-panel"));
+    if (divs.size() > 0) {
+      return divs.get(0);
+    }
+
+    return null;
+  }
+
+  public void closeAdvancedSearchPanel() {
+    WebElement panel = getAdvancedSearchPanel();
+    if (panel != null) {
+      WebElement closeButton = panel.findElement(By.xpath(".//button[@title='Close']"));
+      closeButton.click();
+    } else {
+      throw new NoSuchElementException("Failed to find Advanced search panel");
+    }
+  }
+
+  public void openAdvancedSearchPanel() {
+    WebElement toggle = getAdvancedSearchFilterIcon();
+    if (toggle != null) {
+      toggle.click();
+    } else {
+      throw new NoSuchElementException("Failed to find Advanced search filter icon");
+    }
+  }
+
+  private WebElement getAdvancedSearchInput() {
+    WebElement advSearchSelector = getRefineControl("AdvancedSearchSelector");
+    return advSearchSelector.findElement(By.tagName("input"));
+  }
+}

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/advancedsearch/NewAdvancedSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/advancedsearch/NewAdvancedSearchPage.java
@@ -25,7 +25,7 @@ public class NewAdvancedSearchPage extends NewSearchPage {
     return input.getAttribute("value");
   }
 
-  public void deleteSelection() {
+  public void clearSelection() {
     WebElement input = getAdvancedSearchInput();
     // Click the input to display the Clear icon button.
     input.click();

--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -257,7 +257,7 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
    *
    * @param id The ID of a Refine Search control, excluding its prefix.
    */
-  private WebElement getRefineControl(String id) {
+  protected WebElement getRefineControl(String id) {
     return driver.findElement(By.id("RefineSearchPanel-" + id));
   }
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
@@ -37,10 +37,10 @@ public class AdvancedSearchPageTest extends AbstractSessionTest {
     assertEquals(selected, "DRM Party search");
   }
 
-  @Test(description = "Exist Advanced search mode")
+  @Test(description = "Exit Advanced search mode")
   @NewUIOnly
-  public void existAdvancedSearch() {
-    advancedSearchPage.deleteSelection();
+  public void exitAdvancedSearch() {
+    advancedSearchPage.clearSelection();
     // Check if the filter icon button disappears.
     assertNull(advancedSearchPage.getAdvancedSearchFilterIcon());
     // The selector's value should be an empty string now.

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
@@ -1,0 +1,62 @@
+package io.github.openequella.search;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.tle.webtests.framework.TestInstitution;
+import com.tle.webtests.test.AbstractSessionTest;
+import io.github.openequella.pages.advancedsearch.NewAdvancedSearchPage;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import testng.annotation.NewUIOnly;
+
+@TestInstitution("fiveo")
+public class AdvancedSearchPageTest extends AbstractSessionTest {
+  private NewAdvancedSearchPage advancedSearchPage;
+
+  @Override
+  protected void prepareBrowserSession() {
+    logon();
+  }
+
+  @BeforeMethod
+  public void loadAdvancedSearchPage() {
+    advancedSearchPage = new NewAdvancedSearchPage(context);
+    advancedSearchPage.load();
+    advancedSearchPage.selectAdvancedSearch("DRM");
+  }
+
+  @Test(description = "Select an Advanced search")
+  @NewUIOnly
+  public void accessAdvancedSearch() {
+    // Check if the filter icon button is displayed.
+    assertNotNull(advancedSearchPage.getAdvancedSearchFilterIcon());
+    // Check value of the selector.
+    String selected = advancedSearchPage.getSelection();
+    assertEquals(selected, "DRM Party search");
+  }
+
+  @Test(description = "Exist Advanced search mode")
+  @NewUIOnly
+  public void existAdvancedSearch() {
+    advancedSearchPage.deleteSelection();
+    // Check if the filter icon button disappears.
+    assertNull(advancedSearchPage.getAdvancedSearchFilterIcon());
+    // The selector's value should be an empty string now.
+    String selected = advancedSearchPage.getSelection();
+    assertEquals(selected, "");
+  }
+
+  @Test(description = "Open and close Advanced search panel")
+  @NewUIOnly
+  public void toggleAdvancedSearchPanel() {
+    assertNotNull(advancedSearchPage.getAdvancedSearchPanel());
+
+    advancedSearchPage.closeAdvancedSearchPanel();
+    assertNull(advancedSearchPage.getAdvancedSearchPanel());
+
+    advancedSearchPage.openAdvancedSearchPanel();
+    assertNotNull(advancedSearchPage.getAdvancedSearchPanel());
+  }
+}

--- a/react-front-end/__stories__/search/AdvancedSearchSelector.stories.tsx
+++ b/react-front-end/__stories__/search/AdvancedSearchSelector.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import { getAdvancedSearchesFromServerResult } from "../../__mocks__/AdvancedSearchModule.mock";
+import {
+  AdvancedSearchSelector,
+  AdvancedSearchSelectorProps,
+} from "../../tsrc/search/components/AdvancedSearchSelector";
+
+export default {
+  title: "Search/AdvancedSearchSelector",
+  component: AdvancedSearchSelector,
+  argTypes: {
+    onSelectionChange: { action: "on select Advanced Search" },
+  },
+} as Meta<AdvancedSearchSelectorProps>;
+
+export const NoValueSelected: Story<AdvancedSearchSelectorProps> = (args) => (
+  <AdvancedSearchSelector {...args} />
+);
+NoValueSelected.args = {
+  advancedSearches: getAdvancedSearchesFromServerResult,
+};
+
+export const InitialValueSelected: Story<AdvancedSearchSelectorProps> = (
+  args
+) => <AdvancedSearchSelector {...args} />;
+InitialValueSelected.args = {
+  ...NoValueSelected.args,
+  value: getAdvancedSearchesFromServerResult[0],
+};

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -147,7 +147,7 @@ type SearchPageProps = TemplateUpdateProps & AdvancedSearchParams;
 
 const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const history = useHistory();
-  const existAdvancedSearchMode = () => history.push(NEW_SEARCH_PATH);
+  const exitAdvancedSearchMode = () => history.push(NEW_SEARCH_PATH);
   const location = useLocation();
 
   // Retrieve any AdvancedSearchId from the Router
@@ -445,9 +445,10 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
         ? window.open(buildSelectionSessionAdvancedSearchLink(uuid), "_self")
         : history.push(routes.NewAdvancedSearch.to(uuid));
     } else {
-      existAdvancedSearchMode();
+      exitAdvancedSearchMode();
     }
   };
+
   const handleCollapsibleFilterClick = () => {
     setFilterExpansion(!filterExpansion);
   };
@@ -502,7 +503,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     setFilterExpansion(false);
 
     if (advancedSearchId) {
-      existAdvancedSearchMode();
+      exitAdvancedSearchMode();
     }
   };
 

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -59,7 +59,7 @@ export const AdvancedSearchPanel = ({
   onClose,
   onSubmit,
 }: AdvancedSearchPanelProps) => (
-  <Card>
+  <Card id="advanced-search-panel">
     <CardHeader
       title={languageStrings.searchpage.AdvancedSearchPanel.title}
       action={

--- a/react-front-end/tsrc/search/components/AdvancedSearchSelector.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchSelector.tsx
@@ -27,19 +27,18 @@ export interface AdvancedSearchSelectorProps {
    */
   advancedSearches: OEQ.Common.BaseEntitySummary[];
   /**
-   * Fires when a different Advanced search is selected.
-   * @param collections Selected collections.
+   * Function fired when the selection is changed.
+   *
+   * @param selection Currently selected Advanced search.
    */
-  onSelectionChange: (
-    advancedSearch: OEQ.Common.BaseEntitySummary | null
-  ) => void;
+  onSelectionChange: (selection: OEQ.Common.BaseEntitySummary | null) => void;
   /**
    * Initially selected Advanced search.
    */
   value?: OEQ.Common.BaseEntitySummary;
 }
 
-const { title } = languageStrings.searchpage.advancedSearchSelector;
+const { label } = languageStrings.searchpage.advancedSearchSelector;
 
 /**
  * Component used to select an Advanced search. Only single selection is supported.
@@ -50,18 +49,21 @@ export const AdvancedSearchSelector = ({
   value,
 }: AdvancedSearchSelectorProps) => (
   <Autocomplete
-    value={value}
+    debug
+    value={value ?? null}
     options={advancedSearches}
+    getOptionSelected={(option, selected) => selected.uuid === option.uuid}
     getOptionLabel={({ name }: OEQ.Common.BaseEntitySummary) => name}
     onChange={(_, value: OEQ.Common.BaseEntitySummary | null) =>
       onSelectionChange(value)
     }
+    renderOption={({ name }) => name}
     renderInput={(params) => (
       <TextField
         {...params}
         variant="outlined"
-        label={title}
-        placeholder={title}
+        label={label}
+        placeholder={label}
       />
     )}
   />

--- a/react-front-end/tsrc/search/components/AdvancedSearchSelector.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchSelector.tsx
@@ -1,0 +1,68 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TextField } from "@material-ui/core";
+import { Autocomplete } from "@material-ui/lab";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { languageStrings } from "../../util/langstrings";
+
+export interface AdvancedSearchSelectorProps {
+  /**
+   * All available Advanced searches.
+   */
+  advancedSearches: OEQ.Common.BaseEntitySummary[];
+  /**
+   * Fires when a different Advanced search is selected.
+   * @param collections Selected collections.
+   */
+  onSelectionChange: (
+    advancedSearch: OEQ.Common.BaseEntitySummary | null
+  ) => void;
+  /**
+   * Initially selected Advanced search.
+   */
+  value?: OEQ.Common.BaseEntitySummary;
+}
+
+const { title } = languageStrings.searchpage.advancedSearchSelector;
+
+/**
+ * Component used to select an Advanced search. Only single selection is supported.
+ */
+export const AdvancedSearchSelector = ({
+  advancedSearches,
+  onSelectionChange,
+  value,
+}: AdvancedSearchSelectorProps) => (
+  <Autocomplete
+    value={value}
+    options={advancedSearches}
+    getOptionLabel={({ name }: OEQ.Common.BaseEntitySummary) => name}
+    onChange={(_, value: OEQ.Common.BaseEntitySummary | null) =>
+      onSelectionChange(value)
+    }
+    renderInput={(params) => (
+      <TextField
+        {...params}
+        variant="outlined"
+        label={title}
+        placeholder={title}
+      />
+    )}
+  />
+);

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -507,6 +507,7 @@ export const languageStrings = {
       title: "Refine search",
     },
     advancedSearchSelector: {
+      label: "Advanced searches",
       title: "Access Advanced searches",
     },
     remoteSearchSelector: {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR created a new component `AdvancedSearchSelector` and integrated it with `SearchPage`. In order to hide the selector, the API call to list advanced searches is now executed in SearchPage initialising state.

The way to enter into or exist Advanced search mode is to change the current URL.  The benefit of doing this is to keep the data saved in history.

Also, when performing a new search, the page will exist Advanced search mode.


