### PR TITLE
Prevent black line from displaying on DRM page

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -5703,3 +5703,7 @@ button:focus {
 #selection-page .area.error {
   width: 100%;
 }
+
+.itemsummary-layout #col2 hr {
+  display: none;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] screenshots are included showing significant UI changes


##### Description of change
#2970 
This black line shouldn't exist on the DRM page - adding a simple CSS rule to hide it. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Before: 
![image](https://user-images.githubusercontent.com/24543345/132295266-0975d7ad-5a38-4616-b8d7-d80c62ecbc12.png)

After:
![image](https://user-images.githubusercontent.com/24543345/132295473-66011e7f-11d1-43ab-8516-131f233068df.png)


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
