### PR TITLE
chore(build): stop signing Admin Console JAR

### DIFF
--- a/Source/Plugins/Admin/com.tle.web.adminconsole/build.sbt
+++ b/Source/Plugins/Admin/com.tle.web.adminconsole/build.sbt
@@ -3,7 +3,7 @@ lazy val adminConsoleJar = project in file("jarsrc")
 (Compile / resourceGenerators) += Def.task {
   val outJar  = (Compile / resourceManaged).value / "web/adminconsole.jar"
   val jarFile = (adminConsoleJar / assembly).value
-  (jarSigner.value).apply(jarFile, outJar)
+  IO copyFile (jarFile, outJar)
   Seq(outJar)
 }.taskValue
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This was only needed when launched via JLNP. But that support was
removed back in 2019.1, and we now use the Admin Console Launcher
Package.

Not sure if this is optimum SBT, however due to the dependency structure it seems easiest way to maintain that. (i.e. the use here of `(adminConsoleJar / assembly).value`)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
