### PR TITLE
chore: specify the npm version in all 'package.json' files

### DIFF
--- a/Source/Plugins/Core/com.equella.core/swaggerui/package.json
+++ b/Source/Plugins/Core/com.equella.core/swaggerui/package.json
@@ -4,6 +4,9 @@
     "clean": "rm -rf target/ node_modules/",
     "dev": "parcel watch index.js --out-dir=../target/scala-2.12/classes/web/apidocs --out-file=bundle.js"
   },
+  "engines": {
+    "npm": "7.19.1"
+  },
   "dependencies": {
     "swagger-ui": "3.52.0"
   },

--- a/Source/Plugins/Core/com.equella.core/test/javascript/package.json
+++ b/Source/Plugins/Core/com.equella.core/test/javascript/package.json
@@ -10,6 +10,9 @@
     "clean": "rm -rf node_modules/",
     "test": "jest test"
   },
+  "engines": {
+    "npm": "7.19.1"
+  },
   "dependencies": {},
   "license": "Apache-2.0",
   "devDependencies": {

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -6,6 +6,9 @@
     "build": "pulp build && parcel build --no-autoinstall --out-dir=target/www www/*.html www/*.tsx",
     "dev": "pulp build && parcel watch --no-autoinstall --out-dir=../target/scala-2.12/classes/www www/*.html www/*.tsx"
   },
+  "engines": {
+    "npm": "7.19.1"
+  },
   "dependencies": {
     "@material-ui/core": "4.11.4",
     "axios": "0.21.1",

--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10",
+    "npm": "7.19.1"
   },
   "scripts": {
     "start": "rollup --config --watch",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "stylesheet_glob": "Source/Plugins/Core/com.equella.core/{js,resources}/**/*.{css,scss}",
     "typescript_glob": "{react-front-end,Source/Plugins/Core/com.equella.core/test/javascript}/**/*.{js,ts,tsx}"
   },
+  "engines": {
+    "npm": "7.19.1"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "4.30.0",
     "@typescript-eslint/parser": "4.30.0",

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -14,7 +14,7 @@
     "tools": "target/tools"
   },
   "engines": {
-    "npm": "^7.19.1"
+    "npm": "7.19.1"
   },
   "scripts": {
     "prepare": "cross-env-shell \"cd ../oeq-ts-rest-api && npm ci build\"",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

specify the npm version in all 'package.json' files. However, the version is pinned to `7.19.1` because newer versions can fail renovateBot builds. The reason is still unknown.