### PR TITLE
chore: update NPM scripts to correctly build the REST module

### DIFF
--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -18,8 +18,7 @@
     "build": "rollup --config",
     "test": "jest --no-cache",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
-    "format": "eslint --fix \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
-    "prepare": "npm run build"
+    "format": "eslint --fix \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\""
   },
   "peerDependencies": {},
   "prettier": {

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -17,7 +17,7 @@
     "npm": "7.19.1"
   },
   "scripts": {
-    "prepare": "cross-env-shell \"cd ../oeq-ts-rest-api && npm ci build\"",
+    "prepare": "cross-env-shell \"cd ../oeq-ts-rest-api && npm ci && npm run build\"",
     "install": "cross-env-shell \"mkdirp ${npm_package_config_devlang} ${npm_package_config_buildlang}\"",
     "clean": "rm -rf target/ node_modules/ .cache/",
     "compile:langbundle-tool": "cross-env-shell tsc --types \"node\" --outDir ${npm_package_config_languageBundle} build-tools/BuildLanguageBundle.ts",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The `prepare` script in `oeq-ts-rest-api` seems redundant as we can build the module when we run `npm install` for  `react-front-end`. So this PR removed The `prepare` in `oeq-ts-rest-api`.