### PR TITLE
chore: install `psc-package` via a NPM script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -406,11 +406,6 @@ jobs:
           ./sbt -jvm-opts autotest/.jvmopts "project autotest" \
             installEquella startEquella configureInstall setupForTests
 
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-
       - name: Run tests
         working-directory: oeq-ts-rest-api
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,6 +244,15 @@ jobs:
           distribution: adopt
           java-version: 8
 
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
       - uses: actions/checkout@v2
 
       - name: Download Artefacts
@@ -368,6 +377,15 @@ jobs:
           distribution: adopt
           java-version: 8
 
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
       - name: Download installer
         uses: actions/download-artifact@v2
         with:
@@ -387,10 +405,6 @@ jobs:
         run: |
           ./sbt -jvm-opts autotest/.jvmopts "project autotest" \
             installEquella startEquella configureInstall setupForTests
-
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
 
       - name: Setup node
         uses: actions/setup-node@v2

--- a/autotest/IntegTester/ps/.gitignore
+++ b/autotest/IntegTester/ps/.gitignore
@@ -6,3 +6,4 @@
 /.psc*
 /.purs*
 /.psa*
+/psc-package

--- a/autotest/IntegTester/ps/install.js
+++ b/autotest/IntegTester/ps/install.js
@@ -1,0 +1,37 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const https = require("follow-redirects").https;
+const tar = require("tar");
+const shell = require("shelljs");
+
+https.get(
+  `https://github.com/purescript/psc-package/releases/download/v0.6.2/linux64.tar.gz`,
+  (res) => {
+    return res.pipe(
+      tar.x().on("finish", () => {
+        if (shell.test("-f", "./psc-package/psc-package")) {
+          shell.mv(
+            "./psc-package/psc-package",
+            "./psc-package/psc-package.exe"
+          );
+        }
+      })
+    );
+  }
+);

--- a/autotest/IntegTester/ps/install.js
+++ b/autotest/IntegTester/ps/install.js
@@ -26,6 +26,7 @@ https.get(
     return res.pipe(
       tar.x().on("finish", () => {
         if (shell.test("-f", "./psc-package/psc-package")) {
+          shell.cp("./psc-package/psc-package", "./node_modules/.bin/");
           shell.mv(
             "./psc-package/psc-package",
             "./psc-package/psc-package.exe"

--- a/autotest/IntegTester/ps/install.js
+++ b/autotest/IntegTester/ps/install.js
@@ -27,10 +27,6 @@ https.get(
       tar.x().on("finish", () => {
         if (shell.test("-f", "./psc-package/psc-package")) {
           shell.cp("./psc-package/psc-package", "./node_modules/.bin/");
-          shell.mv(
-            "./psc-package/psc-package",
-            "./psc-package/psc-package.exe"
-          );
         }
       })
     );

--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "integ-tester",
+      "hasInstallScript": true,
       "dependencies": {
         "@material-ui/core": "4.11.4",
         "axios": "0.21.1",
@@ -16,16 +17,19 @@
         "react": "17.0.2",
         "react-dom": "17.0.2"
       },
+      "bin": {
+        "psc-package": "psc-package/psc-package.exe"
+      },
       "devDependencies": {
         "@types/react": "17.0.19",
         "@types/react-dom": "17.0.9",
-        "follow-redirects": "^1.5.9",
+        "follow-redirects": "1.5.9",
         "mkdirp": "1.0.4",
         "parcel-bundler": "1.12.5",
         "pulp": "15.0.0",
         "purescript": "0.12.3",
-        "shelljs": "^0.8.2",
-        "tar": "^4.4.8",
+        "shelljs": "0.8.2",
+        "tar": "4.4.8",
         "typescript": "4.4.2"
       },
       "engines": {
@@ -2348,6 +2352,25 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dependencies": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "node_modules/axios/node_modules/follow-redirects": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -5110,23 +5133,31 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "dev": true,
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
       "engines": {
         "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
+    },
+    "node_modules/follow-redirects/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/follow-redirects/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -9771,9 +9802,9 @@
       "dev": true
     },
     "node_modules/shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
       "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
@@ -10511,18 +10542,18 @@
       }
     },
     "node_modules/tar": {
-      "version": "4.4.18",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.18.tgz",
-      "integrity": "sha512-ZuOtqqmkV9RE1+4odd+MhBpibmCxNP6PJhH/h2OqNuotTX7/XHPZQJv2pKvWMplFH9SIZZhitehh6vBH6LO8Pg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       },
       "engines": {
         "node": ">=4.5"
@@ -13125,6 +13156,13 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+          "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+        }
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -15470,9 +15508,30 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -19309,9 +19368,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -19914,18 +19973,18 @@
       }
     },
     "tar": {
-      "version": "4.4.18",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.18.tgz",
-      "integrity": "sha512-ZuOtqqmkV9RE1+4odd+MhBpibmCxNP6PJhH/h2OqNuotTX7/XHPZQJv2pKvWMplFH9SIZZhitehh6vBH6LO8Pg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "requires": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       },
       "dependencies": {
         "mkdirp": {

--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -17,9 +17,6 @@
         "react": "17.0.2",
         "react-dom": "17.0.2"
       },
-      "bin": {
-        "psc-package": "psc-package/psc-package.exe"
-      },
       "devDependencies": {
         "@types/react": "17.0.19",
         "@types/react-dom": "17.0.9",

--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "integ-tester",
-      "hasInstallScript": true,
       "dependencies": {
         "@material-ui/core": "4.11.4",
         "axios": "0.21.1",
@@ -20,12 +19,17 @@
       "devDependencies": {
         "@types/react": "17.0.19",
         "@types/react-dom": "17.0.9",
+        "follow-redirects": "^1.5.9",
         "mkdirp": "1.0.4",
         "parcel-bundler": "1.12.5",
-        "psc-package": "4.0.1",
         "pulp": "15.0.0",
         "purescript": "0.12.3",
+        "shelljs": "^0.8.2",
+        "tar": "^4.4.8",
         "typescript": "4.4.2"
+      },
+      "engines": {
+        "npm": "7.19.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8806,21 +8810,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/psc-package": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/psc-package/-/psc-package-4.0.1.tgz",
-      "integrity": "sha512-P74OumVjkyc2ChiZqX6EA5E+2H38DTT3OKA4Rfpp/GeCQ1wF+WWZsREtgQDNotnJrBe6bHE9VGAbLVVXVrsB0g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "follow-redirects": "^1.5.9",
-        "shelljs": "^0.8.2",
-        "tar": "^4.4.8"
-      },
-      "bin": {
-        "psc-package": "psc-package/psc-package.exe"
-      }
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -18520,17 +18509,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
-      }
-    },
-    "psc-package": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/psc-package/-/psc-package-4.0.1.tgz",
-      "integrity": "sha512-P74OumVjkyc2ChiZqX6EA5E+2H38DTT3OKA4Rfpp/GeCQ1wF+WWZsREtgQDNotnJrBe6bHE9VGAbLVVXVrsB0g==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.5.9",
-        "shelljs": "^0.8.2",
-        "tar": "^4.4.8"
       }
     },
     "psl": {

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -32,8 +32,8 @@
     "pulp": "15.0.0",
     "purescript": "0.12.3",
     "typescript": "4.4.2",
-    "follow-redirects": "^1.5.9",
-    "tar": "^4.4.8",
-    "shelljs": "^0.8.2"
+    "follow-redirects": "1.5.9",
+    "tar": "4.4.8",
+    "shelljs": "0.8.2"
   }
 }

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -2,13 +2,10 @@
   "name": "integ-tester",
   "private": true,
   "scripts": {
-    "install": "node install.js && npm exec psc-package install",
+    "install": "node install.js && psc-package install",
     "clean": "rm -rf node_modules/ .psc-package/ psc-package",
     "build": "pulp build && parcel build --no-autoinstall --out-dir=target/www www/*.html www/*.tsx",
     "dev": "pulp build && parcel watch --no-autoinstall --out-dir=../target/scala-2.12/classes/www www/*.html www/*.tsx"
-  },
-  "bin": {
-    "psc-package": "./psc-package/psc-package.exe"
   },
   "engines": {
     "npm": "7.19.1"

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -2,9 +2,13 @@
   "name": "integ-tester",
   "private": true,
   "scripts": {
-    "install": "psc-package install",
+    "install": "node install.js && npm exec psc-package install",
+    "clean": "rm -rf node_modules/ .psc-package/ psc-package",
     "build": "pulp build && parcel build --no-autoinstall --out-dir=target/www www/*.html www/*.tsx",
     "dev": "pulp build && parcel watch --no-autoinstall --out-dir=../target/scala-2.12/classes/www www/*.html www/*.tsx"
+  },
+  "bin": {
+    "psc-package": "./psc-package/psc-package.exe"
   },
   "engines": {
     "npm": "7.19.1"
@@ -25,9 +29,11 @@
     "@types/react-dom": "17.0.9",
     "mkdirp": "1.0.4",
     "parcel-bundler": "1.12.5",
-    "psc-package": "4.0.1",
     "pulp": "15.0.0",
     "purescript": "0.12.3",
-    "typescript": "4.4.2"
+    "typescript": "4.4.2",
+    "follow-redirects": "^1.5.9",
+    "tar": "^4.4.8",
+    "shelljs": "^0.8.2"
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

With NPM 7 `psc-package` is not installed properly. So we created a new NPM script which will downloaded the package and use it.

This issue was originally found in `renovate` PRs (e.g. #3380 ) which failed to update `package-lock.json`.