### PR TITLE
feat: support for retrieving Advanced search definition in REST Module

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/wizard/TermSelectorControl.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/taxonomy/wizard/TermSelectorControl.java
@@ -37,8 +37,10 @@ public class TermSelectorControl extends CustomControl {
     LEAF_ONLY;
   }
 
+  public static final String CLASS_TYPE = "termselector";
+
   public TermSelectorControl() {
-    setClassType("termselector"); // $NON-NLS-1$
+    setClassType(CLASS_TYPE); // $NON-NLS-1$
   }
 
   public TermSelectorControl(CustomControl cloned) {

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/wizard/controls/userselector/UserSelectorControl.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/wizard/controls/userselector/UserSelectorControl.java
@@ -29,9 +29,10 @@ public class UserSelectorControl extends CustomControl {
   private static final String KEY_RESTRICT_CHOICES_PREFIX = "RestrictTo";
 
   public static final String KEY_RESTRICT_USER_GROUPS = "Groups";
+  public static final String CLASS_TYPE = "userselector";
 
   public UserSelectorControl() {
-    setClassType("userselector");
+    setClassType(CLASS_TYPE);
   }
 
   public UserSelectorControl(CustomControl cloned) {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/AdvancedSearchResource.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 
 case class AdvancedSearch(name: Option[String],
                           description: Option[String],
-                          collections: List[String],
+                          collections: List[BaseEntitySummary],
                           // WizardControlDefinition is an abstraction without real data structure so use 'ApiModelProperty'
                           // to provide a concrete structure.
                           @ApiModelProperty(dataType = "com.tle.web.api.wizard.WizardBasicControl")
@@ -76,7 +76,7 @@ class AdvancedSearchResource {
     Option(powerSearchService.getByUuid(uuid)) match {
       case Some(ps) =>
         val controls    = wizardControlConverter(ps.getWizard.getControls.asScala.toList)
-        val collections = ps.getItemdefs.asScala.map(c => c.getUuid).toList
+        val collections = ps.getItemdefs.asScala.map(c => BaseEntitySummary(c)).toList
         val name        = getStringFromCurrentLocale(ps.getName)
         val description = getStringFromCurrentLocale(ps.getDescription)
         Response

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -21,7 +21,9 @@ package com.tle.web.api.wizard
 import com.dytech.edge.wizard.TargetNode
 import com.dytech.edge.wizard.beans.control.{WizardControl, WizardControlItem}
 import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.tle.common.i18n.{LangUtils}
+import com.tle.common.i18n.LangUtils
+import com.tle.common.taxonomy.SelectionRestriction
+import com.tle.common.taxonomy.wizard.TermSelectorControl.TermStorageFormat
 import com.tle.web.api.language.LanguageStringHelper.getStringFromCurrentLocale
 import scala.collection.JavaConverters._
 
@@ -160,6 +162,44 @@ case class WizardCustomControl(
     @JsonUnwrapped
     basicControl: WizardBasicControl,
     attributes: Map[String, Object]
+) extends WizardControlDefinition
+
+/**
+  * Data structure for TermSelector control.
+  *
+  * @param basicControl The basic control providing common fields.
+  * @param selectedTaxonomy Taxonomy selected to search terms.
+  * @param isAllowMultiple Whether to allow multiple selections.
+  * @param isAllowAddTerms Whether to allow adding terms.
+  * @param termStorageFormat Whether to use full taxonomy path or only the selected term.
+  * @param selectionRestriction The restriction of term selection.
+  * @param displayType Which UI to be displayed - TermSelector has three different UI implementations.
+  */
+case class WizardTermSelector(
+    @JsonUnwrapped
+    basicControl: WizardBasicControl,
+    displayType: String,
+    isAllowAddTerms: Boolean,
+    isAllowMultiple: Boolean,
+    selectedTaxonomy: String,
+    selectionRestriction: SelectionRestriction,
+    termStorageFormat: TermStorageFormat,
+) extends WizardControlDefinition
+
+/**
+  * Data structure for UserSelector control.
+  *
+  * @param basicControl The basic control providing common fields.
+  * @param isSelectMultiple Whether to allow selecting multiple users.
+  * @param isRestricted Whether to restrict user selection by groups.
+  * @param restrictedTo Groups which the selection is limited to.
+  */
+case class WizardUserSelector(
+    @JsonUnwrapped
+    basicControl: WizardBasicControl,
+    isSelectMultiple: Boolean,
+    isRestricted: Boolean,
+    restrictedTo: java.util.Set[String]
 ) extends WizardControlDefinition
 
 /**

--- a/oeq-ts-rest-api/src/AdvancedSearch.ts
+++ b/oeq-ts-rest-api/src/AdvancedSearch.ts
@@ -23,7 +23,7 @@ import { WizardControl } from './wizard/WizardControl';
 /**
  * Definition of an Advanced Search.
  */
-export interface AdvancedSearch {
+export interface WizardDefinition {
   /**
    * Name of an Advanced Search.
    */
@@ -61,8 +61,8 @@ export const listAdvancedSearches = (
 export const getAdvancedSearchByUuid = (
   apiBasePath: string,
   uuid: string
-): Promise<AdvancedSearch> =>
+): Promise<WizardDefinition> =>
   GET(
     apiBasePath + ADV_SEARCH_SETTINGS_ROOT_PATH + uuid,
-    (data: unknown): data is AdvancedSearch => is<AdvancedSearch>(data)
+    (data: unknown): data is WizardDefinition => is<WizardDefinition>(data)
   );

--- a/oeq-ts-rest-api/src/AdvancedSearch.ts
+++ b/oeq-ts-rest-api/src/AdvancedSearch.ts
@@ -23,13 +23,13 @@ import { WizardControl } from './wizard/WizardControl';
 /**
  * Definition of an Advanced Search.
  */
-export interface WizardDefinition {
+export interface AdvancedSearchDefinition {
   /**
-   * Name of an Advanced Search.
+   * Name of the Advanced Search.
    */
   name?: string;
   /**
-   * Description of an Advanced Search.
+   * Description of the Advanced Search.
    */
   description?: string;
   /**
@@ -37,7 +37,7 @@ export interface WizardDefinition {
    */
   collections: BaseEntitySummary[];
   /**
-   * All the Wizard Controls of an Advanced Search.
+   * All the Wizard Controls of the Advanced Search.
    */
   controls: WizardControl[];
 }
@@ -61,8 +61,9 @@ export const listAdvancedSearches = (
 export const getAdvancedSearchByUuid = (
   apiBasePath: string,
   uuid: string
-): Promise<WizardDefinition> =>
+): Promise<AdvancedSearchDefinition> =>
   GET(
     apiBasePath + ADV_SEARCH_SETTINGS_ROOT_PATH + uuid,
-    (data: unknown): data is WizardDefinition => is<WizardDefinition>(data)
+    (data: unknown): data is AdvancedSearchDefinition =>
+      is<AdvancedSearchDefinition>(data)
   );

--- a/oeq-ts-rest-api/src/AdvancedSearch.ts
+++ b/oeq-ts-rest-api/src/AdvancedSearch.ts
@@ -15,8 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { is } from 'typescript-is';
 import { GET } from './AxiosInstance';
 import { BaseEntitySummary, isBaseEntitySummaryArray } from './Common';
+import { WizardControl } from './wizard/WizardControl';
+
+/**
+ * Definition of an Advanced Search.
+ */
+export interface AdvancedSearch {
+  /**
+   * Name of an Advanced Search.
+   */
+  name?: string;
+  /**
+   * Description of an Advanced Search.
+   */
+  description?: string;
+  /**
+   * A list of Collections configured to limit the search result.
+   */
+  collections: string[];
+  /**
+   * All the Wizard Controls of an Advanced Search.
+   */
+  controls: WizardControl[];
+}
 
 const ADV_SEARCH_SETTINGS_ROOT_PATH = '/settings/advancedsearch/';
 
@@ -27,3 +51,18 @@ export const listAdvancedSearches = (
   apiBasePath: string
 ): Promise<BaseEntitySummary[]> =>
   GET(apiBasePath + ADV_SEARCH_SETTINGS_ROOT_PATH, isBaseEntitySummaryArray);
+
+/**
+ * Retrieve an Advanced search's definition by UUID.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param uuid UUID of an Advanced search.
+ */
+export const getAdvancedSearchByUuid = (
+  apiBasePath: string,
+  uuid: string
+): Promise<AdvancedSearch> =>
+  GET(
+    apiBasePath + ADV_SEARCH_SETTINGS_ROOT_PATH + uuid,
+    (data: unknown): data is AdvancedSearch => is<AdvancedSearch>(data)
+  );

--- a/oeq-ts-rest-api/src/AdvancedSearch.ts
+++ b/oeq-ts-rest-api/src/AdvancedSearch.ts
@@ -35,7 +35,7 @@ export interface WizardDefinition {
   /**
    * A list of Collections configured to limit the search result.
    */
-  collections: string[];
+  collections: BaseEntitySummary[];
   /**
    * All the Wizard Controls of an Advanced Search.
    */

--- a/oeq-ts-rest-api/src/Taxonomy.ts
+++ b/oeq-ts-rest-api/src/Taxonomy.ts
@@ -26,7 +26,7 @@ export enum SelectionRestriction {
 }
 
 /**
- * Formats which ae used to search for a term.
+ * Formats which are used to search for a term.
  */
 export enum TermStorageFormat {
   FULL_PATH = 'FULL_PATH',

--- a/oeq-ts-rest-api/src/Taxonomy.ts
+++ b/oeq-ts-rest-api/src/Taxonomy.ts
@@ -19,16 +19,12 @@
 /**
  * Restrictions applied to Taxonomy term selection.
  */
-export enum SelectionRestriction {
-  TOP_LEVEL_ONLY = 'TOP_LEVEL_ONLY',
-  LEAF_ONLY = 'LEAF_ONLY',
-  UNRESTRICTED = 'UNRESTRICTED',
-}
+export type SelectionRestriction =
+  | 'TOP_LEVEL_ONLY'
+  | 'LEAF_ONLY'
+  | 'UNRESTRICTED';
 
 /**
  * Formats which are used to search for a term.
  */
-export enum TermStorageFormat {
-  FULL_PATH = 'FULL_PATH',
-  LEAF_ONLY = 'LEAF_ONLY',
-}
+export type TermStorageFormat = 'FULL_PATH' | 'LEAF_ONLY';

--- a/oeq-ts-rest-api/src/Taxonomy.ts
+++ b/oeq-ts-rest-api/src/Taxonomy.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Restrictions applied to Taxonomy term selection.
+ */
+export enum SelectionRestriction {
+  TOP_LEVEL_ONLY = 'TOP_LEVEL_ONLY',
+  LEAF_ONLY = 'LEAF_ONLY',
+  UNRESTRICTED = 'UNRESTRICTED',
+}
+
+/**
+ * Formats which ae used to search for a term.
+ */
+export enum TermStorageFormat {
+  FULL_PATH = 'FULL_PATH',
+  LEAF_ONLY = 'LEAF_ONLY',
+}

--- a/oeq-ts-rest-api/src/wizard/WizardCommonTypes.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardCommonTypes.ts
@@ -25,7 +25,7 @@ export interface TargetNode {
    */
   target: string;
   /**
-   * Attributes of the target node.
+   * Attribute of the target node.
    */
   attribute: string;
   /**

--- a/oeq-ts-rest-api/src/wizard/WizardCommonTypes.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardCommonTypes.ts
@@ -33,17 +33,17 @@ export interface TargetNode {
    */
   fullTarget: string;
   /**
-   * XOQ path of the target node.
+   * XOQL path of the target node.
    */
   xoqlPath: string;
   /**
-   * Free text field of the target node.
+   * Free text search index of the target node.
    */
   freetextField: string;
 }
 
 /**
- * Options of Option' type control such as CheckBox Group and Shuffle List.
+ * Options of 'Option' type control such as CheckBox Group and Shuffle List.
  */
 export interface WizardControlOption {
   text?: string;

--- a/oeq-ts-rest-api/src/wizard/WizardCommonTypes.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardCommonTypes.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Information about a Wizard target.
+ */
+export interface TargetNode {
+  /**
+   * The target node.
+   */
+  target: string;
+  /**
+   * Attributes of the target node.
+   */
+  attribute: string;
+  /**
+   * Full path of the target node.
+   */
+  fullTarget: string;
+  /**
+   * XOQ path of the target node.
+   */
+  xoqlPath: string;
+  /**
+   * Free text field of the target node.
+   */
+  freetextField: string;
+}
+
+/**
+ * Options of Option' type control such as CheckBox Group and Shuffle List.
+ */
+export interface WizardControlOption {
+  text?: string;
+  value: string;
+}

--- a/oeq-ts-rest-api/src/wizard/WizardControl.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardControl.ts
@@ -113,6 +113,7 @@ export interface WizardCalendarControl extends WizardBasicControl {
    * values from both representing a range.
    */
   isRange: boolean;
+  controlType: 'calendar';
 }
 
 export interface WizardShuffleListControl extends WizardTextTypeControl {
@@ -121,6 +122,7 @@ export interface WizardShuffleListControl extends WizardTextTypeControl {
    * Lucene query.
    */
   isTokenise: boolean;
+  controlType: 'shufflelist';
 }
 
 export interface WizardEditBoxControl extends WizardTextTypeControl {
@@ -136,6 +138,7 @@ export interface WizardEditBoxControl extends WizardTextTypeControl {
    * Whether to support multiple languages.
    */
   isAllowMultiLang: boolean;
+  controlType: 'editbox';
 }
 
 export interface WizardUserSelectorControl extends WizardBasicControl {
@@ -151,6 +154,7 @@ export interface WizardUserSelectorControl extends WizardBasicControl {
    * Groups which the selection is limited to.
    */
   restrictedTo: UuidString[];
+  controlType: 'userselector';
 }
 
 export interface WizardTermSelectorControl extends WizardBasicControl {
@@ -179,6 +183,7 @@ export interface WizardTermSelectorControl extends WizardBasicControl {
    * e.g. \a\b\term or term
    */
   termStorageFormat: TermStorageFormat;
+  controlType: 'termselector';
 }
 
 /**

--- a/oeq-ts-rest-api/src/wizard/WizardControl.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardControl.ts
@@ -19,6 +19,9 @@ import { UuidString } from '../Common';
 import { SelectionRestriction, TermStorageFormat } from '../Taxonomy';
 import { TargetNode, WizardControlOption } from './WizardCommonTypes';
 
+/**
+ * Supported Wizard Control types.
+ */
 export type ControlType =
   | 'calendar'
   | 'checkboxgroup'
@@ -143,15 +146,15 @@ export interface WizardUserSelectorControl extends WizardBasicControl {
     /**
      * Whether to restrict user selection by groups
      */
-    IsRestrictedGroups: boolean;
+    isRestrictedGroups: boolean;
     /**
      * Whether selecting multiple users is supported.
      */
-    IsSelectMultiple: boolean;
+    isSelectMultiple: boolean;
     /**
      * Groups which the selection is limited to.
      */
-    RestrictToGroups: UuidString[];
+    restrictToGroups: UuidString[];
   };
 }
 

--- a/oeq-ts-rest-api/src/wizard/WizardControl.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardControl.ts
@@ -140,67 +140,45 @@ export interface WizardEditBoxControl extends WizardTextTypeControl {
 
 export interface WizardUserSelectorControl extends WizardBasicControl {
   /**
-   * Attributes specific to UserSelector.
+   * Whether to restrict user selection by groups.
    */
-  attributes: {
-    /**
-     * Whether to restrict user selection by groups
-     */
-    isRestrictedGroups: boolean;
-    /**
-     * Whether selecting multiple users is supported.
-     */
-    isSelectMultiple: boolean;
-    /**
-     * Groups which the selection is limited to.
-     */
-    restrictToGroups: UuidString[];
-  };
+  isRestricted: boolean;
+  /**
+   * Whether selecting multiple users is supported.
+   */
+  isSelectMultiple: boolean;
+  /**
+   * Groups which the selection is limited to.
+   */
+  restrictedTo: UuidString[];
 }
 
 export interface WizardTermSelectorControl extends WizardBasicControl {
   /**
-   * Attributes specific to TermSelector.
+   * Whether to allow adding terms.
    */
-  attributes: {
-    KEY_ALLOW_ADD_TERMS: boolean;
-    /**
-     * Whether to allow multiple terms to be selected.
-     */
-    KEY_ALLOW_MULTIPLE: boolean;
-    /**
-     * Which UI to be displayed - TermSelector has three different UI implementations.
-     */
-    KEY_DISPLAY_TYPE:
-      | 'popupBrowser'
-      | 'autocompleteEditBox'
-      | 'widePopupBrowser';
-    /**
-     * UUID of the selected Taxonomy.
-     */
-    KEY_SELECTED_TAXONOMY: UuidString;
-    /**
-     * The restriction of term selection.
-     */
-    KEY_SELECTION_RESTRICTION: SelectionRestriction;
-    /**
-     * Whether to search the full taxonomy path or only the selected term.
-     * e.g. \a\b\term or term
-     */
-    KEY_TERM_STORAGE_FORMAT: TermStorageFormat;
-    /**
-     * Whether to allow users to navigate the taxonomy by browsing.
-     */
-    POPUP_ALLOW_BROWSING: boolean;
-    /**
-     * Whether to allow users to navigate the taxonomy by searching.
-     */
-    POPUP_ALLOW_SEARCHING: boolean;
-    /**
-     * Whether to reload the page when a term is selected. (Isn't this duplicated ?)
-     */
-    RELOAD_PAGE_ON_SELECTION: boolean;
-  };
+  isAllowAddTerms: boolean;
+  /**
+   * Whether to allow multiple terms to be selected.
+   */
+  isAllowMultiple: boolean;
+  /**
+   * Which UI to be displayed - TermSelector has three different UI implementations.
+   */
+  displayType: 'popupBrowser' | 'autocompleteEditBox' | 'widePopupBrowser';
+  /**
+   * UUID of the selected Taxonomy.
+   */
+  selectedTaxonomy: UuidString;
+  /**
+   * The restriction of term selection.
+   */
+  selectionRestriction: SelectionRestriction;
+  /**
+   * Whether to search the full taxonomy path or only the selected term.
+   * e.g. \a\b\term or term
+   */
+  termStorageFormat: TermStorageFormat;
 }
 
 /**

--- a/oeq-ts-rest-api/src/wizard/WizardControl.ts
+++ b/oeq-ts-rest-api/src/wizard/WizardControl.ts
@@ -1,0 +1,217 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UuidString } from '../Common';
+import { SelectionRestriction, TermStorageFormat } from '../Taxonomy';
+import { TargetNode, WizardControlOption } from './WizardCommonTypes';
+
+export type ControlType =
+  | 'calendar'
+  | 'checkboxgroup'
+  | 'editbox'
+  | 'html'
+  | 'listbox'
+  | 'radiogroup'
+  | 'shufflebox'
+  | 'shufflelist'
+  | 'termselector'
+  | 'userselector';
+
+/**
+ * Provide common properties of Wizard Control.
+ */
+export interface WizardBasicControl {
+  /**
+   * Whether the control must have a value.
+   */
+  mandatory: boolean;
+  /**
+   * Whether to reload all controls after a control has different value.
+   */
+  reload: boolean;
+  /**
+   * Whether the control is selectable in Admin Console Advanced Search editor.
+   */
+  include: boolean;
+  /**
+   * Number of columns typically used in Radio Button groups and Checkbox groups.
+   */
+  size1: number;
+  /**
+   * Number of rows typically used in EditBox.
+   */
+  size2: number;
+  /**
+   * The controls' customised name which is used in the Admin Console.
+   */
+  customName?: string;
+  /**
+   * Title of the control.
+   */
+  title?: string;
+  /**
+   * Description of the control.
+   */
+  description?: string;
+  /**
+   * Script which controls the visibility of the control. (Commonly run when rendering control.)
+   */
+  visibilityScript?: string;
+  /**
+   * Schema nodes that the control targets to.
+   */
+  targetNodes: TargetNode[];
+  /**
+   * Options available for selection. Empty for non-option type controls.
+   */
+  options: WizardControlOption[];
+  /**
+   * Text displayed in the criteria summary instead.
+   */
+  powerSearchFriendlyName?: string;
+  /**
+   * Type of the control.
+   */
+  controlType: ControlType;
+}
+
+/**
+ * Abstract type for controls that support text editing.
+ */
+interface WizardTextTypeControl extends WizardBasicControl {
+  /**
+   * Whether each value must be unique.
+   */
+  isForceUnique: boolean;
+  /**
+   * Whether to check duplicated values.
+   */
+  isCheckDuplication: boolean;
+}
+
+export interface WizardCalendarControl extends WizardBasicControl {
+  /**
+   * Whether to support a date range. If false, should only display a single calendar control
+   * and supply a single date value. However if true, two controls should be displayed with the
+   * values from both representing a range.
+   */
+  isRange: boolean;
+}
+
+export interface WizardShuffleListControl extends WizardTextTypeControl {
+  /**
+   * Whether to tokenise the value. If true, an '*' must be appended to the schema node in the
+   * Lucene query.
+   */
+  isTokenise: boolean;
+}
+
+export interface WizardEditBoxControl extends WizardTextTypeControl {
+  /**
+   * Whether to allow links.
+   */
+  isAllowLinks: boolean;
+  /**
+   * Whether to use numbers only.
+   */
+  isNumber: boolean;
+  /**
+   * Whether to support multiple languages.
+   */
+  isAllowMultiLang: boolean;
+}
+
+export interface WizardUserSelectorControl extends WizardBasicControl {
+  /**
+   * Attributes specific to UserSelector.
+   */
+  attributes: {
+    /**
+     * Whether to restrict user selection by groups
+     */
+    IsRestrictedGroups: boolean;
+    /**
+     * Whether selecting multiple users is supported.
+     */
+    IsSelectMultiple: boolean;
+    /**
+     * Groups which the selection is limited to.
+     */
+    RestrictToGroups: UuidString[];
+  };
+}
+
+export interface WizardTermSelectorControl extends WizardBasicControl {
+  /**
+   * Attributes specific to TermSelector.
+   */
+  attributes: {
+    KEY_ALLOW_ADD_TERMS: boolean;
+    /**
+     * Whether to allow multiple terms to be selected.
+     */
+    KEY_ALLOW_MULTIPLE: boolean;
+    /**
+     * Which UI to be displayed - TermSelector has three different UI implementations.
+     */
+    KEY_DISPLAY_TYPE:
+      | 'popupBrowser'
+      | 'autocompleteEditBox'
+      | 'widePopupBrowser';
+    /**
+     * UUID of the selected Taxonomy.
+     */
+    KEY_SELECTED_TAXONOMY: UuidString;
+    /**
+     * The restriction of term selection.
+     */
+    KEY_SELECTION_RESTRICTION: SelectionRestriction;
+    /**
+     * Whether to search the full taxonomy path or only the selected term.
+     * e.g. \a\b\term or term
+     */
+    KEY_TERM_STORAGE_FORMAT: TermStorageFormat;
+    /**
+     * Whether to allow users to navigate the taxonomy by browsing.
+     */
+    POPUP_ALLOW_BROWSING: boolean;
+    /**
+     * Whether to allow users to navigate the taxonomy by searching.
+     */
+    POPUP_ALLOW_SEARCHING: boolean;
+    /**
+     * Whether to reload the page when a term is selected. (Isn't this duplicated ?)
+     */
+    RELOAD_PAGE_ON_SELECTION: boolean;
+  };
+}
+
+/**
+ * For controls which have types not defined in `ControlType`.
+ */
+export interface UnknownWizardControl {
+  controlType: 'unknown';
+}
+
+export type WizardControl =
+  | WizardBasicControl
+  | WizardCalendarControl
+  | WizardEditBoxControl
+  | WizardShuffleListControl
+  | WizardTermSelectorControl
+  | WizardUserSelectorControl
+  | UnknownWizardControl;

--- a/oeq-ts-rest-api/test/AdvancedSearch.test.ts
+++ b/oeq-ts-rest-api/test/AdvancedSearch.test.ts
@@ -16,7 +16,10 @@
  * limitations under the License.
  */
 import * as OEQ from '../src';
-import { listAdvancedSearches } from '../src/AdvancedSearch';
+import {
+  getAdvancedSearchByUuid,
+  listAdvancedSearches,
+} from '../src/AdvancedSearch';
 import * as TC from './TestConfig';
 
 const API_PATH = TC.API_PATH_VANILLA;
@@ -28,4 +31,14 @@ afterAll(() => OEQ.Auth.logout(API_PATH, true));
 describe('listAdvancedSearches', () => {
   it('lists the available advanced searches in an institution', async () =>
     expect((await listAdvancedSearches(API_PATH)).length).toBeGreaterThan(0));
+});
+
+describe('getAdvancedSearchByUuid', () => {
+  it('retrieves definition of an Advanced search in an institution', async () => {
+    const { controls } = await getAdvancedSearchByUuid(
+      TC.API_PATH_FIVEO,
+      'c9fd1ae8-0dc1-ab6f-e923-1f195a22d537'
+    );
+    expect(controls).toHaveLength(13);
+  });
 });


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for retrieving Advanced search to the REST Module. 

The major change is creating different data structures to support Wizard controls used in Advanced search. And a new function was added to talk to the endpoint.