### PR TITLE
feat: don't show Collection Selector in Advanced search page

### DIFF
--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -23,6 +23,8 @@ import { languageStrings } from "../../../tsrc/util/langstrings";
 import {
   initialiseEssentialMocks,
   mockCollaborators,
+  queryClassificationPanel,
+  queryCollectionSelector,
   renderSearchPage,
 } from "./SearchPageTestHelper";
 
@@ -87,5 +89,19 @@ describe("Advanced Search filter button", () => {
     // Toggle to show again
     togglePanel();
     expect(queryAdvSearchPanel()).toBeInTheDocument();
+  });
+});
+
+describe("Hide components", () => {
+  it("does not show Collection Selector", async () => {
+    const { container } = await renderAdvancedSearchPage();
+    expect(queryCollectionSelector(container)).not.toBeInTheDocument();
+  });
+
+  it("does not list Classifications and show Classification panel", async () => {
+    mockListClassification.mockClear();
+    const { container } = await renderAdvancedSearchPage();
+    expect(mockListClassification).not.toHaveBeenCalled();
+    expect(queryClassificationPanel(container)).not.toBeInTheDocument();
   });
 });

--- a/react-front-end/__tests__/tsrc/search/SearchPageTestHelper.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPageTestHelper.tsx
@@ -325,3 +325,25 @@ export const queryCollectionSelector = (container: HTMLElement) =>
  */
 export const queryStatusSelector = (container: HTMLElement) =>
   queryRefineSearchComponent(container, "StatusSelector");
+
+/**
+ * Helper function to assist in finding the Classification panel.
+ * @param container The root container where <ClassificationsPanel/> exists
+ */
+export const queryClassificationPanel = (
+  container: Element
+): HTMLDivElement | null =>
+  container.querySelector<HTMLDivElement>("#classification-panel");
+
+/**
+ * Similar to queryClassificationPanel but throws an error if ClassificationsPanel is not found.
+ * @param container The root container where <ClassificationsPanel/> exists
+ */
+export const getClassificationPanel = (container: Element): HTMLDivElement => {
+  const classificationPanel = queryClassificationPanel(container);
+  if (!classificationPanel) {
+    throw new Error("Unable to find Classification panel");
+  }
+
+  return classificationPanel;
+};

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -707,7 +707,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           value={searchPageOptions.collections}
         />
       ),
-      disabled: false,
+      disabled: advancedSearchId !== undefined,
       alwaysVisible: true,
     },
     {

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -366,10 +366,9 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
             state.options
           );
           // Do not list classifications in Advanced search mode.
-          const classifications: Classification[] =
-            advancedSearchId === undefined
-              ? await getClassifications(state.options)
-              : [];
+          const classifications: Classification[] = !advancedSearchId
+            ? await getClassifications(state.options)
+            : [];
 
           dispatch({
             type: "search-complete",
@@ -725,7 +724,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           value={searchPageOptions.collections}
         />
       ),
-      disabled: advancedSearchId !== undefined,
+      disabled: !!advancedSearchId,
       alwaysVisible: true,
     },
     {
@@ -843,13 +842,14 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           onClose: () => setShowRefinePanel(false),
         }}
         classificationsPanelProps={
-          advancedSearchId !== undefined
-            ? undefined
-            : {
+          // When in advanced search mode, hide classifications panel
+          !advancedSearchId
+            ? {
                 classifications: getClassifications(),
                 onSelectedCategoriesChange: handleSelectedCategoriesChange,
                 selectedCategories: searchPageOptions.selectedCategories,
               }
+            : undefined
         }
       />
     );

--- a/react-front-end/tsrc/search/components/SidePanel.tsx
+++ b/react-front-end/tsrc/search/components/SidePanel.tsx
@@ -30,7 +30,7 @@ interface SidePanelProps {
   /**
    * Props passed to Classifications Panel
    */
-  classificationsPanelProps: CategorySelectorProps;
+  classificationsPanelProps?: CategorySelectorProps;
 }
 
 /**
@@ -44,7 +44,7 @@ export const SidePanel = ({
     <Grid item id="refine-panel">
       <RefineSearchPanel {...refinePanelProps} />
     </Grid>
-    {classificationsPanelProps.classifications.some(
+    {classificationsPanelProps?.classifications.some(
       (c) => c.categories.length > 0
     ) && (
       <Grid item id="classification-panel">

--- a/react-front-end/tsrc/search/components/SidePanel.tsx
+++ b/react-front-end/tsrc/search/components/SidePanel.tsx
@@ -28,7 +28,7 @@ interface SidePanelProps {
    */
   refinePanelProps: RefinePanelProps;
   /**
-   * Props passed to Classifications Panel
+   * Props passed to Classifications Panel, if undefined the panel is not displayed.
    */
   classificationsPanelProps?: CategorySelectorProps;
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the feature of not showing Collection Selector and Classification panel in Advanced search mode. 

Also the REST API call to list Classifications will not be executed. Should not need to list Collections as well, but due to the existing implementation this will require more changes.


https://user-images.githubusercontent.com/47203811/133177963-7685b440-e692-44eb-8707-ed476a0a1ae7.mp4

