### PR TITLE
chore(front-end): facilitate leave in debug logging

### DIFF
--- a/react-front-end/tsrc/mainui/App.tsx
+++ b/react-front-end/tsrc/mainui/App.tsx
@@ -128,6 +128,8 @@ export const withErrorHandler =
     );
 
 const App = ({ entryPage }: AppProps): JSX.Element => {
+  console.debug("START: <App>");
+
   const [error, setError] = React.useState<Error | string | undefined>();
   const appErrorHandler = useCallback(
     (error: Error | string) => setError(error),

--- a/react-front-end/tsrc/mainui/index.tsx
+++ b/react-front-end/tsrc/mainui/index.tsx
@@ -27,6 +27,17 @@ export type EntryPage = "mainDiv" | "searchPage" | "settingsPage";
 const App = React.lazy(() => import("./App"));
 
 export default function main(entry: EntryPage) {
+  if (process.env.NODE_ENV === "production") {
+    const nop = () => {};
+    console = {
+      ...console,
+      debug: nop,
+      log: nop,
+      time: nop,
+      timeEnd: nop,
+    };
+  }
+
   initStrings();
   ReactDOM.render(
     <React.Suspense fallback={<>loading</>}>

--- a/react-front-end/tsrc/mainui/index.tsx
+++ b/react-front-end/tsrc/mainui/index.tsx
@@ -29,6 +29,7 @@ const App = React.lazy(() => import("./App"));
 export default function main(entry: EntryPage) {
   if (process.env.NODE_ENV === "production") {
     const nop = () => {};
+    // eslint-disable-next-line no-native-reassign
     console = {
       ...console,
       debug: nop,

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -146,6 +146,8 @@ interface AdvancedSearchParams {
 type SearchPageProps = TemplateUpdateProps & AdvancedSearchParams;
 
 const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
+  console.debug("START: <SearchPage>");
+
   const history = useHistory();
   const exitAdvancedSearchMode = () => history.push(NEW_SEARCH_PATH);
   const location = useLocation();
@@ -246,6 +248,10 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
       return;
     }
 
+    const timerId = "sp-init";
+    console.debug("SearchPage: useEffect - initialising");
+    console.time(timerId);
+
     updateTemplate((tp) => ({
       ...templateDefaults(searchStrings.title)(tp),
     }));
@@ -295,6 +301,8 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
       .catch((e) => {
         searchPageErrorHandler(e);
       });
+
+    console.timeEnd(timerId);
   }, [
     dispatch,
     searchPageErrorHandler,
@@ -310,6 +318,10 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
    */
   useEffect(() => {
     if (state.status === "searching") {
+      const timerId = "sp-searching";
+      console.debug("SearchPage: useEffect - searching");
+      console.time(timerId);
+
       const gallerySearch = async (
         search: typeof imageGallerySearch | typeof videoGallerySearch,
         options: SearchPageOptions
@@ -385,6 +397,8 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           }
         )
         .catch(searchPageErrorHandler);
+
+      console.timeEnd(timerId);
     }
   }, [dispatch, filterExpansion, searchPageErrorHandler, history, state]);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

As the front-end is about to become even more complex would be good to be able to add some basic logging which we can leave in place.

Maybe in the future we can build some common functions, but I don't think we need to bring in one of the various JS logging libraries at this point. Just keeping it simple and using what the browser gives us.

As we start doing this more, then we'll see what kind of pattern we really want to support, and add a group of functions to match.


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
