### PR TITLE
feat: support for listing taxonomy terms in REST Module

### DIFF
--- a/oeq-ts-rest-api/src/Taxonomy.ts
+++ b/oeq-ts-rest-api/src/Taxonomy.ts
@@ -51,7 +51,7 @@ export interface Term {
    */
   index: number;
   /**
-   * UUID of the term. Optional because no all endpoints returning it.
+   * UUID of the term. Optional because not all endpoints returning it.
    */
   uuid?: string;
   /**
@@ -59,7 +59,8 @@ export interface Term {
    */
   parentUuid?: string;
   /**
-   * Extra data associated with the term.
+   * Extra data associated with the term, which could be either a HTML fragment displayed
+   * in the Taxonomy term Pop-up Browser or a custom key/value pair.
    */
   data?: Record<string, string>;
 }

--- a/oeq-ts-rest-api/src/Taxonomy.ts
+++ b/oeq-ts-rest-api/src/Taxonomy.ts
@@ -55,7 +55,7 @@ export interface Term {
    */
   uuid?: string;
   /**
-   * UUID of the parent term.
+   * UUID of the parent term. Optional because not all endpoints returning it.
    */
   parentUuid?: string;
   /**

--- a/oeq-ts-rest-api/src/index.ts
+++ b/oeq-ts-rest-api/src/index.ts
@@ -33,5 +33,6 @@ export * as SearchFacets from './SearchFacets';
 export * as SearchSettings from './SearchSettings';
 export * as Security from './Security';
 export * as Settings from './Settings';
+export * as Taxonomy from './Taxonomy';
 export * as UserQuery from './UserQuery';
 export * as Utils from './Utils';

--- a/oeq-ts-rest-api/test/Taxonomy.test.ts
+++ b/oeq-ts-rest-api/test/Taxonomy.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PagedResult } from '../dist/Common';
+import * as OEQ from '../src';
+import {
+  getTaxonomyChildTerms,
+  searchTaxonomyTerms,
+  Term,
+} from '../src/Taxonomy';
+import * as TC from './TestConfig';
+
+const taxonomyUuid = 'a8475ae1-0382-a258-71c3-673e4597c3d2';
+const API_PATH = TC.API_PATH;
+
+beforeAll(() => OEQ.Auth.login(API_PATH, TC.USERNAME_SUPER, TC.PASSWORD_SUPER));
+afterAll(() => OEQ.Auth.logout(API_PATH, true));
+
+describe('getTaxonomyChildTerms', () => {
+  it('lists child terms of a taxonomy', async () => {
+    const terms: Term[] = await getTaxonomyChildTerms(
+      API_PATH,
+      taxonomyUuid,
+      'REST-TAXONOMY-TYPES'
+    );
+    expect(terms).toHaveLength(2);
+  });
+});
+
+describe('searchTaxonomyTerms', () => {
+  it('searches terms of a taxonomy', async () => {
+    const result: PagedResult<Term> = await searchTaxonomyTerms(
+      API_PATH,
+      taxonomyUuid,
+      'REST*'
+    );
+    expect(result.available).toBe(5);
+  });
+});


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for listing taxonomy terms to REST Module.
Two functions have been created. One is used to search child terms, given a path. The other one is used to search terms by query.