### PR TITLE
bugfix: fix Contribution save panel UI issue where buttons are cut off

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -2954,7 +2954,7 @@ Contribution wizard styling
 }
 
 .wizard-layout #col2 {
-  padding-left: $singleMargin;
+  padding-left: $doubleMargin;
 }
 
 #wizard-pagelist {
@@ -3048,8 +3048,7 @@ Contribution wizard styling
 }
 
 #wizard-actions {
-  text-align: right;
-  margin-bottom: 10px;
+  margin: 0 0 $singleMargin $singleMargin;
 }
 
 #more-actions li {
@@ -3057,8 +3056,8 @@ Contribution wizard styling
 }
 
 .action-link {
-  margin-left: 14px;
-  text-align: left;
+  margin-left: $singleMargin;
+  padding: 0;
   font-size: 11px;
 }
 


### PR DESCRIPTION
#2969 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The fix is removing the `text-align: right` applied on those buttons. I also added some adjustments for the margin between the save panel and wizard panel.
![Screenshot from 2021-09-20 09-39-54](https://user-images.githubusercontent.com/47203811/133948322-71ba54bb-631b-4024-ad43-b4b99a713b74.png)
![Screenshot from 2021-09-20 09-45-13](https://user-images.githubusercontent.com/47203811/133948323-0f375bd2-b6ae-49f0-8024-997ba85d104e.png)

