### PR TITLE
build: increase  memory for GHA builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,6 +294,10 @@ jobs:
           ./sbt -jvm-opts autotest/.jvmopts "project autotest" \
             OldTests/test dumpCoverage
 
+      - name: Check memory usage
+        if: failure()
+        run: free -h
+
       - name: Save TestNG Reports
         if: failure()
         uses: actions/upload-artifact@v2.2.4

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,1 @@
--J-Xmx4G
+-J-Xmx5G

--- a/autotest/.jvmopts
+++ b/autotest/.jvmopts
@@ -1,4 +1,4 @@
--Xms2048m
--Xmx2048m
+-Xms3072m
+-Xmx3072m
 -XX:ReservedCodeCacheSize=256m
 -XX:MaxMetaspaceSize=512m

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.2
+sbt.version = 1.5.5

--- a/sbt
+++ b/sbt
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.0"
-declare -r sbt_unreleased_version="1.5.0"
+declare -r sbt_release_version="1.5.5"
+declare -r sbt_unreleased_version="1.5.5"
 
 declare -r latest_213="2.13.5"
 declare -r latest_212="2.12.13"

--- a/sbt
+++ b/sbt
@@ -37,8 +37,8 @@ set -o pipefail
 declare -r sbt_release_version="1.5.5"
 declare -r sbt_unreleased_version="1.5.5"
 
-declare -r latest_213="2.13.5"
-declare -r latest_212="2.12.13"
+declare -r latest_213="2.13.6"
+declare -r latest_212="2.12.15"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

GHA builds have been failing since last Friday due to memory running out during running selenium tests. So let's increase a bit more memory.