### PR TITLE
Feature/advanced search form (part 1)

### DIFF
--- a/react-front-end/__mocks__/WizardHelper.mock.ts
+++ b/react-front-end/__mocks__/WizardHelper.mock.ts
@@ -1,0 +1,129 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const controls: OEQ.WizardControl.WizardControl[] = [
+  {
+    mandatory: false,
+    reload: true,
+    include: true,
+    size1: 2,
+    size2: 0,
+    title: "Do you want to show or hide?",
+    targetNodes: [
+      {
+        target: "/item/name",
+        attribute: "",
+        fullTarget: "/item/name",
+        xoqlPath: "/item/name",
+        freetextField: "/item/name",
+      },
+    ],
+    options: [
+      {
+        text: "Hide",
+        value: "hide",
+      },
+      {
+        text: "Show",
+        value: "",
+      },
+    ],
+    controlType: "radiogroup",
+  },
+  {
+    mandatory: true,
+    reload: false,
+    include: true,
+    size1: 0,
+    size2: 1,
+    customName: "Edit Box #1",
+    title: "Edit Box #1",
+    description: "The first edit box - target name",
+    visibilityScript:
+      "var bRet = false; \nif( xml.get('/item/name') != 'hide' ) \n{ \n    bRet = true; \n} \nreturn bRet; \n",
+    targetNodes: [
+      {
+        target: "/item/name",
+        attribute: "",
+        fullTarget: "/item/name",
+        xoqlPath: "/item/name",
+        freetextField: "/item/name",
+      },
+    ],
+    options: [],
+    controlType: "editbox",
+    isAllowLinks: false,
+    isNumber: false,
+    isAllowMultiLang: false,
+    isForceUnique: false,
+    isCheckDuplication: false,
+  },
+  {
+    mandatory: false,
+    reload: false,
+    include: true,
+    size1: 0,
+    size2: 3,
+    title: "Edit Box #2",
+    description:
+      "The second edit box, with three rows and targetting description",
+    visibilityScript:
+      "var bRet = false; \nif( xml.get('/item/name') != 'hide' && xml.get('/item/name') != 'hide2' ) \n{ \n    bRet = true; \n} \nreturn bRet; \n",
+    targetNodes: [
+      {
+        target: "/item/description",
+        attribute: "",
+        fullTarget: "/item/description",
+        xoqlPath: "/item/description",
+        freetextField: "/item/description",
+      },
+    ],
+    options: [],
+    controlType: "editbox",
+    isAllowLinks: false,
+    isNumber: false,
+    isAllowMultiLang: false,
+    isForceUnique: false,
+    isCheckDuplication: false,
+  },
+  {
+    mandatory: true,
+    reload: false,
+    include: true,
+    size1: 0,
+    size2: 1,
+    description: "This has no title - only a description",
+    targetNodes: [
+      {
+        target: "/item/description",
+        attribute: "",
+        fullTarget: "/item/description",
+        xoqlPath: "/item/description",
+        freetextField: "/item/description",
+      },
+    ],
+    options: [],
+    controlType: "editbox",
+    isAllowLinks: false,
+    isNumber: false,
+    isAllowMultiLang: false,
+    isForceUnique: false,
+    isCheckDuplication: false,
+  },
+];

--- a/react-front-end/__stories__/components/wizard/WizardEditBox.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardEditBox.stories.tsx
@@ -1,0 +1,84 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Typography } from "@material-ui/core";
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import {
+  WizardEditBox,
+  WizardEditBoxProps,
+} from "../../../tsrc/components/wizard/WizardEditBox";
+
+export default {
+  title: "Component/Wizard/WizardEditBox",
+  component: WizardEditBox,
+  argTypes: {
+    onChange: {
+      action: "onChange called",
+    },
+  },
+} as Meta<WizardEditBoxProps>;
+
+export const Normal: Story<WizardEditBoxProps> = (args) => (
+  <WizardEditBox {...args} />
+);
+Normal.args = {
+  id: "wizard-editbox-story",
+  label: "Example",
+  description: "This an example EditBox",
+};
+
+export const Mandatory: Story<WizardEditBoxProps> = (args) => (
+  <WizardEditBox {...args} mandatory />
+);
+Mandatory.args = { ...Normal.args };
+
+export const Multiline: Story<WizardEditBoxProps> = (args) => (
+  <WizardEditBox {...args} />
+);
+Multiline.args = { ...Normal.args, description: "With three rows", rows: 3 };
+
+export const NoDescription: Story<WizardEditBoxProps> = (args) => (
+  <WizardEditBox {...args} />
+);
+NoDescription.args = { ...Normal.args, description: undefined };
+
+export const NoTitle: Story<WizardEditBoxProps> = (args) => (
+  <WizardEditBox {...args} />
+);
+NoTitle.args = {
+  ...Normal.args,
+  description: "No title, only this description",
+  label: undefined,
+};
+
+export const NoDescriptionOrTitle: Story<WizardEditBoxProps> = (args) => (
+  <div>
+    <WizardEditBox {...args} />
+    <br />
+    <br />
+    <Typography variant="caption" color="textSecondary">
+      This may seem odd, but it's a valid configuration in the Admin Console so
+      we need to check it works.
+    </Typography>
+  </div>
+);
+NoDescriptionOrTitle.args = {
+  ...Normal.args,
+  label: undefined,
+  description: undefined,
+};

--- a/react-front-end/__stories__/components/wizard/WizardLabel.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardLabel.stories.tsx
@@ -1,0 +1,80 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Typography } from "@material-ui/core";
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import {
+  WizardLabel,
+  WizardLabelProps,
+} from "../../../tsrc/components/wizard/WizardLabel";
+
+export default {
+  title: "Component/Wizard/WizardLabel",
+  component: WizardLabel,
+} as Meta<WizardLabelProps>;
+
+export const FullySpecified: Story<WizardLabelProps> = (args) => (
+  <WizardLabel {...args} />
+);
+FullySpecified.args = {
+  label: "A label",
+  description: "This is the description",
+  mandatory: true,
+};
+
+export const Optional: Story<WizardLabelProps> = (args) => (
+  <WizardLabel {...args} />
+);
+Optional.args = {
+  label: "Optional",
+  description: "This field is _not_ mandatory",
+  mandatory: false,
+};
+
+export const NoDescription: Story<WizardLabelProps> = (args) => (
+  <WizardLabel {...args} />
+);
+NoDescription.args = {
+  ...FullySpecified.args,
+  description: undefined,
+};
+
+export const NoLabel: Story<WizardLabelProps> = (args) => (
+  <WizardLabel {...args} />
+);
+NoLabel.args = {
+  ...FullySpecified.args,
+  label: undefined,
+};
+
+export const NoDescriptionOrLabel: Story<WizardLabelProps> = (args) => (
+  <>
+    <WizardLabel {...args} />
+    <br />
+    <br />
+    <Typography variant="caption" color="textSecondary">
+      All you should see is this text - as there is nothing from the actual
+      component (above).
+    </Typography>
+  </>
+);
+NoDescriptionOrLabel.args = {
+  ...FullySpecified.args,
+  label: undefined,
+  description: undefined,
+};

--- a/react-front-end/__stories__/components/wizard/WizardUnsupported.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardUnsupported.stories.tsx
@@ -1,0 +1,27 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import { WizardUnsupported } from "../../../tsrc/components/wizard/WizardUnsupported";
+
+export default {
+  title: "Component/Wizard/WizardUnsupported",
+  component: WizardUnsupported,
+} as Meta;
+
+export const Standard: Story = () => <WizardUnsupported />;

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { controls } from "../../../../__mocks__/WizardHelper.mock";
+import {
+  ControlTarget,
+  FieldValue,
+  render,
+} from "../../../../tsrc/components/wizard/WizardHelper";
+
+describe("render()", () => {
+  const logOnChange = (update: FieldValue): void =>
+    console.debug("onChange called", update);
+
+  const nameEditboxTarget: ControlTarget = {
+    type: "editbox",
+    schemaNode: ["/item/name"],
+  };
+
+  it("creates JSX.Elements matching definition", () => {
+    // We currently only support editboxes, so just filter to them for now
+    // Each time we add a control, we need to expand this out
+    const supportedControls = controls.filter(
+      (c) => c.controlType === "editbox"
+    );
+    expect(supportedControls.length).toBeGreaterThan(1); // quick assertions we have good test data
+
+    const elements: JSX.Element[] = render(supportedControls, [], logOnChange);
+    expect(elements).toHaveLength(supportedControls.length);
+    // for now, we just expect Editboxes, we'll need to elaborate on this in the future
+    expect(elements.every((e) => e.type.name === "WizardEditBox")).toBeTruthy();
+  });
+
+  it("creates WizardUnsupported components for unknown/unsupported ones", () => {
+    const elements: JSX.Element[] = render(controls, [], logOnChange);
+    // Current the 'controls' include a radio group which we've not yet written support for
+    expect(
+      elements.filter((e) => e.type.name === "WizardUnsupported")
+    ).toHaveLength(1);
+  });
+
+  it("handles `controlType === 'unknown'` - i.e. `UnknownWizardControl`", () => {
+    const elements: JSX.Element[] = render(
+      [{ controlType: "unknown" }],
+      [],
+      logOnChange
+    );
+    expect(
+      elements.filter((e) => e.type.name === "WizardUnsupported")
+    ).toHaveLength(1);
+  });
+
+  it.each<[string, FieldValue, number]>([
+    [
+      "singular",
+      {
+        target: nameEditboxTarget,
+        value: ["an editbox - name"],
+      },
+      1,
+    ],
+    [
+      "multiple",
+      {
+        target: { type: "editbox", schemaNode: ["/item/description"] },
+        value: ["an editbox - description"],
+      },
+      2,
+    ],
+  ])(
+    "correctly sets the initial value when provided (%s)",
+    (_, value, fieldsSet) => {
+      // smoke test the test data
+      expect(value.value[0]).toBeTruthy();
+
+      const elements = render(controls, [value], logOnChange);
+      // Test the field(s) were set
+      expect(
+        elements.filter((e) => e.props.value === value.value[0])
+      ).toHaveLength(fieldsSet);
+    }
+  );
+
+  it("throws errors when there's a mismatch of ControlValues for ControlTargets", () => {
+    const commonTarget: ControlTarget = nameEditboxTarget;
+    const misMatchedValues: FieldValue[] = [
+      { target: commonTarget, value: ["first value"] },
+      { target: commonTarget, value: ["different value"] },
+    ];
+    expect(() => render(controls, misMatchedValues, logOnChange)).toThrow(
+      Error
+    );
+  });
+
+  it("throws an error if the incorrect control value type is provided", () => {
+    expect(() =>
+      render(controls, [{ target: nameEditboxTarget, value: [1] }], logOnChange)
+    ).toThrow(TypeError);
+  });
+});

--- a/react-front-end/tsrc/components/wizard/WizardEditBox.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardEditBox.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OutlinedInput } from "@material-ui/core";
+import * as React from "react";
+import { WizardLabel } from "./WizardLabel";
+
+export interface WizardEditBoxProps {
+  /**
+   * DOM id
+   */
+  id?: string;
+  /**
+   * The label to display for the control.
+   */
+  label?: string;
+  /**
+   * A description to display alongside the control to assist users.
+   */
+  description?: string;
+  /**
+   * Indicate that this control is 'mandatory' to the user.
+   */
+  mandatory: boolean;
+  /**
+   * If greater than 1 creates a multi-line edit box with the specified number of rows.
+   */
+  rows: number;
+  /**
+   * The current value of the control.
+   */
+  value?: string;
+  /**
+   * On change handler.
+   */
+  onChange: (_: string) => void;
+}
+
+/**
+ * Basic wizard 'EditBox' control.
+ */
+export const WizardEditBox = ({
+  id,
+  label,
+  description,
+  mandatory,
+  rows,
+  value,
+  onChange,
+}: WizardEditBoxProps): JSX.Element => (
+  <>
+    <WizardLabel
+      mandatory={mandatory}
+      label={label}
+      description={description}
+      labelFor={id}
+    />
+    <OutlinedInput
+      id={id}
+      multiline={rows > 1}
+      rows={rows}
+      value={value}
+      onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
+        onChange(target.value)
+      }
+      aria-required={mandatory}
+    />
+  </>
+);

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -1,0 +1,268 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import * as A from "fp-ts/Array";
+import * as E from "fp-ts/Either";
+import { Eq, struct } from "fp-ts/Eq";
+import { absurd, flow, pipe } from "fp-ts/function";
+import * as N from "fp-ts/number";
+import * as O from "fp-ts/Option";
+import { Refinement } from "fp-ts/Refinement";
+import * as S from "fp-ts/string";
+import * as React from "react";
+import { WizardEditBox } from "./WizardEditBox";
+import { WizardUnsupported } from "./WizardUnsupported";
+
+/**
+ * Used to loosely target what a value (typically a `ControlValue`) is being used for.
+ */
+export interface ControlTarget {
+  /**
+   * The 'fullPath's for the targetNode.
+   */
+  schemaNode: string[];
+  /**
+   * The type of control that is being targeted.
+   */
+  type: OEQ.WizardControl.ControlType;
+}
+
+/**
+ * Convenience type for our way of storing the two main value types across our controls. Represents
+ * that some controls are textual, and some are numeric; and that some controls store more than one
+ * value.
+ */
+export type ControlValue = number[] | string[];
+
+/**
+ * Identifies a Wizard 'field' and specifies its value.
+ */
+export interface FieldValue {
+  target: ControlTarget;
+  value: ControlValue;
+}
+
+/**
+ * Check the type of the head of an array. Returns `false` if empty.
+ *
+ * @param refinement method to validate head element.
+ */
+const isHeadType =
+  <T,>(refinement: Refinement<unknown, T>) =>
+  (xs: unknown[]): boolean =>
+    pipe(
+      xs,
+      A.head,
+      O.map(refinement),
+      O.getOrElse((): boolean => false)
+    );
+
+/**
+ * Used to check if the `ControlValue` is of the string[] variety.
+ * (Not a general purpose array util!)
+ */
+const isStringArray = (xs: ControlValue): xs is string[] =>
+  pipe(xs as unknown[], isHeadType<string>(S.isString));
+
+/**
+ * Used to check if the `ControlValue` is of the number[] variety.
+ * (Not a general purpose array util!)
+ */
+const isNumberArray = (xs: ControlValue): xs is number[] =>
+  pipe(xs as unknown[], isHeadType<number>(N.isNumber));
+
+const eqControlTarget: Eq<ControlTarget> = struct({
+  schemaNode: A.getEq(S.Eq),
+  type: S.Eq,
+});
+
+const eqControlValue: Eq<ControlValue> = {
+  equals: (x, y) => {
+    if (isStringArray(x) && isStringArray(y)) {
+      return A.getEq(S.Eq).equals(x, y);
+    } else if (isNumberArray(x) && isNumberArray(y)) {
+      return A.getEq(N.Eq).equals(x, y);
+    }
+    // The two arrays are of different or unsupported types
+    return false;
+  },
+};
+
+const buildControlTarget = (
+  c: OEQ.WizardControl.WizardBasicControl
+): ControlTarget => ({
+  /*
+   * Target nodes are stored in several different ways, for our purposes we just need a single
+   * fully qualified string as provided by `fullTarget`. This function reduces the array down to
+   * such a simple array.
+   */
+  schemaNode: c.targetNodes.map((n) => n.fullTarget),
+  type: c.controlType,
+});
+
+/**
+ * For a control which just needs a singular value, validate and split out the value from the
+ * unionised ControlValue.
+ *
+ * @param value a potential string value
+ */
+const getStringControlValue = (value?: ControlValue): string | undefined => {
+  const potentialValue: E.Either<Error, string | undefined> = pipe(
+    value,
+    O.fromNullable,
+    O.match(
+      () => E.right(undefined),
+      flow(
+        E.fromPredicate(
+          isStringArray,
+          () => new TypeError("Expected string[] but got something else!")
+        ),
+        E.map(flow(A.head, O.toUndefined))
+      )
+    )
+  );
+
+  if (E.isLeft(potentialValue)) {
+    throw potentialValue.left;
+  }
+
+  return potentialValue.right;
+};
+
+/**
+ * Factory function responsible for taking a control definition and producing the correct React
+ * component.
+ */
+const controlFactory = (
+  id: string,
+  control: OEQ.WizardControl.WizardControl,
+  onChange: (_: ControlValue) => void,
+  value?: ControlValue
+): JSX.Element => {
+  if (!OEQ.WizardControl.isWizardBasicControl(control)) {
+    return <WizardUnsupported />;
+  }
+
+  const { controlType, mandatory, title, description, size2 } = control;
+
+  switch (controlType) {
+    case "editbox":
+      return (
+        <WizardEditBox
+          id={id}
+          label={title}
+          description={description}
+          mandatory={mandatory}
+          rows={size2}
+          value={getStringControlValue(value)}
+          onChange={(newValue) => onChange([newValue])}
+        />
+      );
+    case "calendar":
+    case "checkboxgroup":
+    case "html":
+    case "listbox":
+    case "radiogroup":
+    case "shufflebox":
+    case "shufflelist":
+    case "termselector":
+    case "userselector":
+      return <WizardUnsupported />;
+    default:
+      return absurd(controlType);
+  }
+};
+
+/**
+ * Produces an array of `JSX.Element`s representing the wizard defined by the provided `controls`.
+ * Setting their values to those provided in `values` and configuring them with an onChange handler
+ * which can set their value in the external instance of `values` - correctly targetted etc.
+ *
+ * Later, this will also be used for the evaluation and execution of visibility scripting.
+ *
+ * Later, later, this will also be able to support multi-page wizards as used during contribution.
+ *
+ * @param controls A collection of controls which make up a wizard.
+ * @param values A collection of values for the provided controls - if a control currently has
+ *               no value, then it will not be in the collection.
+ * @param onChange The high level callback to use to update `values` - this will be wrapped so that
+ *                 Wizard components only have to worry about calling a typical simple callback
+ *                 with their updated value.
+ */
+export const render = (
+  controls: OEQ.WizardControl.WizardControl[],
+  values: FieldValue[],
+  onChange: (update: FieldValue) => void
+): JSX.Element[] => {
+  /**
+   * There should only be one unique value across the different nodes the control is targeting,
+   * so validate that and then extract that single value.
+   */
+  const mergeControlValues = (
+    target: ControlTarget
+  ): ControlValue | undefined => {
+    const uniqueValues: ControlValue[] = pipe(
+      values,
+      A.filter((x) => eqControlTarget.equals(target, x.target)),
+      A.map(({ value }: FieldValue) => value),
+      A.uniq(eqControlValue)
+    );
+
+    // Make sure there is only one possible value
+    if (uniqueValues.length > 1) {
+      throw new Error(
+        `There should only be one value per controlType/schemaNodes, however [${
+          target.type
+        } for ${target.schemaNode.join()}] has ${uniqueValues.length}.`
+      );
+    }
+
+    // Return either the single value, or `undefined` if there were no matches
+    return pipe(uniqueValues, A.head, O.toUndefined);
+  };
+
+  const buildOnChangeHandler = (
+    c: OEQ.WizardControl.WizardControl
+  ): ((value: ControlValue) => void) =>
+    OEQ.WizardControl.isWizardBasicControl(c)
+      ? (value: ControlValue) =>
+          onChange({ target: buildControlTarget(c), value })
+      : (_) => {
+          throw new Error(
+            "Unexpected onChange called for non-WizardBasicControl."
+          );
+        };
+
+  // Retrieve the value of the specified control
+  const retrieveControlsValue = (
+    c: OEQ.WizardControl.WizardControl
+  ): ControlValue | undefined =>
+    OEQ.WizardControl.isWizardBasicControl(c)
+      ? pipe(c, buildControlTarget, mergeControlValues)
+      : undefined;
+
+  // Build the controls
+  return controls.map((c, idx) =>
+    controlFactory(
+      `wiz-${idx}-${c.controlType}`,
+      c,
+      buildOnChangeHandler(c),
+      retrieveControlsValue(c)
+    )
+  );
+};

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -19,7 +19,7 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
 import { Eq, struct } from "fp-ts/Eq";
-import { absurd, flow, pipe } from "fp-ts/function";
+import { absurd, constFalse, flow, pipe } from "fp-ts/function";
 import * as N from "fp-ts/number";
 import * as O from "fp-ts/Option";
 import { Refinement } from "fp-ts/Refinement";
@@ -58,19 +58,17 @@ export interface FieldValue {
 }
 
 /**
- * Check the type of the head of an array. Returns `false` if empty.
+ * Creates a function which checks the type of the head of an array using the supplied refinement
+ * function. The resulting function returns true when it is passed an array who's head element
+ * matches the refinement specifications, otherwise (including if the array is empty) it will
+ * return false.
  *
- * @param refinement method to validate head element.
+ * @param refinement function used by returned function to validate head element.
  */
 const isHeadType =
   <T,>(refinement: Refinement<unknown, T>) =>
   (xs: unknown[]): boolean =>
-    pipe(
-      xs,
-      A.head,
-      O.map(refinement),
-      O.getOrElse((): boolean => false)
-    );
+    pipe(xs, A.head, O.map(refinement), O.getOrElse(constFalse));
 
 /**
  * Used to check if the `ControlValue` is of the string[] variety.

--- a/react-front-end/tsrc/components/wizard/WizardLabel.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardLabel.tsx
@@ -1,0 +1,62 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Typography } from "@material-ui/core";
+import * as React from "react";
+
+export interface WizardLabelProps {
+  /**
+   * The label to display for the control.
+   */
+  label?: string;
+  /**
+   * A description to display alongside the control to assist users.
+   */
+  description?: string;
+  /**
+   * Indicate that this control is 'mandatory' to the user. Only visible if the field has a `label`.
+   */
+  mandatory?: boolean;
+  /**
+   * The DOM id of the input control this is labelling.
+   */
+  labelFor?: string;
+}
+
+/**
+ * Standardises the display of the header information for each Wizard control.
+ */
+export const WizardLabel = ({
+  label,
+  description,
+  mandatory = false,
+  labelFor,
+}: WizardLabelProps): JSX.Element => (
+  <label htmlFor={labelFor}>
+    {label && (
+      <Typography variant="h6" gutterBottom>
+        {label}
+        {mandatory ? " *" : ""}
+      </Typography>
+    )}
+    {description && (
+      <Typography variant="subtitle1" gutterBottom>
+        {description}
+      </Typography>
+    )}
+  </label>
+);

--- a/react-front-end/tsrc/components/wizard/WizardUnsupported.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardUnsupported.tsx
@@ -1,0 +1,26 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { languageStrings } from "../../util/langstrings";
+import { WizardLabel } from "./WizardLabel";
+
+const { label, description } = languageStrings.wizard.controls.unsupported;
+
+export const WizardUnsupported = () => (
+  <WizardLabel label={label} description={description} />
+);

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -179,6 +179,7 @@ export const languageStrings = {
       undo: "Undo",
       yes: "Yes",
     },
+    required: "* Required",
     result: {
       success: "Saved successfully.",
       fail: "Failed to save.",

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -698,6 +698,15 @@ export const languageStrings = {
     failedToFindUsersMessage: "Unable to find any users matching '%s'",
     queryFieldLabel: "Username, first or last name",
   },
+  wizard: {
+    controls: {
+      unsupported: {
+        label: "Unsupported control configured",
+        description:
+          "An unsupported control has been detected, please contact your system administrator.",
+      },
+    },
+  },
   youTubePlayer: {
     title: "YouTube video player",
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

The is the first part / foundation of the Advanced Search Form. It provides:

- 3 new components (`WizardEditBox`, `WizardLabel` and `WizardUnsupported`)
- `WizardHelper` with the logic for rendering a wizard definition
- Storybook stories for the new components
- Unit tests for the `WizardHelper`

Next step/part is to then integrate this with the new `AdvancedSearchForm`. And following on from that, is to implement and support all the wizard control types (and then visibility scripting).

I've not included screenshots, as I've already walked @PenghaiZhang through the new components.

And, I expect this will be further tweaked as we get into the integration and later and more components. But hopefully it provides a reasonable foundation for us.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
