### PR TITLE
bugfix: make sure the Hierarchy `More` menu uses the correct link

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/hierarchy/HierarchyMenuContributor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/hierarchy/HierarchyMenuContributor.java
@@ -116,7 +116,7 @@ public class HierarchyMenuContributor extends AbstractUpdatableMenuContributor {
     }
 
     if (showMoreLink) {
-      HtmlLinkState hls = new HtmlLinkState(new SimpleBookmark("hierarchy.do?hier.topic=ALL"));
+      HtmlLinkState hls = new HtmlLinkState(new SimpleBookmark("hierarchy.do?topic=ALL"));
       hls.setLabel(MORE);
 
       MenuContribution mc = new MenuContribution(hls, ICON_PATH, 10, linkPriority++);


### PR DESCRIPTION
#556 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR can make sure that when the Hierarchy `More` menu is clicked, the full list of Hierarchies is always displayed.

https://user-images.githubusercontent.com/47203811/134279674-b02daf3e-5adc-477b-b474-7a9f73a2342d.mp4


