### PR TITLE
Feature/advanced search form (part 2)

### DIFF
--- a/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
+++ b/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
@@ -15,9 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as OEQ from "@openequella/rest-api-client";
 import { Meta, Story } from "@storybook/react";
 import * as React from "react";
-import { getAdvancedSearchDefinition } from "../../__mocks__/AdvancedSearchModule.mock";
+import { controls } from "../../__mocks__/WizardHelper.mock";
 import {
   AdvancedSearchPanel,
   AdvancedSearchPanelProps,
@@ -40,5 +41,14 @@ export const Simple: Story<AdvancedSearchPanelProps> = (args) => (
   <AdvancedSearchPanel {...args} />
 );
 Simple.args = {
-  wizardControls: getAdvancedSearchDefinition.controls,
+  wizardControls: controls,
+};
+
+export const NoRequiredFields: Story<AdvancedSearchPanelProps> = (args) => (
+  <AdvancedSearchPanel {...args} />
+);
+NoRequiredFields.args = {
+  wizardControls: controls.map((c) =>
+    OEQ.WizardControl.isWizardBasicControl(c) ? { ...c, mandatory: false } : c
+  ),
 };

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as M from "fp-ts/Map";
 import { controls } from "../../../../__mocks__/WizardHelper.mock";
 import {
   ControlTarget,
@@ -39,14 +40,18 @@ describe("render()", () => {
     );
     expect(supportedControls.length).toBeGreaterThan(1); // quick assertions we have good test data
 
-    const elements: JSX.Element[] = render(supportedControls, [], logOnChange);
+    const elements: JSX.Element[] = render(
+      supportedControls,
+      new Map(),
+      logOnChange
+    );
     expect(elements).toHaveLength(supportedControls.length);
     // for now, we just expect Editboxes, we'll need to elaborate on this in the future
     expect(elements.every((e) => e.type.name === "WizardEditBox")).toBeTruthy();
   });
 
   it("creates WizardUnsupported components for unknown/unsupported ones", () => {
-    const elements: JSX.Element[] = render(controls, [], logOnChange);
+    const elements: JSX.Element[] = render(controls, new Map(), logOnChange);
     // Current the 'controls' include a radio group which we've not yet written support for
     expect(
       elements.filter((e) => e.type.name === "WizardUnsupported")
@@ -56,7 +61,7 @@ describe("render()", () => {
   it("handles `controlType === 'unknown'` - i.e. `UnknownWizardControl`", () => {
     const elements: JSX.Element[] = render(
       [{ controlType: "unknown" }],
-      [],
+      new Map(),
       logOnChange
     );
     expect(
@@ -87,7 +92,11 @@ describe("render()", () => {
       // smoke test the test data
       expect(value.value[0]).toBeTruthy();
 
-      const elements = render(controls, [value], logOnChange);
+      const elements = render(
+        controls,
+        M.singleton(value.target, value.value),
+        logOnChange
+      );
       // Test the field(s) were set
       expect(
         elements.filter((e) => e.props.value === value.value[0])
@@ -95,20 +104,9 @@ describe("render()", () => {
     }
   );
 
-  it("throws errors when there's a mismatch of ControlValues for ControlTargets", () => {
-    const commonTarget: ControlTarget = nameEditboxTarget;
-    const misMatchedValues: FieldValue[] = [
-      { target: commonTarget, value: ["first value"] },
-      { target: commonTarget, value: ["different value"] },
-    ];
-    expect(() => render(controls, misMatchedValues, logOnChange)).toThrow(
-      Error
-    );
-  });
-
   it("throws an error if the incorrect control value type is provided", () => {
     expect(() =>
-      render(controls, [{ target: nameEditboxTarget, value: [1] }], logOnChange)
+      render(controls, M.singleton(nameEditboxTarget, [1]), logOnChange)
     ).toThrow(TypeError);
   });
 });

--- a/react-front-end/tsrc/components/wizard/WizardEditBox.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardEditBox.tsx
@@ -71,6 +71,7 @@ export const WizardEditBox = ({
     />
     <OutlinedInput
       id={id}
+      fullWidth
       multiline={rows > 1}
       rows={rows}
       value={value}

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -33,6 +33,7 @@ import { useHistory, useLocation, useParams } from "react-router";
 import { getBaseUrl } from "../AppConfig";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import MessageInfo, { MessageInfoVariant } from "../components/MessageInfo";
+import * as WizardHelper from "../components/wizard/WizardHelper";
 import { AppRenderErrorContext } from "../mainui/App";
 import { NEW_SEARCH_PATH, routes } from "../mainui/routes";
 import { templateDefaults, TemplateUpdateProps } from "../mainui/Template";
@@ -973,11 +974,17 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
                 <Grid item xs={12}>
                   <AdvancedSearchPanel
                     wizardControls={searchPageModeState.definition.controls}
-                    onSubmit={
-                      // In the future, this would merge the updated Advanced Search Criteria into
-                      // searchPageOptions before calling search()
-                      (_) => search(searchPageOptions)
-                    }
+                    values={searchPageModeState.queryValues}
+                    onSubmit={(
+                      advSearchQueryValues: WizardHelper.FieldValueMap
+                    ) => {
+                      searchPageModeDispatch({
+                        type: "setQueryValues",
+                        values: advSearchQueryValues,
+                      });
+                      // TODO: search() still needs to support using the Advanced Search Query values
+                      search(searchPageOptions);
+                    }}
                     onClose={() =>
                       searchPageModeDispatch({ type: "hideAdvSearchPanel" })
                     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included (kinda)
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This integrates the previous work (#3420) to process a wizard definition into the actual search panel (and to some degree the search page - as far as storing the values). It did highlight the direction (rabbit hole) I went in the first PR for storing the control values was incorrect, so a refactor is also included here.

I will do a subsequent PR to this one to get some Jest tests going. But just wanted to get the core finalised before I go on leave. :wink:  (As you can see though, I did at least tweak the Storybook stories.)

https://user-images.githubusercontent.com/43919233/134453464-2aaaa163-4fa2-4550-8604-c2e67faf2392.mp4



<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
