### PR TITLE
Re-enable Sanity test for cloud search

### DIFF
--- a/autotest/Tests/src/test/scala/equellatests/tests/SanityTestProperties.scala
+++ b/autotest/Tests/src/test/scala/equellatests/tests/SanityTestProperties.scala
@@ -23,7 +23,8 @@ object SanityTestProperties extends StatefulProperties("Sanity test") with Simpl
 
   object Pages extends Enumeration {
     val Home, Contribute, ManageTasks, ManageResources, TaskList, Notifications, Reports,
-    MyResources, Searching, Hierarchy, Harvester, RemoteRepos, Favourites, ManageActivations = Value
+    MyResources, Searching, Hierarchy, Harvester, RemoteRepos, Favourites, ManageActivations,
+    CloudSearch = Value
   }
   import Pages._
   case class SanityState(completedPages: Pages.ValueSet = Pages.ValueSet.empty)
@@ -59,6 +60,7 @@ object SanityTestProperties extends StatefulProperties("Sanity test") with Simpl
       case RemoteRepos       => RemoteReposPage
       case Favourites        => FavouritesPage
       case ManageActivations => ManageActivationsPage
+      case CloudSearch       => CloudSearchPage
     }
     val page = lp(b.page.ctx).load()
     (page, Prop(page.error.isEmpty).label(c.toString))


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Not sure why tests related to cloud search work again so open a PR to confirm.