### PR TITLE
Feature/indicate adv search criteria has been set

### DIFF
--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -66,6 +66,20 @@ mockGetAdvancedSearchByUuid.mockResolvedValue(getAdvancedSearchDefinition);
 
 const testUuid = "4be6ae54-68ca-4d8b-acd0-0ca96fc39280";
 
+const editBoxTitle = "Test Edit Box";
+const oneEditBoxWizard = (
+  mandatory: boolean
+): OEQ.AdvancedSearch.AdvancedSearchDefinition => ({
+  ...getAdvancedSearchDefinition,
+  controls: [
+    mockEditbox({
+      title: editBoxTitle,
+      mandatory,
+      schemaNodes: [{ target: "/item/name", attribute: "" }],
+    }),
+  ],
+});
+
 const renderAdvancedSearchPage = async () =>
   await renderSearchPage(searchPromise, undefined, testUuid);
 
@@ -120,6 +134,24 @@ describe("Advanced Search filter button", () => {
     togglePanel();
     expect(queryAdvSearchPanel(container)).toBeInTheDocument();
   });
+
+  it("indicates whether advanced search criteria has been set", async () => {
+    mockGetAdvancedSearchByUuid.mockResolvedValue(oneEditBoxWizard(false));
+    const { container, getByLabelText } = await renderAdvancedSearchPage();
+
+    const getHighlightedFilterButton = () =>
+      getByLabelText(
+        languageStrings.searchpage.showAdvancedSearchFilter
+      ).querySelector(".MuiSvgIcon-colorSecondary");
+
+    // The filter button is not highlighted yet.
+    expect(getHighlightedFilterButton()).not.toBeInTheDocument();
+    // Put some texts in the EditBox.
+    userEvent.type(getByLabelText(editBoxTitle), "text");
+    await clickSearchButton(container);
+    // Now the filter button is highlighted in Secondary color.
+    expect(getHighlightedFilterButton()).toBeInTheDocument();
+  });
 });
 
 describe("Hide components", () => {
@@ -137,20 +169,6 @@ describe("Hide components", () => {
 });
 
 describe("Rendering of wizard", () => {
-  const editBoxTitle = "Test Edit Box";
-  const oneEditBoxWizard = (
-    mandatory: boolean
-  ): OEQ.AdvancedSearch.AdvancedSearchDefinition => ({
-    ...getAdvancedSearchDefinition,
-    controls: [
-      mockEditbox({
-        title: editBoxTitle,
-        mandatory,
-        schemaNodes: [{ target: "/item/name", attribute: "" }],
-      }),
-    ],
-  });
-
   it("shows an explanatory caption for mandatory fields", async () => {
     mockGetAdvancedSearchByUuid.mockResolvedValue(oneEditBoxWizard(true));
     const { queryByText } = await renderAdvancedSearchPage();

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -18,6 +18,7 @@
 import { debounce, Drawer, Grid, Hidden } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
 import { pipe } from "fp-ts/function";
+import * as M from "fp-ts/Map";
 import { isEqual } from "lodash";
 import * as React from "react";
 import {
@@ -963,7 +964,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
                           searchPageModeDispatch({
                             type: "toggleAdvSearchPanel",
                           }),
-                        accent: false,
+                        accent: !M.isEmpty(searchPageModeState.queryValues),
                       }
                     : undefined
                 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Indicate whether Advanced search criteria has been set by checking if the map of query values is empty or not.
![Screenshot from 2021-09-28 10-54-34](https://user-images.githubusercontent.com/47203811/135004797-b7093692-2337-48f5-b45b-88fb3dfe910d.png)

