### PR TITLE
Feature/wizard check box group

### DIFF
--- a/react-front-end/__stories__/components/wizard/WizardCheckBoxGroup.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardCheckBoxGroup.stories.tsx
@@ -1,0 +1,92 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { Meta, Story } from "@storybook/react";
+import {
+  WizardCheckBoxGroup,
+  WizardCheckBoxGroupProps,
+} from "../../../tsrc/components/wizard/WizardCheckBoxGroup";
+
+export default {
+  title: "Component/Wizard/WizardCheckBoxGroup",
+  component: WizardCheckBoxGroup,
+  argTypes: {
+    onSelect: {
+      action: "onSelect called",
+    },
+  },
+} as Meta<WizardCheckBoxGroupProps>;
+
+export const Normal: Story<WizardCheckBoxGroupProps> = (args) => (
+  <WizardCheckBoxGroup {...args} />
+);
+Normal.args = {
+  id: "wizard-checkboxgroup-story",
+  label: "Example",
+  description: "This an example of CheckBox Group",
+  columns: 1,
+  mandatory: true,
+  options: [
+    {
+      text: "option1",
+      value: "1",
+    },
+    {
+      text: "option2",
+      value: "2",
+    },
+    {
+      text: "option3",
+      value: "3",
+    },
+    {
+      text: "option4",
+      value: "4",
+    },
+    {
+      text: "option5",
+      value: "5",
+    },
+    {
+      text: "option6",
+      value: "6",
+    },
+    {
+      text: "option7",
+      value: "7",
+    },
+  ],
+};
+
+export const MultipleColumns: Story<WizardCheckBoxGroupProps> = (args) => (
+  <WizardCheckBoxGroup {...args} />
+);
+MultipleColumns.args = {
+  ...Normal.args,
+  columns: 4,
+  description: "Options are displayed in 4 columns 2 rows",
+};
+
+export const ValueSelected: Story<WizardCheckBoxGroupProps> = (args) => (
+  <WizardCheckBoxGroup {...args} />
+);
+ValueSelected.args = {
+  ...Normal.args,
+  values: ["1", "3"],
+  description: "Option 1 and 3 are initially selected.",
+};

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -219,7 +219,7 @@ describe("Rendering of wizard", () => {
       }))
     );
     labelsAndValues.forEach(({ label, value }) => {
-      act(() => userEvent.type(getByLabelText(label), value));
+      userEvent.type(getByLabelText(label), value);
     });
 
     // Click search - so as to persist values

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearchTestHelper.ts
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearchTestHelper.ts
@@ -1,0 +1,164 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { getByLabelText } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { absurd } from "fp-ts/function";
+import {
+  BasicControlEssentials,
+  getAdvancedSearchDefinition,
+  mockControlOptionLabels,
+  mockWizardControlFactory,
+} from "../../../__mocks__/AdvancedSearchModule.mock";
+
+export const editBoxTitle = "Test Edit Box";
+
+export const editBoxEssentials: BasicControlEssentials = {
+  title: editBoxTitle,
+  mandatory: false,
+  schemaNodes: [{ target: "/item/name", attribute: "" }],
+  controlType: "editbox",
+};
+
+export const oneEditBoxWizard = (
+  mandatory: boolean
+): OEQ.AdvancedSearch.AdvancedSearchDefinition => ({
+  ...getAdvancedSearchDefinition,
+  controls: [{ ...editBoxEssentials, mandatory }].map(mockWizardControlFactory),
+});
+
+// As we go forward, let's build on the below collection of controls,
+// and add each control type as we build them.
+const controlValues: Map<BasicControlEssentials, string[]> = new Map([
+  [
+    {
+      ...editBoxEssentials,
+      title: "Edit Box - name",
+      schemaNodes: [{ target: "/item/name", attribute: "" }],
+    },
+    ["a name"],
+  ],
+  [
+    {
+      ...editBoxEssentials,
+      title: "Edit Box - year",
+      schemaNodes: [{ target: "/item/", attribute: "@year" }],
+    },
+    ["2021"],
+  ],
+  [
+    {
+      title: "CheckBox Group",
+      schemaNodes: [{ target: "/item/options", attribute: "" }],
+      mandatory: false,
+      controlType: "checkboxgroup",
+    },
+    mockControlOptionLabels,
+  ],
+]);
+
+export const controls: OEQ.WizardControl.WizardControl[] = Array.from(
+  controlValues.keys()
+).map(mockWizardControlFactory);
+
+export const controlLabelsAndValues = Array.from(controlValues).map(
+  ([{ title, controlType }, values]) => ({
+    // for option type component like CheckBox Group, we need the labels of
+    // control's options, not the label of the control itself.
+    labels:
+      controlType === "checkboxgroup"
+        ? mockControlOptionLabels
+        : [title ?? "!!BLANK LABEL!!"],
+    values,
+    controlType: controlType,
+  })
+);
+
+/**
+ * Trigger a HTML DOM event for a Wizard control.
+ *
+ * @param container Root container where <AdvancedSearchPanel/> exists
+ * @param labels Depending on the control type, the label can be the control's own label or its options' labels.
+ * @param values Depending on the control type, the value can be the control's value or its options' values.
+ * @param controlType Type of the control.
+ */
+export const updateControlValue = (
+  container: HTMLElement,
+  labels: string[],
+  values: string[],
+  controlType: OEQ.WizardControl.ControlType
+) => {
+  const getLabel = (label: string): HTMLElement =>
+    getByLabelText(container, label);
+  switch (controlType) {
+    case "editbox":
+      userEvent.type(getLabel(labels[0]), values[0]);
+      break;
+    case "checkboxgroup":
+      labels.forEach((l) => userEvent.click(getLabel(l)));
+      break;
+    case "calendar":
+    case "html":
+    case "listbox":
+    case "radiogroup":
+    case "shufflebox":
+    case "shufflelist":
+    case "termselector":
+    case "userselector":
+      break;
+    default:
+      return absurd(controlType);
+  }
+};
+
+/**
+ * Validate if a Wizard control or its options have correct values.
+ *
+ * @param container Root container where <AdvancedSearchPanel/> exists
+ * @param labels Depending on the control type, the label can be the control's own label or its options' labels.
+ * @param values Depending on the control type, the value can be the control's value or its options' values.
+ * @param controlType Type of the control.
+ */
+export const validateControlValue = (
+  container: HTMLElement,
+  labels: string[],
+  values: string[],
+  controlType: OEQ.WizardControl.ControlType
+) => {
+  const getLabel = (label: string): HTMLElement =>
+    getByLabelText(container, label);
+  switch (controlType) {
+    case "editbox":
+      expect(getLabel(labels[0])).toHaveValue(values[0]);
+      break;
+    case "checkboxgroup":
+      labels.forEach((l) => expect(getLabel(l)).toBeChecked());
+      break;
+    case "calendar":
+    case "html":
+    case "listbox":
+    case "radiogroup":
+    case "shufflebox":
+    case "shufflelist":
+    case "termselector":
+    case "userselector":
+      break;
+    default:
+      return absurd(controlType);
+  }
+};

--- a/react-front-end/tsrc/components/wizard/WizardCheckBoxGroup.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardCheckBoxGroup.tsx
@@ -120,22 +120,19 @@ export const WizardCheckBoxGroup = ({
         mandatory={mandatory}
         label={label}
         description={description}
-        labelFor={id}
       />
-      <div id={id}>
-        {range(0, rowNumber).map((rowIndex) => (
-          <div className={classes.checkBoxGroupRow} key={`${id}-${rowIndex}`}>
-            {getOptionsForRow(rowIndex).map((option, optionIndex) => (
-              <div
-                className={classes.checkBoxGroupColumn}
-                key={`${id}-${rowIndex}-${optionIndex}`}
-              >
-                {buildOption(option)}
-              </div>
-            ))}
-          </div>
-        ))}
-      </div>
+      {range(0, rowNumber).map((rowIndex) => (
+        <div className={classes.checkBoxGroupRow} key={`${id}-${rowIndex}`}>
+          {getOptionsForRow(rowIndex).map((option, optionIndex) => (
+            <div
+              className={classes.checkBoxGroupColumn}
+              key={`${id}-${rowIndex}-${optionIndex}`}
+            >
+              {buildOption(option)}
+            </div>
+          ))}
+        </div>
+      ))}
     </>
   );
 };

--- a/react-front-end/tsrc/components/wizard/WizardCheckBoxGroup.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardCheckBoxGroup.tsx
@@ -1,0 +1,125 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FormControlLabel, Theme } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import * as OEQ from "@openequella/rest-api-client/";
+import * as React from "react";
+import { WizardLabel } from "./WizardLabel";
+import { range } from "lodash";
+import { Checkbox } from "@material-ui/core";
+
+const useStyles = makeStyles<Theme, { width: number }>({
+  checkBoxGroupRow: {
+    flexDirection: "row",
+    display: "flex",
+    alignItems: "center",
+  },
+  checkBoxGroupColumn: {
+    width: ({ width }) => `${width}%`,
+  },
+});
+
+export interface WizardCheckBoxGroupProps {
+  /**
+   * DOM id.
+   */
+  id?: string;
+  /**
+   * The label to display for the control.
+   */
+  label?: string;
+  /**
+   * A description to display alongside the control to assist users.
+   */
+  description?: string;
+  /**
+   * Indicate that this control is 'mandatory' to the user.
+   */
+  mandatory: boolean;
+  /**
+   * The list of CheckBox options.
+   */
+  options: OEQ.WizardCommonTypes.WizardControlOption[];
+  /**
+   * The number of options displayed in one row.
+   */
+  columns: number;
+  /**
+   * The currently selected options.
+   */
+  values?: string[];
+  /**
+   * Handler for selecting an option.
+   */
+  onSelect: (_: string[]) => void;
+}
+
+export const WizardCheckBoxGroup = ({
+  id,
+  label,
+  description,
+  mandatory,
+  columns,
+  options,
+  values = [],
+  onSelect,
+}: WizardCheckBoxGroupProps) => {
+  const columnNumber = columns > 0 ? columns : 1;
+  const rowNumber = Math.ceil(options.length / columnNumber);
+  const classes = useStyles({ width: Math.round(100 / columnNumber) });
+
+  // Predicate to filter options by their indexes for each row.
+  const filterOptionsByIndex = (start: number, index: number) =>
+    start * columnNumber <= index && index < columnNumber * (start + 1);
+
+  return (
+    <>
+      <WizardLabel
+        mandatory={mandatory}
+        label={label}
+        description={description}
+        labelFor={id}
+      />
+      <div id={id}>
+        {range(0, rowNumber).map((i) => (
+          <div className={classes.checkBoxGroupRow} key={`${id}-${i}`}>
+            {options
+              .filter((_, order) => filterOptionsByIndex(i, order))
+              .map(({ text, value }) => (
+                <div
+                  className={classes.checkBoxGroupColumn}
+                  key={`${id}-${i}-${value}`}
+                >
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={values?.some((v) => v === value)}
+                        value={value}
+                        onChange={(e) => onSelect([...values, e.target.value])}
+                      />
+                    }
+                    label={text}
+                  />
+                </div>
+              ))}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/react-front-end/tsrc/components/wizard/WizardEditBox.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardEditBox.tsx
@@ -74,7 +74,7 @@ export const WizardEditBox = ({
       fullWidth
       multiline={rows > 1}
       rows={rows}
-      value={value}
+      value={value ?? ""}
       onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
         onChange(target.value)
       }

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -114,13 +114,15 @@ export const AdvancedSearchPanel = ({
           direction="column"
           spacing={2}
         >
-          {WizardHelper.render(wizardControls, values, onChangeHandler).map(
-            (e) => (
-              <Grid key={e.props.id} item>
-                {e}
-              </Grid>
-            )
-          )}
+          {WizardHelper.render(
+            wizardControls,
+            currentValues,
+            onChangeHandler
+          ).map((e) => (
+            <Grid key={e.props.id} item>
+              {e}
+            </Grid>
+          ))}
           {hasRequiredFields && (
             <Grid item>
               <Typography variant="caption" color="textSecondary">


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds a new component for the Wizard CheckBox Group. Thanks to the foundation work done previously, it wasn't hard to create the component. Maybe a couple things worth to note: 

1. I did not use `MUI Grid` because it seems not quite fit to this case. For example, if 8 options are displayed in 2 rows and each row can display up to 5 options, then the each grid item in the first row should take 20% width, but the question is how to represent 20% width by the number of grids (from 1 to 12) ? 

2.The `values` passed to this component should be `currentValues` controlled by  the state of `AdvancedSearchPanel`, nor the one provided by `SearchPage`. If we don't do this, the result is only the lastly selected option will be added to `currentValues`.

For the test, I have made some significant changes due to the labels of a CheckBox Group. 

1. Update how to trigger an event because the control's label (title) is not so important and what matters is its options' labels. 

2. Update how to check whether values are saved once search is triggered.

3. I also dropped some fp-ts code, particularly around the `Map` which subsequently introduced `Ord`. I feel it made the test much more complicated. 



https://user-images.githubusercontent.com/47203811/135372522-f9c0ace7-b083-45bd-85be-346d2eb78cd6.mp4



