### PR TITLE
Feature/wizard control calandar

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -19,7 +19,7 @@
 package com.tle.web.api.wizard
 
 import com.dytech.edge.wizard.TargetNode
-import com.dytech.edge.wizard.beans.control.{EditBox, WizardControl, WizardControlItem}
+import com.dytech.edge.wizard.beans.control.{Calendar, EditBox, WizardControl, WizardControlItem}
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.tle.common.i18n.LangUtils
 import com.tle.common.taxonomy.SelectionRestriction
@@ -90,8 +90,12 @@ case class WizardBasicControl(
 ) extends WizardControlDefinition
 
 object WizardBasicControl {
-  def getDefaultValues(options: List[WizardControlItem], isEditBox: Boolean): List[String] = {
-    options.filter(o => isEditBox || o.isDefaultOption).map(_.getValue)
+  def getDefaultValues(options: List[WizardControlItem], controlType: String): List[String] = {
+    // Option of controls whose types are in the below list is always the default option.
+    // For those not in the list, check `isDefaultOption` of the option.
+    options
+      .filter(o => List(EditBox.CLASS, Calendar.CLASS).contains(controlType) || o.isDefaultOption)
+      .map(_.getValue)
   }
 
   def apply(control: WizardControl): WizardBasicControl = {
@@ -108,7 +112,7 @@ object WizardBasicControl {
       visibilityScript = Option(control.getScript),
       targetNodes = control.getTargetnodes.asScala.toList,
       options = options.map(o => WizardControlOption(o)),
-      defaultValues = getDefaultValues(options, EditBox.CLASS.equals(control.getClassType)),
+      defaultValues = getDefaultValues(options, control.getClassType),
       powerSearchFriendlyName = getStringFromCurrentLocale(control.getPowerSearchFriendlyName),
       controlType = control.getClassType
     )

--- a/react-front-end/__mocks__/AdvancedSearchModule.mock.ts
+++ b/react-front-end/__mocks__/AdvancedSearchModule.mock.ts
@@ -94,6 +94,15 @@ const mockEditbox = (
   isNumber: false,
 });
 
+const mockCalendar = (
+  mockDetails: BasicControlEssentials
+): OEQ.WizardControl.WizardCalendarControl => ({
+  ...mockBasicControl(mockDetails),
+  isRange: true,
+  dateFormat: "DMY",
+  controlType: "calendar",
+});
+
 export const mockRawHtmlContent = `<div><p>label for raw HTML control</p><hr></div>`;
 
 export const mockWizardControlFactory = (
@@ -111,6 +120,7 @@ export const mockWizardControlFactory = (
     case "listbox":
       return mockOptionTypeControl(mockDetails);
     case "calendar":
+      return mockCalendar(mockDetails);
     case "shufflebox":
     case "shufflelist":
     case "termselector":

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearchTestHelper.ts
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearchTestHelper.ts
@@ -416,8 +416,7 @@ export const updateControlValue = (
         ),
         E.fold<string, string[], string[]>(
           (e) => {
-            console.error(e);
-            return [];
+            throw new TypeError(e);
           },
           (vs) => vs
         ),

--- a/react-front-end/jest.setup.ts
+++ b/react-front-end/jest.setup.ts
@@ -15,4 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-jest.setTimeout(6000);
+jest.setTimeout(7000);

--- a/react-front-end/tsrc/components/DateRangeSelector.tsx
+++ b/react-front-end/tsrc/components/DateRangeSelector.tsx
@@ -393,7 +393,7 @@ export const DateRangeSelector = ({
   );
 
   return (
-    <Grid container>
+    <Grid container id={id}>
       <Grid item xs={12}>
         {quickModeEnabled ? quickOptionSelector : customDatePicker}
       </Grid>

--- a/react-front-end/tsrc/components/wizard/WizardCalendar.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardCalendar.tsx
@@ -17,7 +17,7 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import * as E from "fp-ts/Either";
-import { identity, pipe } from "fp-ts/function";
+import { flow, identity, pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
 import * as S from "fp-ts/string";
 import { DateTime } from "luxon";
@@ -90,11 +90,16 @@ export const WizardCalendar = ({
       )
     );
 
-  const processDateString = (dateString: string): Date | undefined =>
+  const processDateString = (dateString?: string): Date | undefined =>
     pipe(
       dateString,
-      pfTernary(S.isEmpty, () => undefined, identity), // Return undefined for empty string.
       O.fromNullable,
+      O.chain(
+        flow(
+          pfTernary(S.isEmpty, () => undefined, identity), // Return undefined for empty string.
+          O.fromNullable
+        )
+      ),
       O.map(convertToDate),
       O.toUndefined
     );

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -28,6 +28,7 @@ import { Refinement } from "fp-ts/Refinement";
 import * as S from "fp-ts/string";
 import * as React from "react";
 import { OrdAsIs } from "../../util/Ord";
+import { WizardCalendar } from "./WizardCalendar";
 import { WizardCheckBoxGroup } from "./WizardCheckBoxGroup";
 import { WizardEditBox } from "./WizardEditBox";
 import { WizardRawHtml } from "./WizardRawHtml";
@@ -281,6 +282,19 @@ const controlFactory = (
           onSelect={onChangeForSingleValue}
         />
       );
+    case "calendar":
+      const { dateFormat, isRange } =
+        control as OEQ.WizardControl.WizardCalendarControl;
+
+      return (
+        <WizardCalendar
+          {...commonProps}
+          values={ifAvailable<string[]>(value, getStringArrayControlValue)}
+          onChange={(newValue) => onChange(newValue)}
+          dateFormat={dateFormat}
+          isRange={isRange}
+        />
+      );
     case "html":
       return <WizardRawHtml {...commonProps} fieldValueMap={fieldValueMap} />;
     case "listbox":
@@ -292,7 +306,6 @@ const controlFactory = (
           onSelect={onChangeForSingleValue}
         />
       );
-    case "calendar":
     case "shufflebox":
     case "shufflelist":
     case "termselector":


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This is the third PR to support Wizard Calendar in Advanced search.

1. Update how to get default values on server.
2. Integrate `WizardCalendar` with the Control factory.
3. Update Jest test to check the integration.

https://user-images.githubusercontent.com/47203811/139370326-40e8cb79-c69d-4ed6-a167-af55d68f8d10.mp4


