### PR TITLE
feat(front-end): add WizardShuffleList component

### DIFF
--- a/react-front-end/__stories__/components/wizard/WizardShuffleList.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardShuffleList.stories.tsx
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import {
+  WizardShuffleList,
+  WizardShuffleListProps,
+} from "../../../tsrc/components/wizard/WizardShuffleList";
+
+export default {
+  title: "Component/Wizard/WizardShuffleList",
+  component: WizardShuffleList,
+  argTypes: {
+    onChange: {
+      action: "onChange called",
+    },
+  },
+} as Meta<WizardShuffleListProps>;
+
+export const NoValues: Story<WizardShuffleListProps> = (args) => (
+  <WizardShuffleList {...args} />
+);
+NoValues.args = {
+  id: "wizard-shufflelist-story",
+  label: "WizardShuffleList",
+  description: "A Shuffle List with no values set",
+  values: new Set<string>([]),
+};
+
+export const WithValues: Story<WizardShuffleListProps> = (args) => (
+  <WizardShuffleList {...args} />
+);
+WithValues.args = {
+  ...NoValues.args,
+  description:
+    "A Shuffle List with values provided - they should be nicely sorted",
+  values: new Set<string>(["first one", "second one", "and another"]),
+};

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardShuffleList.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardShuffleList.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { pipe } from "fp-ts/function";
+import * as RSET from "fp-ts/ReadonlySet";
+import * as S from "fp-ts/string";
+import * as React from "react";
+import { WizardShuffleList } from "../../../../tsrc/components/wizard/WizardShuffleList";
+import { languageStrings } from "../../../../tsrc/util/langstrings";
+
+const {
+  common: {
+    action: { add: addString, delete: deleteString },
+  },
+  shuffleList: shuffleListStrings,
+} = languageStrings;
+
+describe("<WizardShuffleList/>", () => {
+  it("displays the values provided", () => {
+    const values: readonly string[] = ["mouse", "cat", "dog"];
+    const { queryByText } = render(
+      <WizardShuffleList
+        values={new Set(values)}
+        onChange={jest.fn()}
+        mandatory={false}
+      />
+    );
+
+    expect(values.every((v) => queryByText(v))).toBeTruthy();
+  });
+
+  it.each([
+    ["pressing enter", true],
+    ["using add button", false],
+  ])(
+    "supports the adding of a value by %s",
+    (_: string, pressEnterKey: boolean) => {
+      const onChange = jest.fn();
+      const { getByLabelText } = render(
+        <WizardShuffleList
+          values={new Set()}
+          onChange={onChange}
+          mandatory={false}
+        />
+      );
+
+      const doAdd = (value: string) => {
+        userEvent.type(
+          getByLabelText(shuffleListStrings.newEntry),
+          `${value}${pressEnterKey ? "{enter}" : ""}`
+        );
+        if (!pressEnterKey) {
+          userEvent.click(getByLabelText(addString));
+        }
+      };
+
+      const me = "Add me";
+      doAdd(me);
+      expect(onChange).toHaveBeenLastCalledWith(new Set([me]));
+    }
+  );
+
+  it("supports removing a value", () => {
+    const onChange = jest.fn();
+    const deleteMe = "Please delete me";
+    const testValues: ReadonlySet<string> = new Set<string>([
+      "Keep me",
+      deleteMe,
+      "Save me for later",
+    ]);
+    const { getByLabelText } = render(
+      <WizardShuffleList
+        values={testValues}
+        onChange={onChange}
+        mandatory={false}
+      />
+    );
+
+    userEvent.click(getByLabelText(`${deleteString} ${deleteMe}`));
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      pipe(testValues, RSET.remove(S.Eq)(deleteMe))
+    );
+  });
+});

--- a/react-front-end/tsrc/components/wizard/WizardShuffleList.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardShuffleList.tsx
@@ -1,0 +1,138 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Grid,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  TextField,
+} from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
+import DeleteIcon from "@material-ui/icons/Delete";
+import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as RSET from "fp-ts/ReadonlySet";
+import * as S from "fp-ts/string";
+import * as React from "react";
+import { useState } from "react";
+import { languageStrings } from "../../util/langstrings";
+import { TooltipIconButton } from "../TooltipIconButton";
+import { WizardControlBasicProps } from "./WizardHelper";
+import { WizardLabel } from "./WizardLabel";
+
+const {
+  common: { action: commonActionStrings },
+  shuffleList: shuffleListStrings,
+} = languageStrings;
+
+export interface WizardShuffleListProps extends WizardControlBasicProps {
+  /**
+   * Values to be displayed below the input field, with delete button alongside.
+   */
+  values: ReadonlySet<string>;
+  /**
+   * Callback called when users add another value, or remove a value. The resultant set can be
+   * passed back as `values`.
+   */
+  onChange: (_: ReadonlySet<string>) => void;
+}
+
+export const WizardShuffleList = ({
+  id,
+  label,
+  description,
+  mandatory,
+  values,
+  onChange,
+}: WizardShuffleListProps): JSX.Element => {
+  const [newEntry, setNewEntry] = useState<string>("");
+
+  const handleOnChange = () =>
+    pipe(
+      newEntry,
+      O.fromPredicate((s) => !S.isEmpty(s)),
+      O.map((s) =>
+        pipe(values, RSET.insert(S.Eq)(s), (updatedValues) => {
+          onChange(updatedValues);
+          setNewEntry("");
+        })
+      )
+    );
+
+  return (
+    <>
+      <WizardLabel
+        mandatory={mandatory}
+        label={label}
+        description={description}
+        labelFor={id}
+      />
+      <Grid id={id} container spacing={2}>
+        <Grid item xs={12} sm={6}>
+          <List aria-label={shuffleListStrings.valueList}>
+            <ListItem key="input controls">
+              <ListItemText>
+                <TextField
+                  id={`${id}-new-entry`}
+                  variant="outlined"
+                  style={{ width: "95%" /* to accommodate icon at the end */ }}
+                  label={shuffleListStrings.newEntry}
+                  value={newEntry}
+                  onChange={(event) => setNewEntry(event.target.value)}
+                  onKeyPress={(event) =>
+                    event.key === "Enter" ? handleOnChange() : undefined
+                  }
+                />
+              </ListItemText>
+              <ListItemSecondaryAction>
+                <TooltipIconButton
+                  title={commonActionStrings.add}
+                  onClick={handleOnChange}
+                >
+                  <AddIcon />
+                </TooltipIconButton>
+              </ListItemSecondaryAction>
+            </ListItem>
+            {pipe(
+              values,
+              RSET.toReadonlyArray<string>(S.Ord),
+              RA.map<string, JSX.Element>((s) => (
+                <ListItem key={s}>
+                  <ListItemText>{s}</ListItemText>
+                  <ListItemSecondaryAction>
+                    <TooltipIconButton
+                      aria-label={`${commonActionStrings.delete} ${s}`}
+                      title={commonActionStrings.delete}
+                      onClick={() =>
+                        pipe(values, RSET.remove(S.Eq)(s), onChange)
+                      }
+                    >
+                      <DeleteIcon />
+                    </TooltipIconButton>
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))
+            )}
+          </List>
+        </Grid>
+      </Grid>
+    </>
+  );
+};

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -678,6 +678,10 @@ export const languageStrings = {
     removeAll: "Remove all",
     removeSelected: "Remove selected",
   },
+  shuffleList: {
+    newEntry: "New entry",
+    valueList: "Current list of values",
+  },
   template: {
     navaway: {
       title: "You have unsaved changes",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Adds a new Wizard component: Shuffle List. Following this PR will be an integration PR.

Before a user adds values:

![2021-11-02-161457_849x227_scrot](https://user-images.githubusercontent.com/43919233/139790797-11871b91-f709-412f-a4c4-d282806fa2fa.png)

Once a user adds values (note they are sorted, and can be removed via the delete buttons):

![2021-11-02-161516_830x366_scrot](https://user-images.githubusercontent.com/43919233/139790850-a03fe2f1-6f81-444d-82ec-913dd4deaa0e.png)


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
