### PR TITLE
refactor: convert RichTextEditor from class to functional component

### DIFF
--- a/react-front-end/tsrc/components/RichTextEditor.tsx
+++ b/react-front-end/tsrc/components/RichTextEditor.tsx
@@ -19,6 +19,8 @@ import { Editor } from "@tinymce/tinymce-react";
 import { AxiosPromise, AxiosResponse } from "axios";
 import * as React from "react";
 
+import "tinymce/tinymce";
+
 import "tinymce/icons/default";
 import "tinymce/plugins/advlist";
 
@@ -57,7 +59,6 @@ import "tinymce/plugins/visualchars";
 import "tinymce/plugins/wordcount";
 import "tinymce/themes/silver/theme";
 
-import "tinymce/tinymce";
 import { getBaseUrl, getRenderData } from "../AppConfig";
 
 const renderData = getRenderData();

--- a/react-front-end/tsrc/components/RichTextEditor.tsx
+++ b/react-front-end/tsrc/components/RichTextEditor.tsx
@@ -15,20 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import * as React from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import { AxiosPromise, AxiosResponse } from "axios";
-
-import { getBaseUrl, getRenderData } from "../AppConfig";
-
-import "tinymce/tinymce";
+import * as React from "react";
 
 import "tinymce/icons/default";
-import "tinymce/themes/silver/theme";
+import "tinymce/plugins/advlist";
 
 import "tinymce/plugins/anchor";
-import "tinymce/plugins/advlist";
 import "tinymce/plugins/autolink";
 import "tinymce/plugins/autoresize";
 import "tinymce/plugins/charmap";
@@ -61,6 +55,10 @@ import "tinymce/plugins/toc";
 import "tinymce/plugins/visualblocks";
 import "tinymce/plugins/visualchars";
 import "tinymce/plugins/wordcount";
+import "tinymce/themes/silver/theme";
+
+import "tinymce/tinymce";
+import { getBaseUrl, getRenderData } from "../AppConfig";
 
 const renderData = getRenderData();
 

--- a/react-front-end/tsrc/components/RichTextEditor.tsx
+++ b/react-front-end/tsrc/components/RichTextEditor.tsx
@@ -17,13 +17,8 @@
  */
 
 import * as React from "react";
-import { useEffect, useState } from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import { AxiosPromise, AxiosResponse } from "axios";
-import { pipe } from "fp-ts/function";
-import * as O from "fp-ts/Option";
-import * as E from "fp-ts/Either";
-import * as TE from "fp-ts/TaskEither";
 
 import { getBaseUrl, getRenderData } from "../AppConfig";
 
@@ -101,57 +96,26 @@ const RichTextEditor = ({
   onStateChange,
   imageUploadCallBack,
 }: RichTextEditorProps) => {
-  const [ready, setReady] = useState<boolean>(false);
-
-  useEffect(() => {
-    setTimeout(() => {
-      // this is a workaround for something related to: https://github.com/tinymce/tinymce-angular/issues/76
-      setReady(true);
-    }, 1);
-  }, []);
-
-  // const uploadImages = (
-  //   blobInfo: BlobInfo,
-  //   success: (msg: string) => void,
-  //   failure: (msg: string) => void
-  // ): void => {
-  //   if (imageUploadCallBack) {
-  //     imageUploadCallBack(blobInfo)
-  //       .then((response: AxiosResponse<ImageReturnType>) =>
-  //         success(response.data.link)
-  //       )
-  //       .catch((error: Error) => failure(error.name + error.message));
-  //   } else {
-  //     failure("No upload path specified.");
-  //   }
-  // };
-
   const uploadImages = (
     blobInfo: BlobInfo,
     success: (msg: string) => void,
     failure: (msg: string) => void
-  ) => {
-    pipe(
-      imageUploadCallBack,
-      O.fromNullable,
-      O.map((cb) => {
-        TE.tryCatch(
-          () => {
-            return cb(blobInfo);
-          },
-          (error) => failure(error.name + error.message)
-        );
-      }),
-      O.getOrElse(() => {
-        failure("No upload path specified.");
-      })
-    );
+  ): void => {
+    if (imageUploadCallBack) {
+      imageUploadCallBack(blobInfo)
+        .then((response: AxiosResponse<ImageReturnType>) =>
+          success(response.data.link)
+        )
+        .catch((error: Error) => failure(error.name + error.message));
+    } else {
+      failure("No upload path specified.");
+    }
   };
 
   const defaultSkinUrl =
     getBaseUrl() + renderData?.baseResources + "reactjs/tinymce/skins/ui/oxide";
 
-  return ready ? (
+  return (
     <Editor
       init={{
         min_height: 500,
@@ -176,7 +140,7 @@ const RichTextEditor = ({
       onEditorChange={onStateChange}
       value={htmlInput}
     />
-  ) : null;
+  );
 };
 
 export default RichTextEditor;

--- a/react-front-end/tsrc/components/RichTextEditor.tsx
+++ b/react-front-end/tsrc/components/RichTextEditor.tsx
@@ -15,10 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useEffect, useState } from "react";
 import * as React from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import { AxiosPromise, AxiosResponse } from "axios";
-import { AppConfig, getRenderData } from "../AppConfig";
+import { getBaseUrl, getRenderData } from "../AppConfig";
 
 import "tinymce/tinymce";
 
@@ -87,34 +88,30 @@ interface ImageReturnType {
   link: string;
 }
 
-interface RichTextEditorState {
-  ready: boolean;
-}
+const RichTextEditor = ({
+  htmlInput,
+  skinName,
+  skinUrl,
+  onStateChange,
+  imageUploadCallBack,
+}: RichTextEditorProps) => {
+  const [ready, setReady] = useState<boolean>(false);
 
-class RichTextEditor extends React.Component<
-  RichTextEditorProps,
-  RichTextEditorState
-> {
-  constructor(props: RichTextEditorProps) {
-    super(props);
-    this.state = { ready: false };
-  }
-
-  componentDidMount = () => {
+  useEffect(() => {
     setTimeout(() => {
       // this is a workaround for something related to: https://github.com/tinymce/tinymce-angular/issues/76
-      this.setState({ ready: true });
+      setReady(true);
+      console.log(ready);
     }, 1);
-  };
+  });
 
-  uploadImages = (
+  const uploadImages = (
     blobInfo: BlobInfo,
     success: (msg: string) => void,
     failure: (msg: string) => void
   ): void => {
-    if (this.props.imageUploadCallBack) {
-      this.props
-        .imageUploadCallBack(blobInfo)
+    if (imageUploadCallBack) {
+      imageUploadCallBack(blobInfo)
         .then((response: AxiosResponse<ImageReturnType>) =>
           success(response.data.link)
         )
@@ -124,41 +121,35 @@ class RichTextEditor extends React.Component<
     }
   };
 
-  render() {
-    const skinUrl =
-      AppConfig.baseUrl +
-      renderData?.baseResources +
-      "reactjs/tinymce/skins/ui/oxide";
+  const defaultSkinUrl =
+    getBaseUrl() + renderData?.baseResources + "reactjs/tinymce/skins/ui/oxide";
 
-    return (
-      this.state.ready && (
-        <Editor
-          init={{
-            min_height: 500,
-            automatic_uploads: true,
-            file_picker_types: "image",
-            images_reuse_filename: true,
-            images_upload_handler: this.uploadImages,
-            paste_data_images: true,
-            relative_urls: false,
-            skin: this.props.skinName ?? "oxide",
-            skin_url: this.props.skinUrl ?? skinUrl,
-            media_dimensions: false,
-          }}
-          toolbar="formatselect | bold italic strikethrough underline forecolor backcolor | link image media file | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent hr | removeformat | undo redo | preview | ltr rtl"
-          plugins={
-            "anchor autolink autoresize advlist charmap code codesample  " +
-            "directionality fullscreen help hr image imagetools " +
-            "importcss insertdatetime link lists media nonbreaking noneditable pagebreak paste " +
-            "preview print quickbars save searchreplace table template " +
-            "textpattern toc visualblocks visualchars wordcount"
-          }
-          onEditorChange={this.props.onStateChange}
-          value={this.props.htmlInput}
-        />
-      )
-    );
-  }
-}
+  return ready ? (
+    <Editor
+      init={{
+        min_height: 500,
+        automatic_uploads: true,
+        file_picker_types: "image",
+        images_reuse_filename: true,
+        images_upload_handler: uploadImages,
+        paste_data_images: true,
+        relative_urls: false,
+        skin: skinName ?? "oxide",
+        skin_url: skinUrl ?? defaultSkinUrl,
+        media_dimensions: false,
+      }}
+      toolbar="formatselect | bold italic strikethrough underline forecolor backcolor | link image media file | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent hr | removeformat | undo redo | preview | ltr rtl"
+      plugins={
+        "anchor autolink autoresize advlist charmap code codesample  " +
+        "directionality fullscreen help hr image imagetools " +
+        "importcss insertdatetime link lists media nonbreaking noneditable pagebreak paste " +
+        "preview print quickbars save searchreplace table template " +
+        "textpattern toc visualblocks visualchars wordcount"
+      }
+      onEditorChange={onStateChange}
+      value={htmlInput}
+    />
+  ) : null;
+};
 
 export default RichTextEditor;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Convert RichTextEditor from class component to functional component.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
