### PR TITLE
refactor: update how to build the default value of Calendar

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -25,6 +25,8 @@ import com.tle.common.i18n.LangUtils
 import com.tle.common.taxonomy.SelectionRestriction
 import com.tle.common.taxonomy.wizard.TermSelectorControl.TermStorageFormat
 import com.tle.web.api.language.LanguageStringHelper.getStringFromCurrentLocale
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import scala.collection.JavaConverters._
 
 /** Data structure representing an option provided by a 'Option' type control such as CheckBox Group and Shuffle List.
@@ -91,11 +93,21 @@ case class WizardBasicControl(
 
 object WizardBasicControl {
   def getDefaultValues(options: List[WizardControlItem], controlType: String): List[String] = {
+    def processValue(item: WizardControlItem): String = {
+      val value = item.getValue
+      controlType match {
+        case Calendar.CLASS if value.matches("^[0-9]+$") =>
+          // If the value is numeric, convert it to Int and plus it to today.
+          LocalDate.now.plus(value.toInt, ChronoUnit.DAYS).toString
+        case _ => value
+      }
+    }
+
     // Option of controls whose types are in the below list is always the default option.
     // For those not in the list, check `isDefaultOption` of the option.
     options
       .filter(o => List(EditBox.CLASS, Calendar.CLASS).contains(controlType) || o.isDefaultOption)
-      .map(_.getValue)
+      .map(processValue)
   }
 
   def apply(control: WizardControl): WizardBasicControl = {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardBasicControl.scala
@@ -28,6 +28,7 @@ import com.tle.web.api.language.LanguageStringHelper.getStringFromCurrentLocale
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 /** Data structure representing an option provided by a 'Option' type control such as CheckBox Group and Shuffle List.
   *
@@ -96,9 +97,11 @@ object WizardBasicControl {
     def processValue(item: WizardControlItem): String = {
       val value = item.getValue
       controlType match {
-        case Calendar.CLASS if value.matches("^[0-9]+$") =>
+        case Calendar.CLASS =>
           // If the value is numeric, convert it to Int and plus it to today.
-          LocalDate.now.plus(value.toInt, ChronoUnit.DAYS).toString
+          Try(value.toInt).toOption
+            .map(i => LocalDate.now.plus(i, ChronoUnit.DAYS).toString)
+            .getOrElse(value)
         case _ => value
       }
     }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The testing work found that if the default value of Calendar is configured as `today` or `today plus xx days`, the default value is not displayed properly in the advanced search panel.  The reason is when using `today`, the value is actually a number which represents how many days to be added to today.

So the fix is to check if the value is numeric, if yes then plus it to the day of today, otherwise use the value.

Please note that the Date Range Selector will show a warning if the default day is a future day.

![image](https://user-images.githubusercontent.com/47203811/139982024-5cbc1dbf-a5e8-4920-969a-3276d069309a.png)
