### PR TITLE
feat(REST): add support to search2 for raw lucene query and add new tokenisation endpoint

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
@@ -69,10 +69,20 @@ public class DefaultSearch extends VeryBasicSearch {
   protected Collection<DateFilter> dateFilters = Lists.newArrayList();
   private final List<List<Field>> musts = new ArrayList<List<Field>>();
   private final List<List<Field>> mustNots = new ArrayList<List<Field>>();
+  private String customLuceneQuery;
 
   public DefaultSearch() {
     super();
     toplevel = this;
+  }
+
+  @Override
+  public String getCustomLuceneQuery() {
+    return customLuceneQuery;
+  }
+
+  public void setCustomLuceneQuery(String customLuceneQuery) {
+    this.customLuceneQuery = customLuceneQuery;
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/search/DefaultSearch.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 @SuppressWarnings("nls")
 public class DefaultSearch extends VeryBasicSearch {
@@ -77,8 +78,8 @@ public class DefaultSearch extends VeryBasicSearch {
   }
 
   @Override
-  public String getCustomLuceneQuery() {
-    return customLuceneQuery;
+  public Optional<String> getCustomLuceneQuery() {
+    return Optional.ofNullable(customLuceneQuery);
   }
 
   public void setCustomLuceneQuery(String customLuceneQuery) {

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
@@ -23,6 +23,7 @@ import com.tle.beans.item.ItemSelect;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public interface Search {
   String INDEX_TASK = "task";
@@ -95,15 +96,16 @@ public interface Search {
   boolean useServerTimeZone();
 
   /**
-   * The background of creating this method is to support the Lucene query built in New Advanced
+   * Returns an optional additional query which is in raw text Lucene query syntax, available to be
+   * merged with other query parameters. e.g. name:OEQ AND year:[2021-11-01 TO * ] AND (city:Hobart
+   * OR city:Sydney) AND message:"hello world"
+   *
+   * <p>The background of creating this method is to support the Lucene query built in New Advanced
    * search page.
    *
-   * <p>The result of calling this method is a String in Lucene query syntax or null. e.g. name:OEQ
-   * AND year:[2021-11-01 TO * ] AND (city:Hobart OR city:Sydney) AND message:"hello world"
-   *
-   * @return A string is Lucene query syntax or null.
+   * @return An Optional string in Lucene query syntax.
    */
-  default String getCustomLuceneQuery() {
-    return null;
+  default Optional<String> getCustomLuceneQuery() {
+    return Optional.empty();
   }
 }

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/searching/Search.java
@@ -93,4 +93,17 @@ public interface Search {
    * @return True if server time zone is used or otherwise false.
    */
   boolean useServerTimeZone();
+
+  /**
+   * The background of creating this method is to support the Lucene query built in New Advanced
+   * search page.
+   *
+   * <p>The result of calling this method is a String in Lucene query syntax or null. e.g. name:OEQ
+   * AND year:[2021-11-01 TO * ] AND (city:Hobart OR city:Sydney) AND message:"hello world"
+   *
+   * @return A string is Lucene query syntax or null.
+   */
+  default String getCustomLuceneQuery() {
+    return null;
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -120,6 +120,7 @@ object SearchHelper {
       case None    => whereQuery
     }
     search.setFreeTextQuery(freeTextQuery)
+    search.setCustomLuceneQuery(params.customLuceneQuery)
 
     handleMusts(params.musts) foreach {
       case (field, value) => search.addMust(field, value.asJavaCollection)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -96,7 +96,8 @@ class SearchParam {
   @QueryParam("musts")
   var musts: Array[String] = _
 
-  @ApiParam("Custom Lucene query")
+  @ApiParam(
+    "Custom Lucene query which will be merged with the query generated from the other parameters. The relationship between them is 'AND'.")
   @QueryParam("customLuceneQuery")
   var customLuceneQuery: String = _
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -95,4 +95,8 @@ class SearchParam {
     "List of search index key/value pairs to filter by. e.g. videothumb:true or realthumb:true.")
   @QueryParam("musts")
   var musts: Array[String] = _
+
+  @ApiParam("Custom Lucene query")
+  @QueryParam("customLuceneQuery")
+  var customLuceneQuery: String = _
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/tokenisation/TokenisationResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/tokenisation/TokenisationResource.scala
@@ -1,0 +1,53 @@
+package com.tle.web.api.tokenisation
+
+import com.tle.freetext.{LuceneConstants, TLEAnalyzer}
+import com.tle.legacy.LegacyGuice
+import com.tle.web.api.ApiErrorResponse.badRequest
+import io.swagger.annotations.{Api, ApiOperation, ApiParam}
+import org.apache.lucene.analysis.{CharArraySet, WordlistLoader}
+import org.jboss.resteasy.annotations.cache.NoCache
+import org.apache.lucene.queryParser.{ParseException, QueryParser}
+import org.apache.lucene.search.BooleanQuery
+import java.io.{File, FileReader}
+import javax.ws.rs.core.Response
+import javax.ws.rs.{GET, Path, Produces, QueryParam}
+import scala.util.{Failure, Success, Try}
+
+case class Tokens(tokens: Array[String]);
+
+@NoCache
+@Path("search/token")
+@Produces(Array("application/json"))
+@Api("Search V2")
+class TokenisationResource {
+  @GET
+  @ApiOperation(
+    value = "Tokenise text by Lucene",
+    notes =
+      "This endpoint is used to tokenise plain texts by Lucene. It supports stemming and stop words.",
+    response = classOf[Tokens],
+  )
+  def tokenise(@ApiParam("The text to be tokenised") @QueryParam("text") text: String): Response = {
+    val stopWordsFile: File = LegacyGuice.freetextIndex.getStopWordsFile
+    val stopSet: CharArraySet = WordlistLoader.getWordSet(
+      new FileReader(stopWordsFile),
+      new CharArraySet(LuceneConstants.LATEST_VERSION, 0, true))
+
+    // Use empty string as the Field because we just need tokens.
+    val parser: QueryParser =
+      new QueryParser(LuceneConstants.LATEST_VERSION, "", new TLEAnalyzer(stopSet, true))
+
+    Try {
+      parser.parse(text) match {
+        // If the result is a BooleanQuery get all of its clauses and convert to strings.
+        // For others like TermQuery and PhraseQuery, just call `toString`.
+        case booleanQuery: BooleanQuery => booleanQuery.getClauses.map(_.toString)
+        case other                      => Array(other.toString)
+      }
+    } match {
+      case Success(tokens) => Response.ok().entity(Tokens(tokens)).build()
+      case Failure(e: ParseException) =>
+        badRequest(s"The provided text: ${text} cannot be tokenised due to error: ${e.getMessage}")
+    }
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/tokenisation/TokenisationResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/tokenisation/TokenisationResource.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.tokenisation
 
 import com.tle.freetext.{LuceneConstants, TLEAnalyzer}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
@@ -970,15 +970,19 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
       Query extraQuery = addExtraQuery(query, request, reader);
 
       // if custom Lucene query is provided, combine it with `extraQuery`.
-      return processCustomLuceneQuery(request.getCustomLuceneQuery())
-          .<Query>map(
-              q -> {
-                BooleanQuery combinedQuery = new BooleanQuery();
-                combinedQuery.add(extraQuery, Occur.MUST);
-                combinedQuery.add(q, Occur.MUST);
+      return request
+          .getCustomLuceneQuery()
+          .<Query>flatMap(
+              luceneQuery ->
+                  processCustomLuceneQuery(luceneQuery)
+                      .map(
+                          q -> {
+                            BooleanQuery combinedQuery = new BooleanQuery();
+                            combinedQuery.add(extraQuery, Occur.MUST);
+                            combinedQuery.add(q, Occur.MUST);
 
-                return combinedQuery;
-              })
+                            return combinedQuery;
+                          }))
           .orElse(extraQuery);
     } catch (ParseException ex) {
       throw new InvalidSearchQueryException(queryString, ex);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
@@ -74,6 +74,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
@@ -964,11 +965,21 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
         }
         query = orQuery;
       }
-      query = addExtraQuery(query, request, reader);
+      Query extraQuery = addExtraQuery(query, request, reader);
+
+      return processCustomLuceneQuery(request.getCustomLuceneQuery())
+          .<Query>map(
+              q -> {
+                BooleanQuery combinedQuery = new BooleanQuery();
+                combinedQuery.add(extraQuery, Occur.MUST);
+                combinedQuery.add(q, Occur.MUST);
+
+                return combinedQuery;
+              })
+          .orElse(query);
     } catch (ParseException ex) {
       throw new InvalidSearchQueryException(queryString, ex);
     }
-    return query;
   }
 
   protected Filter getFilter(Search request) {
@@ -1091,6 +1102,26 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
       return new Sort(convFields);
     }
     return new Sort(new SortField(null, SortField.SCORE, false));
+  }
+
+  private Optional<Query> processCustomLuceneQuery(String customLuceneQuery) {
+    QueryParser parser =
+        new QueryParser(LuceneConstants.LATEST_VERSION, FreeTextQuery.FIELD_ALL, getAnalyser());
+
+    return Optional.ofNullable(customLuceneQuery)
+        .map(
+            q -> {
+              try {
+                return parser.parse(q);
+              } catch (ParseException e) {
+                LOGGER.error(
+                    "Failed to parse custom Lucene query: "
+                        + customLuceneQuery
+                        + " due to error: "
+                        + e.getMessage());
+                return null;
+              }
+            });
   }
 
   /** @dytech.jira see Jira Review TLE-784 : http://apps.dytech.com.au/jira/browse/TLE-784 */

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
@@ -965,8 +965,11 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
         }
         query = orQuery;
       }
+
+      // This one includes the query built above and all the FreeTextQuery of the search.
       Query extraQuery = addExtraQuery(query, request, reader);
 
+      // if custom Lucene query is provided, combine it with `extraQuery`.
       return processCustomLuceneQuery(request.getCustomLuceneQuery())
           .<Query>map(
               q -> {
@@ -976,7 +979,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
 
                 return combinedQuery;
               })
-          .orElse(query);
+          .orElse(extraQuery);
     } catch (ParseException ex) {
       throw new InvalidSearchQueryException(queryString, ex);
     }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -61,6 +61,7 @@ import com.tle.core.services.user.UserService;
 import com.tle.core.services.user.UserSessionService;
 import com.tle.core.settings.service.ConfigurationService;
 import com.tle.core.usermanagement.standard.dao.TLEUserDao;
+import com.tle.freetext.FreetextIndex;
 import com.tle.web.api.item.ItemLinkService;
 import com.tle.web.api.search.service.ExportService;
 import com.tle.web.contentrestrictions.ContentRestrictionsPrivilegeTreeProvider;
@@ -150,6 +151,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static FederatedSearchService federatedSearchService;
 
   @Inject public static FileSystemService fileSystemService;
+
+  @Inject public static FreetextIndex freetextIndex;
 
   @Inject public static FreeTextService freeTextService;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/remoting/resteasy/RestEasyServlet.java
@@ -57,6 +57,7 @@ import com.tle.web.api.settings.RemoteSearchResource;
 import com.tle.web.api.settings.SearchFilterResource;
 import com.tle.web.api.settings.SearchSettingsResource;
 import com.tle.web.api.settings.SettingsResource;
+import com.tle.web.api.tokenisation.TokenisationResource;
 import com.tle.web.api.users.UserQueryResource;
 import com.tle.web.api.wizard.WizardApi;
 import com.tle.web.remoting.rest.resource.InstitutionSecurityFilter;
@@ -127,6 +128,7 @@ public class RestEasyServlet extends HttpServletDispatcher implements MapperExte
           SearchSettingsResource.class,
           SelectionApi.class,
           SettingsResource.class,
+          TokenisationResource.class,
           UserQueryResource.class,
           WizardApi.class);
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -124,6 +124,25 @@ public class Search2ApiTest extends AbstractRestApiTest {
     assertEquals(getAvailable(result), 1);
   }
 
+  @DataProvider
+  public Object[][] luceneQueryprovider() {
+    String pathOfName = "/item/name\\*:";
+    String pathOfDescription = "/item/description\\*:";
+
+    return new Object[][] {
+      {pathOfName + "\"SearchApiTest - Crabs\"", 1},
+      {pathOfName + "SearchApiTest - Crabs", 7},
+      {pathOfName + "\"Crabs\" OR " + pathOfName + "\"Basic\"", 2},
+      {pathOfName + "SearchApiTest AND " + pathOfDescription + "\"Description 4\"", 1}
+    };
+  }
+
+  @Test(description = "Search by a custom Lucene query", dataProvider = "luceneQueryprovider")
+  public void customLuceneQueryTest(String q, int expectNumber) throws IOException {
+    JsonNode result = doSearch(200, null, new NameValuePair("customLuceneQuery", q));
+    assertEquals(getAvailable(result), expectNumber);
+  }
+
   @Test(description = "Search by an invalid item status")
   public void invalidItemStatusSearch() throws IOException {
     doSearch(404, null, new NameValuePair("status", "ALIVE"));

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -125,7 +125,7 @@ public class Search2ApiTest extends AbstractRestApiTest {
   }
 
   @DataProvider
-  public Object[][] luceneQueryprovider() {
+  public Object[][] luceneQueryProvider() {
     String pathOfName = "/item/name\\*:";
     String pathOfDescription = "/item/description\\*:";
 
@@ -137,10 +137,25 @@ public class Search2ApiTest extends AbstractRestApiTest {
     };
   }
 
-  @Test(description = "Search by a custom Lucene query", dataProvider = "luceneQueryprovider")
+  @Test(description = "Search by a custom Lucene query", dataProvider = "luceneQueryProvider")
   public void customLuceneQueryTest(String q, int expectNumber) throws IOException {
     JsonNode result = doSearch(200, null, new NameValuePair("customLuceneQuery", q));
     assertEquals(getAvailable(result), expectNumber);
+  }
+
+  @Test(description = "Search by Lucene query and other params")
+  public void luceneQueryWithOtherParamsTest() throws IOException {
+    JsonNode result =
+        doSearch(
+            200,
+            null,
+            // There are four items that have 'book' in their names.
+            new NameValuePair("customLuceneQuery", "/item/itembody/name\\*:book"),
+            // But only two of them belongs to below Collection.
+            new NameValuePair("collections", "4c147089-cddb-e67c-b5ab-189614eb1463"),
+            // And only one of the two items was modified after 2014-04-01.
+            new NameValuePair("modifiedAfter", "2014-04-01"));
+    assertEquals(getAvailable(result), 1);
   }
 
   @Test(description = "Search by an invalid item status")

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/TokenisationApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/TokenisationApiTest.java
@@ -1,0 +1,51 @@
+package io.github.openequella.rest;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.stream.StreamSupport;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.NameValuePair;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ArrayNode;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TokenisationApiTest extends AbstractRestApiTest {
+  private final String TOKEN_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/search/token";
+
+  @DataProvider
+  private Object[][] textProvider() {
+    return new Object[][] {
+      {"book", new String[] {"book"}}, // single word
+      {"books", new String[] {"book"}}, // stemming
+      {"book portion", new String[] {"book", "portion"}}, // multiple words
+      {"\"book portion\"", new String[] {"\"book portion\""}}, // single phrase
+      {"the book portion", new String[] {"book", "portion"}}, // stop words
+      {
+        "\"book portion\" and hello world", new String[] {"\"book portion\"", "hello", "world"}
+      }, // mixed
+    };
+  }
+
+  @Test(description = "tokenise texts", dataProvider = "textProvider")
+  public void tokenisationTest(String text, String[] expectedTokens) throws IOException {
+    HttpMethod method = new GetMethod(TOKEN_API_ENDPOINT);
+    NameValuePair query = new NameValuePair("text", text);
+
+    method.setQueryString(new NameValuePair[] {query});
+
+    int statusCode = makeClientRequest(method);
+    assertEquals(statusCode, 200);
+
+    ArrayNode result = (ArrayNode) mapper.readTree(method.getResponseBody()).get("tokens");
+    String[] tokens =
+        StreamSupport.stream(result.spliterator(), false)
+            .map(JsonNode::asText)
+            .toArray(String[]::new);
+
+    assertEquals(tokens, expectedTokens);
+  }
+}


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This is the first PR for supporting the advanced search criteria. 

The steps are:
1. Add a new field to `SearchParam` to receive lucene query sent from client.
2. Set the lucene query to the new field added in `DefaultSearch`.
3. In the method which builds the whole query, parse the lucene query and combine it to other queries.

Also includes:

- A new /api/search/token endpoint to use lucene to tokenise a raw string (so that it can be used to build up 'tokenised' queries for advanced search controls)