### PR TITLE
Test: add mock data and control type for 3 wizard components

### DIFF
--- a/react-front-end/__mocks__/WizardHelper.mock.ts
+++ b/react-front-end/__mocks__/WizardHelper.mock.ts
@@ -192,5 +192,86 @@ export const controls: OEQ.WizardControl.WizardControl[] = [
     isCheckDuplication: false,
     isTokenise: true,
   },
+  {
+    mandatory: false,
+    reload: false,
+    include: true,
+    size1: 2,
+    size2: 0,
+    title: "Check box group",
+    description: "This is check box group, shows 2 items per row",
+    targetNodes: [
+      {
+        target: "/item/description",
+        attribute: "",
+        fullTarget: "/item/description",
+        xoqlPath: "/item/description",
+        freetextField: "/item/description",
+      },
+    ],
+    options: [
+      {
+        text: "Zebra",
+        value: "z",
+      },
+      {
+        text: "Cat",
+        value: "c",
+      },
+      {
+        text: "Mouse",
+        value: "m",
+      },
+    ],
+    defaultValues: [],
+    controlType: "checkboxgroup",
+  },
+  {
+    mandatory: false,
+    reload: false,
+    include: true,
+    size1: 0,
+    size2: 0,
+    title: "List box",
+    description: "This is list box targeting name",
+    targetNodes: [
+      {
+        target: "/item/name",
+        attribute: "",
+        fullTarget: "/item/name",
+        xoqlPath: "/item/name",
+        freetextField: "/item/name",
+      },
+    ],
+    options: [
+      {
+        text: "Zebra",
+        value: "z",
+      },
+      {
+        text: "Dog",
+        value: "d",
+      },
+      {
+        text: "Monkey",
+        value: "m",
+      },
+    ],
+    defaultValues: [],
+    controlType: "listbox",
+  },
+  {
+    mandatory: false,
+    reload: false,
+    include: true,
+    size1: 0,
+    size2: 0,
+    title: "Raw Html",
+    description: "<h1>This is just a raw Html content</h1>>",
+    targetNodes: [],
+    options: [],
+    defaultValues: [],
+    controlType: "html",
+  },
   { controlType: "unknown" },
 ];

--- a/react-front-end/__mocks__/WizardHelper.mock.ts
+++ b/react-front-end/__mocks__/WizardHelper.mock.ts
@@ -267,7 +267,7 @@ export const controls: OEQ.WizardControl.WizardControl[] = [
     size1: 0,
     size2: 0,
     title: "Raw Html",
-    description: "<h1>This is just a raw Html content</h1>>",
+    description: "<h1>This is just a raw Html content</h1>",
     targetNodes: [],
     options: [],
     defaultValues: [],

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -61,6 +61,9 @@ describe("render()", () => {
             radiogroup: () => "WizardRadioButtonGroup",
             shufflebox: () => "WizardShuffleBox",
             shufflelist: () => "WizardShuffleList",
+            checkboxgroup: () => "WizardCheckBoxGroup",
+            listbox: () => "WizardListBox",
+            html: () => "WizardRawHtml",
             _: () => "WizardUnsupported",
           })
         )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Add mock data and control type for `Html`, `Check box` group and `List box`. Based on #3539 ticket.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
