### PR TITLE
feat: integrate Advanced search criteria with New Search UI

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
@@ -52,12 +52,13 @@ public class AdvancedSearchPageTest extends AbstractSessionTest {
   @Test(description = "Open and close Advanced search panel")
   @NewUIOnly
   public void toggleAdvancedSearchPanel() {
-    assertNotNull(advancedSearchPage.getAdvancedSearchPanel());
-
-    advancedSearchPage.closeAdvancedSearchPanel();
+    // Closed initially.
     assertNull(advancedSearchPage.getAdvancedSearchPanel());
-
+    // Open the panel.
     advancedSearchPage.openAdvancedSearchPanel();
     assertNotNull(advancedSearchPage.getAdvancedSearchPanel());
+    // Close again.
+    advancedSearchPage.closeAdvancedSearchPanel();
+    assertNull(advancedSearchPage.getAdvancedSearchPanel());
   }
 }

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -88,6 +88,10 @@ interface SearchParamsBase {
    * List of MIME types to filter by.
    */
   mimeTypes?: string[];
+  /**
+   * Custom query in Lucene syntax.
+   */
+  customLuceneQuery?: string;
 }
 
 /**

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -71,11 +71,19 @@ mockGetAdvancedSearchByUuid.mockResolvedValue(getAdvancedSearchDefinition);
 
 const testUuid = "4be6ae54-68ca-4d8b-acd0-0ca96fc39280";
 
-const renderAdvancedSearchPage = async () =>
-  await renderSearchPage(searchPromise, undefined, testUuid);
-
 const togglePanel = () =>
   act(() => userEvent.click(screen.getByLabelText(filterButtonLabel)));
+
+const renderAdvancedSearchPage = async () => {
+  const page = await renderSearchPage(searchPromise, undefined, testUuid);
+  // Due to the UI change - hiding the panel when a search is triggered, the tests should
+  // also get updated accordingly. However, as we will make further changes for the UI,
+  // just manually open the panel for now so that we can keep the tests as they are.
+  // We will rework here later when we figure out how to nicely display the panel.
+  togglePanel();
+
+  return page;
+};
 
 const queryAdvSearchPanel = (container: Element): HTMLElement | null =>
   container.querySelector("#advanced-search-panel");

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -306,10 +306,7 @@ describe("search with Advanced search criteria", () => {
     mockGetAdvancedSearchByUuid.mockResolvedValue(
       oneEditBoxWizard(false, [defaultValue])
     );
-    const { container } = await renderAdvancedSearchPage();
-
-    // Search with the EditBox's default value.
-    await clickSearchButton(container);
+    await renderAdvancedSearchPage();
 
     // Should do a tokenisation.
     expect(mockGetTokensForText).toHaveBeenCalledWith(defaultValue);

--- a/react-front-end/__tests__/tsrc/search/SearchPageTestHelper.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPageTestHelper.tsx
@@ -44,6 +44,7 @@ import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFilterSettingsModule from "../../../tsrc/modules/SearchFilterSettingsModule";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
 import * as SearchSettingsModule from "../../../tsrc/modules/SearchSettingsModule";
+import * as TokenisationModule from "../../../tsrc/modules/TokenisationModule";
 import * as UserModule from "../../../tsrc/modules/UserModule";
 import SearchPage from "../../../tsrc/search/SearchPage";
 import * as SearchPageHelper from "../../../tsrc/search/SearchPageHelper";
@@ -147,6 +148,9 @@ export const mockCollaborators = () => {
       AdvancedSearchModule,
       "getAdvancedSearchByUuid"
     ),
+    mockGetTokensForText: jest
+      .spyOn(TokenisationModule, "getTokensForText")
+      .mockResolvedValue({ tokens: ["hello", "world"] }),
   };
 };
 

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -134,7 +134,8 @@ const isStringArray = (xs: ControlValue): xs is NEA.NonEmptyArray<string> =>
  * Typically used to check if the `ControlValue` of an Option type control (e.g. CheckBox Group) is a non-empty array.
  * If you also want to confirm if the value is `string`, use `isStringArray`.
  */
-const isControlValueNonEmpty = (xs: ControlValue): boolean => xs.length > 0;
+export const isControlValueNonEmpty = (xs: ControlValue): boolean =>
+  xs.length > 0;
 
 /**
  * Type guard which not only checks if a Wizard control value is string but also checks if the value

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -136,8 +136,13 @@ const isStringArray = (xs: ControlValue): xs is NEA.NonEmptyArray<string> =>
  */
 const isControlValueNonEmpty = (xs: ControlValue): boolean => xs.length > 0;
 
-// Type guard which not only checks if a value is string but also checks if the value is not an empty string.
-const isNonEmptyString = (s: string | number): s is string =>
+/**
+ * Type guard which not only checks if a Wizard control value is string but also checks if the value
+ * is not an empty string. (Not a general purpose string util!)
+ *
+ * @param s A Wizard control value that may be either a string or a number.
+ */
+export const isNonEmptyString = (s: string | number): s is string =>
   S.isString(s) && !S.isEmpty(s);
 
 const eqControlTarget: Eq<ControlTarget> = struct({

--- a/react-front-end/tsrc/modules/SearchModule.ts
+++ b/react-front-end/tsrc/modules/SearchModule.ts
@@ -19,7 +19,6 @@
 import * as OEQ from "@openequella/rest-api-client";
 import { Literal, Static, Union } from "runtypes";
 import { API_BASE_URL } from "../AppConfig";
-import type { FieldValueMap } from "../components/wizard/WizardHelper";
 import { DateRange, getISODateString } from "../util/Date";
 import type { Collection } from "./CollectionsModule";
 import type { SelectedCategories } from "./SearchFacetsModule";
@@ -131,10 +130,6 @@ export interface SearchOptions {
    * Raw Lucene query generated from the values of Wizard controls.
    */
   customLuceneQuery?: string;
-  /**
-   * Currently configured Advanced search criteria.
-   */
-  advFieldValue?: FieldValueMap;
 }
 
 /**

--- a/react-front-end/tsrc/modules/SearchModule.ts
+++ b/react-front-end/tsrc/modules/SearchModule.ts
@@ -19,6 +19,7 @@
 import * as OEQ from "@openequella/rest-api-client";
 import { Literal, Static, Union } from "runtypes";
 import { API_BASE_URL } from "../AppConfig";
+import type { FieldValueMap } from "../components/wizard/WizardHelper";
 import { DateRange, getISODateString } from "../util/Date";
 import type { Collection } from "./CollectionsModule";
 import type { SelectedCategories } from "./SearchFacetsModule";
@@ -126,6 +127,14 @@ export interface SearchOptions {
    * @see OEQ.Search.SearchParams for examples
    */
   musts?: OEQ.Search.Must[];
+  /**
+   * Raw Lucene query generated from the values of Wizard controls.
+   */
+  customLuceneQuery?: string;
+  /**
+   * Currently configured Advanced search criteria.
+   */
+  advFieldValue?: FieldValueMap;
 }
 
 /**
@@ -212,6 +221,7 @@ const buildSearchParams = ({
   mimeTypeFilters,
   externalMimeTypes,
   musts,
+  customLuceneQuery,
 }: SearchOptions): OEQ.Search.SearchParams => {
   const processedQuery = query ? formatQuery(query, !rawMode) : undefined;
   // We use selected filters to generate MIME types. However, in Image Gallery,
@@ -236,6 +246,7 @@ const buildSearchParams = ({
     whereClause: generateCategoryWhereQuery(selectedCategories),
     mimeTypes: externalMimeTypes ?? _mimeTypes,
     musts: musts,
+    customLuceneQuery: customLuceneQuery,
   };
 };
 

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -18,10 +18,7 @@
 import * as OEQ from "@openequella/rest-api-client";
 import * as E from "fp-ts/Either";
 import { absurd, flow, pipe } from "fp-ts/function";
-import {
-  extractDefaultValues,
-  FieldValueMap,
-} from "../components/wizard/WizardHelper";
+import type { FieldValueMap } from "../components/wizard/WizardHelper";
 
 export type State =
   | {
@@ -39,8 +36,9 @@ export type Action =
       type: "useNormal";
     }
   | {
-      type: "showAdvSearchPanel";
+      type: "initialiseAdvSearch";
       selectedAdvSearch: OEQ.AdvancedSearch.AdvancedSearchDefinition;
+      initialQueryValues: FieldValueMap;
     }
   | {
       type: "toggleAdvSearchPanel";
@@ -95,13 +93,13 @@ export const searchPageModeReducer = (state: State, action: Action): State => {
   switch (action.type) {
     case "useNormal":
       return { mode: "normal" };
-    case "showAdvSearchPanel":
+    case "initialiseAdvSearch":
       const { selectedAdvSearch: definition } = action;
       return {
         mode: "advSearch",
         definition,
-        isAdvSearchPanelOpen: true,
-        queryValues: extractDefaultValues(definition.controls),
+        isAdvSearchPanelOpen: false,
+        queryValues: action.initialQueryValues,
       };
     case "toggleAdvSearchPanel":
       return toggleOrHidePanel(state, "toggle");

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -319,6 +319,8 @@ export const languageStrings = {
     noFileSelected: "No attached resources",
     failedToDelete: "Failed to delete '%s' due to error: %s",
   },
+  invalidLuceneQuery:
+    "Your query is invalid. Try simplifying your query to only contain basic terms, and check that you do not have any whitespace around '*' or '+' characters.",
   lightboxComponent: {
     kalturaExternalIdIssue:
       "There is an issue with the format of the externalId for the the Kaltura Video",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This is the fourth (and hopefully the last) PR for the advanced search criteria. It's all about the integration with `SearchPage`.
 
Main changes are:
1. Add a new field to `SearchParam` and `SearchOptions` to support the raw Lucene query.
2. Hide the Adv search panel whenever a search is triggered.
3. Update how to generate the initial advanced search query values.
4. Rework how to perform the initial search.
5. Update how to check if any adv search criteria has been set.
