### PR TITLE
fix(test): remove flakiness of MyResourcesTest - testAddMyResource

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/DrmApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/DrmApiTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.codehaus.jackson.JsonNode;
-import org.junit.After;
 import org.testng.annotations.Test;
 
 @TestInstitution("fiveo")
@@ -48,7 +47,6 @@ public class DrmApiTest extends AbstractRestApiTest {
     assertEquals(acceptDrm(ITEM_UUID, ITEM_VERSION), 400);
   }
 
-  @After
   @Test(description = "Fail to accept DRM terms due to access denied", priority = 10)
   public void accessDenied() throws IOException {
     logout();

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/DrmApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/DrmApiTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.codehaus.jackson.JsonNode;
+import org.junit.After;
 import org.testng.annotations.Test;
 
 @TestInstitution("fiveo")
@@ -47,6 +48,7 @@ public class DrmApiTest extends AbstractRestApiTest {
     assertEquals(acceptDrm(ITEM_UUID, ITEM_VERSION), 400);
   }
 
+  @After
   @Test(description = "Fail to accept DRM terms due to access denied", priority = 10)
   public void accessDenied() throws IOException {
     logout();

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/selection/SelectionStatusPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/selection/SelectionStatusPage.java
@@ -2,8 +2,10 @@ package com.tle.webtests.pageobject.selection;
 
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.AbstractPage;
+import com.tle.webtests.pageobject.ExpectWaiter;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class SelectionStatusPage extends AbstractPage<SelectionStatusPage> {
   @FindBy(id = "ss_finishedButton")
@@ -22,6 +24,7 @@ public class SelectionStatusPage extends AbstractPage<SelectionStatusPage> {
   }
 
   public SelectionCheckoutPage finishSelections() {
+    ExpectWaiter.waiter(ExpectedConditions.invisibilityOf(finishedButton), this);
     scrollToElement(finishedButton);
     finishedButton.click();
     return new SelectionCheckoutPage(context).get();

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/selection/SelectionStatusPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/selection/SelectionStatusPage.java
@@ -24,7 +24,7 @@ public class SelectionStatusPage extends AbstractPage<SelectionStatusPage> {
   }
 
   public SelectionCheckoutPage finishSelections() {
-    ExpectWaiter.waiter(ExpectedConditions.invisibilityOf(finishedButton), this);
+    ExpectWaiter.waiter(ExpectedConditions.visibilityOf(finishedButton), this).get();
     scrollToElement(finishedButton);
     finishedButton.click();
     return new SelectionCheckoutPage(context).get();

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/selection/SelectionStatusPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/selection/SelectionStatusPage.java
@@ -2,15 +2,11 @@ package com.tle.webtests.pageobject.selection;
 
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.AbstractPage;
-import com.tle.webtests.pageobject.ExpectWaiter;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class SelectionStatusPage extends AbstractPage<SelectionStatusPage> {
-  @FindBy(id = "ss_finishedButton")
-  private WebElement finishedButton;
-
   @FindBy(id = "selection-summary")
   private WebElement summaryDiv;
 
@@ -24,7 +20,7 @@ public class SelectionStatusPage extends AbstractPage<SelectionStatusPage> {
   }
 
   public SelectionCheckoutPage finishSelections() {
-    ExpectWaiter.waiter(ExpectedConditions.visibilityOf(finishedButton), this).get();
+    WebElement finishedButton = waitForElement(By.id("ss_finishedButton"));
     scrollToElement(finishedButton);
     finishedButton.click();
     return new SelectionCheckoutPage(context).get();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Trying to fix this issue, but failed to reproduce in local env. 

![image](https://user-images.githubusercontent.com/92769668/141724611-62996443-b412-483b-ba93-983af4777232.png)

But based on this [reference](https://stackoverflow.com/questions/38596456/how-to-over-staleelementreferenceexception-when-working-with-pagefactory)  I add a waiter before clicking the finish button. Not sure if it works or not.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
