### PR TITLE
feat(front-end): add User Selector wizard component

### DIFF
--- a/react-front-end/__mocks__/UserSearch.mock.ts
+++ b/react-front-end/__mocks__/UserSearch.mock.ts
@@ -67,3 +67,13 @@ export const userDetailsProvider = async (
     query ? users.filter((u) => u.username.search(query) === 0) : users
   );
 };
+
+/**
+ * Helper function to inject into component for user retrieval by an array of ids.
+ *
+ * @param ids A list of user IDs to lookup, should be one of those in `users`
+ */
+export const resolveUsersProvider = async (
+  ids: ReadonlyArray<string>
+): Promise<OEQ.UserQuery.UserDetails[]> =>
+  Promise.resolve(users.filter(({ id }) => ids.includes(id)));

--- a/react-front-end/__stories__/components/wizard/WizardUserSelector.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardUserSelector.stories.tsx
@@ -1,0 +1,71 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
+import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
+import {
+  WizardUserSelector,
+  WizardUserSelectorProps,
+} from "../../../tsrc/components/wizard/WizardUserSelector";
+
+export default {
+  title: "Component/Wizard/WizardUserSelector",
+  component: WizardUserSelector,
+  argTypes: {
+    onChange: {
+      action: "onChange called",
+    },
+  },
+} as Meta<WizardUserSelectorProps>;
+
+export const NoUsers: Story<WizardUserSelectorProps> = (args) => (
+  <WizardUserSelector {...args} />
+);
+NoUsers.args = {
+  id: "wizard-userselector-story",
+  label: "WizardUserSelector",
+  description: "A user selector (single selection) with no users specified",
+  users: new Set<string>([]),
+  userListProvider: UserSearchMock.userDetailsProvider,
+  resolveUsersProvider: UserSearchMock.resolveUsersProvider,
+};
+
+export const WithUsers: Story<WizardUserSelectorProps> = (args) => (
+  <WizardUserSelector {...args} />
+);
+WithUsers.args = {
+  ...NoUsers.args,
+  description:
+    "A User Selector (multi selection) with users specified - they should be nicely sorted",
+  users: new Set<string>([
+    UserSearchMock.users[1].id,
+    UserSearchMock.users[2].id,
+  ]),
+  multiple: true,
+};
+
+export const ErrorOnResolvingUserIds: Story<WizardUserSelectorProps> = (
+  args
+) => <WizardUserSelector {...args} />;
+ErrorOnResolvingUserIds.args = {
+  ...WithUsers.args,
+  description:
+    "A User Selector which has failed to resolve the provided IDs into full user details",
+  resolveUsersProvider: async () =>
+    Promise.reject("This is an example failure..."),
+};

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardUserSelector.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardUserSelector.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import "@testing-library/jest-dom/extend-expect";
+import { render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import * as UserSearchMock from "../../../../__mocks__/UserSearch.mock";
+import { WizardUserSelector } from "../../../../tsrc/components/wizard/WizardUserSelector";
+
+describe("<WizardUserSelector/>", () => {
+  it("displays a specified set of users", async () => {
+    const testUser = UserSearchMock.users[1];
+    const { queryByText } = render(
+      <WizardUserSelector
+        groupsFilter={new Set()}
+        multiple
+        onChange={jest.fn()}
+        users={new Set([testUser.id])}
+        mandatory={false}
+        resolveUsersProvider={UserSearchMock.resolveUsersProvider}
+      />
+    );
+
+    await waitFor(() =>
+      expect(queryByText(testUser.username)).toBeInTheDocument()
+    );
+  });
+});

--- a/react-front-end/__tests__/tsrc/modules/UserModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/UserModule.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { pipe } from "fp-ts/function";
+import * as ORD from "fp-ts/Ord";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as RR from "fp-ts/ReadonlyRecord";
+import * as RSET from "fp-ts/ReadonlySet";
+import { last } from "fp-ts/Semigroup";
+import * as S from "fp-ts/string";
+import {
+  resolveUsersProvider,
+  users,
+} from "../../../__mocks__/UserSearch.mock";
+import {
+  resolveUsersCached,
+  UserCache,
+} from "../../../tsrc/modules/UserModule";
+import { expectRight } from "../FpTsMatchers";
+
+describe("resolveUsersCached", () => {
+  // Note that this function retrieves unknown users via `resolveUsersProvider` mock which just
+  // looks up IDs within the `users` mock from `UserSearch.mock`.
+  const retrieveTestUser = async (
+    ids: ReadonlySet<string>,
+    cache: UserCache,
+    setCache: (_: UserCache) => void
+  ) => {
+    const result = await pipe(
+      ids,
+      resolveUsersCached(cache, setCache, resolveUsersProvider)
+    )();
+
+    return expectRight(result)!;
+  };
+
+  const lastUserDetailsMagma = last<OEQ.UserQuery.UserDetails>();
+
+  const buildCacheFromUsers = (
+    cacheUsers: ReadonlyArray<OEQ.UserQuery.UserDetails>
+  ): UserCache =>
+    RR.fromFoldableMap(lastUserDetailsMagma, RA.Foldable)(
+      cacheUsers,
+      (u: OEQ.UserQuery.UserDetails) => [u.id, u]
+    );
+
+  it("retrieves unknown user, and places the new details in (previously empty) cache", async () => {
+    const testUser = users[0];
+
+    const emptyCache = {};
+    const setCache = jest.fn();
+
+    const retrievedUser = await retrieveTestUser(
+      RSET.singleton(testUser.id),
+      emptyCache,
+      setCache
+    );
+
+    expect(retrievedUser).toStrictEqual(new Set([testUser]));
+    expect(setCache).toHaveBeenLastCalledWith(
+      RR.singleton(testUser.id, testUser)
+    );
+  });
+
+  it("retrieves unknown user, and merges the new details with existing cache", async () => {
+    const testUser = users[0];
+
+    const existingCache = buildCacheFromUsers([users[1], users[2]]);
+    const setCache = jest.fn();
+
+    const retrievedUser = await retrieveTestUser(
+      RSET.singleton(testUser.id),
+      existingCache,
+      setCache
+    );
+
+    expect(retrievedUser).toStrictEqual(new Set([testUser]));
+    expect(setCache).toHaveBeenLastCalledWith(
+      pipe(
+        existingCache,
+        RR.union(lastUserDetailsMagma)(RR.singleton(testUser.id, testUser))
+      )
+    );
+  });
+
+  it("returns a known users, with no update to cache", async () => {
+    const testUsers: ReadonlySet<OEQ.UserQuery.UserDetails> = new Set([
+      users[1],
+      users[2],
+    ]);
+
+    const existingCache = buildCacheFromUsers(users);
+    const setCache = jest.fn();
+
+    const retrievedUsers = await retrieveTestUser(
+      pipe(
+        testUsers,
+        RSET.map(S.Eq)(({ id }) => id)
+      ),
+      existingCache,
+      setCache
+    );
+
+    expect(retrievedUsers).toStrictEqual(testUsers);
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it("returns users details from both the cache and by retrieval as required in the one call", async () => {
+    const cachedUser = users[0];
+    const testUsers: ReadonlySet<OEQ.UserQuery.UserDetails> = new Set([
+      cachedUser,
+      users[1],
+    ]);
+
+    const existingCache = buildCacheFromUsers([cachedUser]);
+    const setCache = jest.fn();
+
+    const retrievedUsers = await retrieveTestUser(
+      pipe(
+        testUsers,
+        RSET.map(S.Eq)(({ id }) => id)
+      ),
+      existingCache,
+      setCache
+    );
+
+    expect(retrievedUsers).toStrictEqual(testUsers);
+    expect(setCache).toHaveBeenLastCalledWith(
+      buildCacheFromUsers(
+        RSET.toReadonlyArray<OEQ.UserQuery.UserDetails>(ORD.trivial)(testUsers)
+      )
+    );
+  });
+});

--- a/react-front-end/tsrc/components/SelectUserDialog.tsx
+++ b/react-front-end/tsrc/components/SelectUserDialog.tsx
@@ -1,0 +1,84 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@material-ui/core";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { useState } from "react";
+import { languageStrings } from "../util/langstrings";
+import UserSearch from "./UserSearch";
+
+interface SelectUserDialogProps {
+  /** Controls displaying of dialog. */
+  open: boolean;
+  /** Handler for when dialog closes. */
+  onClose: (selection?: OEQ.UserQuery.UserDetails) => void;
+  /** Function which will provide the list of users for UserSearch. */
+  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
+}
+
+/**
+ * Simple dialog to prompt user to search and select a user to use in the owner filter.
+ */
+export const SelectUserDialog = ({
+  open,
+  onClose,
+  userListProvider,
+}: SelectUserDialogProps) => {
+  const [selectedUser, setSelectedUser] = useState<
+    OEQ.UserQuery.UserDetails | undefined
+  >(undefined);
+
+  const handleClose = () => {
+    onClose(selectedUser);
+    setSelectedUser(undefined);
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth>
+      <DialogTitle>
+        {languageStrings.searchpage.filterOwner.selectTitle}
+      </DialogTitle>
+      <DialogContent>
+        <UserSearch
+          onSelect={setSelectedUser}
+          userListProvider={userListProvider}
+          listHeight={300}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => onClose()} color="primary">
+          {languageStrings.common.action.cancel}
+        </Button>
+        <Button
+          onClick={handleClose}
+          color="primary"
+          autoFocus
+          disabled={!selectedUser}
+        >
+          {languageStrings.common.action.select}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
@@ -1,0 +1,300 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemSecondaryAction,
+  ListItemText,
+} from "@material-ui/core";
+import AccountCircleIcon from "@material-ui/icons/AccountCircle";
+import AddIcon from "@material-ui/icons/Add";
+import ClearIcon from "@material-ui/icons/Clear";
+import DeleteIcon from "@material-ui/icons/Delete";
+import ErrorIcon from "@material-ui/icons/Error";
+import ListIcon from "@material-ui/icons/List";
+import * as OEQ from "@openequella/rest-api-client";
+import { flow, pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import * as ORD from "fp-ts/Ord";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as RSET from "fp-ts/ReadonlySet";
+import * as S from "fp-ts/string";
+import * as T from "fp-ts/Task";
+import * as TE from "fp-ts/TaskEither";
+import React, { useEffect, useState } from "react";
+import {
+  eqUserById,
+  resolveUsers,
+  resolveUsersCached,
+  UserCache,
+  userIds,
+} from "../../modules/UserModule";
+import { languageStrings } from "../../util/langstrings";
+import { SelectUserDialog } from "../SelectUserDialog";
+import { TooltipIconButton } from "../TooltipIconButton";
+import { WizardControlBasicProps } from "./WizardHelper";
+import { WizardLabel } from "./WizardLabel";
+
+const {
+  common: { action: commonActionStrings },
+  wizard: {
+    controls: { userSelector: userSelectorStrings },
+  },
+} = languageStrings;
+
+/**
+ * Repository for cached users with resolveUsersCached. Updated by `updateUserCache`.
+ */
+let userCache: UserCache = {};
+/**
+ * Centralised function for updating `userCache`.
+ */
+const updateUserCache = (newCache: UserCache): void => {
+  userCache = newCache;
+};
+
+interface ListItemErrorProps {
+  /**
+   * The error to display.
+   */
+  error: string;
+  /**
+   * What do do when the click the clear button.
+   */
+  onClear: () => void;
+}
+
+/**
+ * Display component for display any errors in the list of users.
+ */
+const ListItemError = ({ error, onClear }: ListItemErrorProps): JSX.Element => (
+  <ListItem>
+    <ListItemIcon>
+      <ErrorIcon />
+    </ListItemIcon>
+    <ListItemText primary={error} />
+    <TooltipIconButton title={commonActionStrings.clear} onClick={onClear}>
+      <ClearIcon />
+    </TooltipIconButton>
+  </ListItem>
+);
+
+interface ListItemUserProps {
+  /**
+   * Callback for when the delete button is clicked
+   */
+  onDelete: () => void;
+  /**
+   * The details of the user to display
+   */
+  userDetails: {
+    firstName: string;
+    lastName: string;
+    username: string;
+  };
+}
+
+/**
+ * Display component for showing a user's details in the list of user.
+ */
+const ListItemUser = ({
+  onDelete,
+  userDetails: { firstName, lastName, username },
+}: ListItemUserProps): JSX.Element => (
+  <ListItem>
+    <ListItemIcon>
+      <AccountCircleIcon />
+    </ListItemIcon>
+    <ListItemText primary={username} secondary={`${firstName} ${lastName}`} />
+    <ListItemSecondaryAction>
+      <TooltipIconButton
+        aria-label={`${commonActionStrings.delete} ${username}`}
+        title={commonActionStrings.delete}
+        onClick={onDelete}
+      >
+        <DeleteIcon />
+      </TooltipIconButton>
+    </ListItemSecondaryAction>
+  </ListItem>
+);
+
+export interface WizardUserSelectorProps extends WizardControlBasicProps {
+  /**
+   * Groups to filter the user selection to.
+   */
+  groupsFilter: ReadonlySet<string>;
+  /**
+   * Whether to support selection of multiple users.
+   */
+  multiple: boolean;
+  /**
+   * Called when a user adds or removes one of the selected user(s), with the passed parameter
+   * being the current set of selections.
+   */
+  onChange: (_: ReadonlySet<string>) => void;
+  /**
+   * The currently selected user(s). Each user is represented by their UUID.
+   */
+  users: ReadonlySet<string>;
+  /**
+   * Function which will provide the list of users for UserSearch.
+   */
+  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
+  /**
+   * Function which can provide the full details of specified users based on id.
+   */
+  resolveUsersProvider?: (
+    ids: ReadonlyArray<string>
+  ) => Promise<OEQ.UserQuery.UserDetails[]>;
+}
+
+export const WizardUserSelector = ({
+  id,
+  label,
+  mandatory,
+  description,
+  multiple,
+  onChange,
+  users,
+  userListProvider,
+  resolveUsersProvider = resolveUsers,
+}: WizardUserSelectorProps): JSX.Element => {
+  const [showSelectUserDialog, setShowSelectUserDialog] =
+    useState<boolean>(false);
+  const [error, setError] = useState<string>();
+  const [fullUsers, setFullUsers] = useState<
+    ReadonlySet<OEQ.UserQuery.UserDetails>
+  >(new Set());
+
+  // Update `fullUsers` when `users` changes
+  useEffect(() => {
+    if (RSET.getEq(S.Eq).equals(users, pipe(fullUsers, userIds))) {
+      // Already in sync, no action required.
+      return;
+    }
+
+    console.debug("useEffect(users)", users);
+
+    // Update `fullUsers` but only if there's a change
+    const updateFullUsers: (updatedList: typeof fullUsers) => void = flow(
+      O.fromPredicate(
+        (updatedList) => !RSET.getEq(eqUserById).equals(updatedList, fullUsers)
+      ),
+      O.map(setFullUsers)
+    );
+
+    const processUsersUpdate: T.Task<void> = pipe(
+      users,
+      // We use the cached version to avoid excessive server calls in the two way binding
+      // of `users` and `onChange`
+      resolveUsersCached(userCache, updateUserCache, resolveUsersProvider),
+      TE.match(setError, updateFullUsers)
+    );
+
+    (async () => await processUsersUpdate())();
+  }, [users, fullUsers, resolveUsersProvider]);
+
+  const handleCloseSelectUserDialog = (
+    selection?: OEQ.UserQuery.UserDetails
+  ) => {
+    setError(undefined);
+    setShowSelectUserDialog(false);
+
+    const callOnChange = (
+      updatedFullUsers: ReadonlySet<OEQ.UserQuery.UserDetails>
+    ) => pipe(updatedFullUsers, userIds, onChange);
+
+    pipe(
+      selection,
+      O.fromNullable,
+      O.map((u) =>
+        multiple
+          ? pipe(fullUsers, RSET.insert(eqUserById)(u))
+          : RSET.singleton(u)
+      ),
+      O.map(callOnChange)
+    );
+  };
+
+  const fullUsersArray: ReadonlyArray<OEQ.UserQuery.UserDetails> = pipe(
+    fullUsers,
+    RSET.toReadonlyArray<OEQ.UserQuery.UserDetails>(
+      ORD.contramap((ud: OEQ.UserQuery.UserDetails) => ud.username)(S.Ord)
+    )
+  );
+
+  return (
+    <>
+      <WizardLabel
+        mandatory={mandatory}
+        label={label}
+        description={description}
+        labelFor={id}
+      />
+      <Grid id={id} container spacing={2}>
+        <Grid item xs={12} sm={6}>
+          <List aria-label={userSelectorStrings.userList}>
+            <ListItem key="user selector">
+              <ListItemIcon>
+                <ListIcon />
+              </ListItemIcon>
+              <ListItemText primary={userSelectorStrings.selectUsers} />
+              <ListItemSecondaryAction>
+                <TooltipIconButton
+                  title={commonActionStrings.add}
+                  onClick={() => setShowSelectUserDialog(true)}
+                >
+                  <AddIcon />
+                </TooltipIconButton>
+              </ListItemSecondaryAction>
+            </ListItem>
+            {!RSET.isEmpty(users) && <Divider />}
+            {error && (
+              <ListItemError
+                error={error}
+                onClear={() => setError(undefined)}
+              />
+            )}
+            {pipe(
+              fullUsersArray,
+              RA.map<OEQ.UserQuery.UserDetails, JSX.Element>(
+                ({ id, firstName, lastName, username }) => (
+                  <ListItemUser
+                    key={id}
+                    onDelete={() =>
+                      pipe(users, RSET.remove(S.Eq)(id), onChange)
+                    }
+                    userDetails={{ firstName, lastName, username }}
+                  />
+                )
+              )
+            )}
+          </List>
+        </Grid>
+      </Grid>
+      <SelectUserDialog
+        open={showSelectUserDialog}
+        onClose={handleCloseSelectUserDialog}
+        userListProvider={userListProvider}
+      />
+    </>
+  );
+};

--- a/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
@@ -77,7 +77,7 @@ interface ListItemErrorProps {
    */
   error: string;
   /**
-   * What do do when the click the clear button.
+   * Handler for when the clear button is clicked.
    */
   onClear: () => void;
 }

--- a/react-front-end/tsrc/modules/UserModule.ts
+++ b/react-front-end/tsrc/modules/UserModule.ts
@@ -16,7 +16,36 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
+import * as E from "fp-ts/Either";
+import { contramap, Eq } from "fp-ts/Eq";
+import { flow, pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import { not } from "fp-ts/Predicate";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as RR from "fp-ts/ReadonlyRecord";
+import { ReadonlyRecord } from "fp-ts/ReadonlyRecord";
+import * as RSET from "fp-ts/ReadonlySet";
+import * as R from "fp-ts/Record";
+import * as Semigroup from "fp-ts/Semigroup";
+import * as Separated from "fp-ts/Separated";
+import * as S from "fp-ts/string";
+import * as TE from "fp-ts/TaskEither";
 import { API_BASE_URL } from "../AppConfig";
+import { OrdAsIs } from "../util/Ord";
+
+/**
+ * Eq for `OEQ.UserQuery.UserDetails` with equality based on the user's UUID.
+ */
+export const eqUserById: Eq<OEQ.UserQuery.UserDetails> = contramap(
+  (user: OEQ.UserQuery.UserDetails) => user.id
+)(S.Eq);
+
+/**
+ * Given a set of `OEQ.UserQuery.UserDetails`, return a set of UUIDs for all the users.
+ */
+export const userIds: (
+  a: ReadonlySet<OEQ.UserQuery.UserDetails>
+) => ReadonlySet<string> = flow(RSET.map(S.Eq)(({ id }) => id));
 
 /**
  * List users known in oEQ. Useful for filtering by users, or assigning permissions etc.
@@ -43,13 +72,14 @@ export const getCurrentUserDetails = () =>
 
 /**
  * Lookup users known in oEQ.
+ *
  * @param ids An array of oEQ ids
  */
 export const resolveUsers = (
-  ids: string[]
+  ids: ReadonlyArray<string>
 ): Promise<OEQ.UserQuery.UserDetails[]> =>
   OEQ.UserQuery.lookup(API_BASE_URL, {
-    users: ids,
+    users: RA.toArray<string>(ids),
     groups: [],
     roles: [],
   }).then((result: OEQ.UserQuery.SearchResult) => result.users);
@@ -67,3 +97,83 @@ export const findUserById = async (
     throw new Error(`More than one user was resolved for id: ${userId}`);
   return userDetails[0];
 };
+
+export type UserCache = ReadonlyRecord<string, OEQ.UserQuery.UserDetails>;
+
+/**
+ * Returns a function which can be used to retrieve user details (like `resolveUsers`) but using
+ * a cache where possible.
+ *
+ * @param cache A cache update from previous calls, or initially simply `{}`
+ * @param setCache A function which will be called if any updates where made which should trigger
+ *                 an updated version of the cache. Typically this will occur if additional user
+ *                 details had to be fetched. However if no additional details were required, then
+ *                 no update to cache will be made and this function wont be called.
+ * @param resolver a function (such as `resolveUsers`) which can make a call to the server to fetch
+ *                 the details of any unknown user ids.
+ */
+export const resolveUsersCached =
+  (
+    cache: UserCache,
+    setCache: (c: UserCache) => void,
+    resolver: (
+      ids: ReadonlyArray<string>
+    ) => Promise<OEQ.UserQuery.UserDetails[]>
+  ) =>
+  (
+    users: ReadonlySet<string>
+  ): TE.TaskEither<string, ReadonlySet<OEQ.UserQuery.UserDetails>> => {
+    const updateCache = (
+      newUsers: ReadonlyArray<OEQ.UserQuery.UserDetails>
+    ): ReadonlyArray<OEQ.UserQuery.UserDetails> => {
+      const magmaLast = Semigroup.last<OEQ.UserQuery.UserDetails>();
+
+      pipe(
+        newUsers,
+        (xs): UserCache =>
+          RR.fromFoldableMap(magmaLast, RA.Foldable)(
+            xs,
+            (x: OEQ.UserQuery.UserDetails) => [x.id, x]
+          ),
+        // Before updating the cache, just be sure there is an update required
+        O.fromPredicate(not(RR.isEmpty)),
+        O.map(flow(RR.union(magmaLast)(cache), setCache))
+      );
+
+      return newUsers;
+    };
+
+    return pipe(
+      users,
+      RSET.partitionMap<string, OEQ.UserQuery.UserDetails>(
+        S.Eq,
+        eqUserById
+      )((id) =>
+        pipe(
+          cache,
+          R.lookup(id),
+          E.fromOption(() => id)
+        )
+      ),
+      // We now have previously cached users on the `right`, and on the `left` we have users
+      // we need to go and retrieve
+      Separated.mapLeft<
+        ReadonlySet<string>,
+        TE.TaskEither<string, ReadonlySet<OEQ.UserQuery.UserDetails>>
+      >(
+        flow(
+          RSET.toReadonlyArray<string>(OrdAsIs),
+          (ids) =>
+            TE.tryCatch<string, OEQ.UserQuery.UserDetails[]>(
+              () => resolver(ids),
+              (reason) => `Failed to retrieve users: ${reason}`
+            ),
+          TE.map(updateCache),
+          TE.map(RSET.fromReadonlyArray(eqUserById))
+        )
+      ),
+      // Now merge the cached users with those retrieved
+      ({ left: retrievalResult, right: cachedUsers }) =>
+        pipe(retrievalResult, TE.map(RSET.union(eqUserById)(cachedUsers)))
+    );
+  };

--- a/react-front-end/tsrc/search/components/OwnerSelector.tsx
+++ b/react-front-end/tsrc/search/components/OwnerSelector.tsx
@@ -15,15 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as OEQ from "@openequella/rest-api-client";
-import * as React from "react";
-import { useState } from "react";
 import {
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   Grid,
   IconButton,
   List,
@@ -34,7 +27,10 @@ import {
 } from "@material-ui/core";
 import AccountCircle from "@material-ui/icons/AccountCircle";
 import DeleteIcon from "@material-ui/icons/Delete";
-import UserSearch from "../../components/UserSearch";
+import * as OEQ from "@openequella/rest-api-client";
+import * as React from "react";
+import { useState } from "react";
+import { SelectUserDialog } from "../../components/SelectUserDialog";
 import { languageStrings } from "../../util/langstrings";
 
 export interface OwnerSelectorProps {
@@ -105,61 +101,6 @@ const OwnerSelector = ({
         userListProvider={userListProvider}
       />
     </>
-  );
-};
-
-interface SelectUserDialogProps {
-  /** Controls displaying of dialog. */
-  open: boolean;
-  /** Handler for when dialog closes. */
-  onClose: (selection?: OEQ.UserQuery.UserDetails) => void;
-  /** Function which will provide the list of users for UserSearch. */
-  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
-}
-
-/**
- * Simple dialog to prompt user to search and select a user to use in the owner filter.
- */
-const SelectUserDialog = ({
-  open,
-  onClose,
-  userListProvider,
-}: SelectUserDialogProps) => {
-  const [selectedUser, setSelectedUser] = useState<
-    OEQ.UserQuery.UserDetails | undefined
-  >(undefined);
-
-  const handleClose = () => {
-    onClose(selectedUser);
-    setSelectedUser(undefined);
-  };
-
-  return (
-    <Dialog open={open} onClose={handleClose} fullWidth>
-      <DialogTitle>
-        {languageStrings.searchpage.filterOwner.selectTitle}
-      </DialogTitle>
-      <DialogContent>
-        <UserSearch
-          onSelect={setSelectedUser}
-          userListProvider={userListProvider}
-          listHeight={300}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={() => onClose()} color="primary">
-          {languageStrings.common.action.cancel}
-        </Button>
-        <Button
-          onClick={handleClose}
-          color="primary"
-          autoFocus
-          disabled={!selectedUser}
-        >
-          {languageStrings.common.action.select}
-        </Button>
-      </DialogActions>
-    </Dialog>
   );
 };
 

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -719,6 +719,10 @@ export const languageStrings = {
         description:
           "An unsupported control has been detected, please contact your system administrator.",
       },
+      userSelector: {
+        selectUsers: "Select users",
+        userList: "Current selection of users",
+      },
     },
     options: {
       allOptions: "All",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Here is the User Selector Wizard control. It re-uses existing functionality to search for users, however further updates are still to come to properly support the level of multi-user selection capable with the legacy user selector (as that common control will need to be further developer). Additionally, there is not yet support for filtering to specific groups etc.

It does include some optimisation to minimise server calls to resolve full user details, however there slightly more optimisation could be done but things were getting out of hand. That said though, it should be fine without those but if needs be adding it wont be too involved. (I'll highlight what this is in comments on the code.)

Up next I'll integrate this into the wizard/advanced search, and then loop back around after that and add filtering support.


https://user-images.githubusercontent.com/43919233/142357582-6c59d9d0-6f81-41c6-b637-eb1eed387746.mp4



<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
