### PR TITLE
feat(rest-api): add support for the theme endpoint to oeq-ts-rest-api

### DIFF
--- a/oeq-ts-rest-api/src/Theme.ts
+++ b/oeq-ts-rest-api/src/Theme.ts
@@ -62,15 +62,12 @@ export const updateThemeSettings = (
   );
 
 /**
- * Retrieve theme logo
+ * Retrieve theme logo url
  *
  * @param apiBasePath Base URI to the oEQ institution and API
  */
-export const getThemeLogo = (apiBasePath: string): Promise<string> =>
-  GET<string>(
-    apiBasePath + THEME_ROOT_PATH + '/newLogo.png',
-    (data): data is any => is<any>(data)
-  );
+export const getThemeLogoUrl = (apiBasePath: string): string =>
+  apiBasePath + THEME_ROOT_PATH + '/newLogo.png';
 
 /**
  * Delete theme logo, reset logo to default
@@ -84,7 +81,7 @@ export const deleteLogo = (apiBasePath: string): Promise<void> =>
  * Update theme logo.
  *
  * @param apiBasePath Base URI to the oEQ institution and API
- * @param updatedSettings New theme Settings
+ * @param file New logo file
  */
 export const updateThemeLogo = (
   apiBasePath: string,

--- a/oeq-ts-rest-api/src/Theme.ts
+++ b/oeq-ts-rest-api/src/Theme.ts
@@ -1,0 +1,94 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GET, PUT, DELETE } from './AxiosInstance';
+import { is } from 'typescript-is';
+
+const THEME_ROOT_PATH = '/theme';
+const THEME_SETTINGS_PATH = `${THEME_ROOT_PATH}/settings`;
+const THEME_LOGO_PATH = `${THEME_ROOT_PATH}/logo`;
+
+export interface IThemeSettings {
+  primaryColor: string;
+  secondaryColor: string;
+  backgroundColor: string;
+  paperColor: string;
+  menuItemColor: string;
+  menuItemTextColor: string;
+  menuItemIconColor: string;
+  primaryTextColor: string;
+  menuTextColor: string;
+  fontSize: number;
+}
+
+/**
+ * Retrieve the theme settings for oEQ.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ */
+export const getThemeSettings = (
+  apiBasePath: string
+): Promise<IThemeSettings> =>
+  GET<IThemeSettings>(
+    apiBasePath + THEME_SETTINGS_PATH,
+    (data): data is IThemeSettings => is<IThemeSettings>(data)
+  );
+
+/**
+ * Update the theme settings to those provided.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param updatedSettings New theme Settings
+ */
+export const updateThemeSettings = (
+  apiBasePath: string,
+  updatedSettings: IThemeSettings
+): Promise<void> =>
+  PUT<IThemeSettings, undefined>(
+    apiBasePath + THEME_SETTINGS_PATH,
+    updatedSettings
+  );
+
+/**
+ * Retrieve theme logo
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ */
+export const getThemeLogo = (apiBasePath: string): Promise<string> =>
+  GET<string>(
+    apiBasePath + THEME_ROOT_PATH + '/newLogo.png',
+    (data): data is any => is<any>(data)
+  );
+
+/**
+ * Delete theme logo, reset logo to default
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ */
+export const deleteLogo = (apiBasePath: string): Promise<void> =>
+  DELETE<void>(apiBasePath + THEME_LOGO_PATH);
+
+/**
+ * Update theme logo.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param updatedSettings New theme Settings
+ */
+export const updateThemeLogo = (
+  apiBasePath: string,
+  file: File
+): Promise<void> => PUT<File, undefined>(apiBasePath + THEME_LOGO_PATH, file);

--- a/oeq-ts-rest-api/src/Theme.ts
+++ b/oeq-ts-rest-api/src/Theme.ts
@@ -22,7 +22,7 @@ const THEME_ROOT_PATH = '/theme';
 const THEME_SETTINGS_PATH = `${THEME_ROOT_PATH}/settings`;
 const THEME_LOGO_PATH = `${THEME_ROOT_PATH}/logo`;
 
-export interface IThemeSettings {
+export interface ThemeSettings {
   primaryColor: string;
   secondaryColor: string;
   backgroundColor: string;
@@ -40,12 +40,10 @@ export interface IThemeSettings {
  *
  * @param apiBasePath Base URI to the oEQ institution and API
  */
-export const getThemeSettings = (
-  apiBasePath: string
-): Promise<IThemeSettings> =>
-  GET<IThemeSettings>(
+export const getThemeSettings = (apiBasePath: string): Promise<ThemeSettings> =>
+  GET<ThemeSettings>(
     apiBasePath + THEME_SETTINGS_PATH,
-    (data): data is IThemeSettings => is<IThemeSettings>(data)
+    (data): data is ThemeSettings => is<ThemeSettings>(data)
   );
 
 /**
@@ -56,9 +54,9 @@ export const getThemeSettings = (
  */
 export const updateThemeSettings = (
   apiBasePath: string,
-  updatedSettings: IThemeSettings
+  updatedSettings: ThemeSettings
 ): Promise<void> =>
-  PUT<IThemeSettings, undefined>(
+  PUT<ThemeSettings, undefined>(
     apiBasePath + THEME_SETTINGS_PATH,
     updatedSettings
   );

--- a/oeq-ts-rest-api/src/index.ts
+++ b/oeq-ts-rest-api/src/index.ts
@@ -33,5 +33,6 @@ export * as SearchFacets from './SearchFacets';
 export * as SearchSettings from './SearchSettings';
 export * as Security from './Security';
 export * as Settings from './Settings';
+export * as Theme from './Theme';
 export * as UserQuery from './UserQuery';
 export * as Utils from './Utils';

--- a/oeq-ts-rest-api/test/Theme.test.ts
+++ b/oeq-ts-rest-api/test/Theme.test.ts
@@ -30,6 +30,10 @@ describe('Theme settings', () => {
     settingsAtStart = await OEQ.Theme.getThemeSettings(TC.API_PATH);
   });
 
+  afterAll(async () => {
+    await OEQ.Theme.updateThemeSettings(TC.API_PATH, settingsAtStart);
+  });
+
   it('Should be able to retrieve theme settings', async () => {
     expect(settingsAtStart).not.toBeNull();
   });
@@ -39,7 +43,8 @@ describe('Theme settings', () => {
       ...settingsAtStart,
       fontSize: 666,
     });
-    const settings = await OEQ.Theme.getThemeSettings(TC.API_PATH);
-    expect(settings.fontSize).toBe(666);
+    const newSettings = await OEQ.Theme.getThemeSettings(TC.API_PATH);
+    expect(newSettings).not.toEqual(settingsAtStart);
+    expect(newSettings.fontSize).toBe(666);
   });
 });

--- a/oeq-ts-rest-api/test/Theme.test.ts
+++ b/oeq-ts-rest-api/test/Theme.test.ts
@@ -17,14 +17,14 @@
  */
 import * as OEQ from '../src';
 import * as TC from './TestConfig';
-import { IThemeSettings } from '../src/Theme';
+import { ThemeSettings } from '../src/Theme';
 
 beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
 
 afterAll(() => OEQ.Auth.logout(TC.API_PATH, true));
 
 describe('Theme settings', () => {
-  let settingsAtStart: IThemeSettings;
+  let settingsAtStart: ThemeSettings;
 
   beforeAll(async () => {
     settingsAtStart = await OEQ.Theme.getThemeSettings(TC.API_PATH);

--- a/oeq-ts-rest-api/test/Theme.test.ts
+++ b/oeq-ts-rest-api/test/Theme.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from '../src';
+import * as TC from './TestConfig';
+import { IThemeSettings } from '../src/Theme';
+
+beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
+
+afterAll(() => OEQ.Auth.logout(TC.API_PATH, true));
+
+describe('Theme settings', () => {
+  let settingsAtStart: IThemeSettings;
+
+  beforeAll(async () => {
+    settingsAtStart = await OEQ.Theme.getThemeSettings(TC.API_PATH);
+  });
+
+  it('Should be able to retrieve theme settings', async () => {
+    expect(settingsAtStart).not.toBeNull();
+  });
+
+  it('Should be possible to change the theme settings', async () => {
+    await OEQ.Theme.updateThemeSettings(TC.API_PATH, {
+      ...settingsAtStart,
+      fontSize: 666,
+    });
+    const settings = await OEQ.Theme.getThemeSettings(TC.API_PATH);
+    expect(settings.fontSize).toBe(666);
+  });
+});

--- a/oeq-ts-rest-api/tsconfig.json
+++ b/oeq-ts-rest-api/tsconfig.json
@@ -2,7 +2,10 @@
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "ES6",
-    "lib": ["ES6"],
+    "lib": [
+      "ES6",
+      "dom"
+    ],
     "target": "ES6",
     "importHelpers": true,
     "declaration": true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Create api with tests for Theme module.

API: 
  - getThemeSettings,
  - updateThemeSettings,
  - getThemeLogo,
  - updateThemeLogo,

Because I am still struggling with tests for theme logo, only contains tests for:
 - getThemeSettings
 - updateThemeSettings

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
