### PR TITLE
Feature/wizard user selector filtering api

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
@@ -22,9 +22,10 @@ import com.tle.beans.usermanagement.standard.wrapper.SharedSecretSettings
 import com.tle.common.security.SecurityConstants
 import com.tle.common.usermanagement.user.valuebean.{GroupBean, RoleBean, UserBean}
 import com.tle.legacy.LegacyGuice
-import io.swagger.annotations.{Api, ApiParam}
-import javax.ws.rs._
+import io.swagger.annotations.{Api, ApiOperation, ApiParam}
 
+import javax.ws.rs._
+import javax.ws.rs.core.Response
 import scala.collection.JavaConverters._
 
 case class LookupQuery(users: Seq[String], groups: Seq[String], roles: Seq[String])
@@ -79,6 +80,30 @@ class UserQueryResource {
     LookupQueryResult(users.map(UserDetails.apply),
                       groups.map(GroupQueryResult.apply),
                       roles.filterNot(r => exclude(r.getUniqueID)).map(RoleQueryResult.apply))
+  }
+
+  @GET
+  @Path("filtered")
+  @ApiOperation(
+    value = "Search for users",
+    notes = "Searches for users, but filters the results based on the byGroups parameter.",
+    response = classOf[UserDetails],
+    responseContainer = "List"
+  )
+  def filtered(
+      @QueryParam(value = "q") @ApiParam("Query string") q: String,
+      @QueryParam("byGroups") @ApiParam("A list of group UUIDs to filter the search by") groups: Array[
+        String]
+  ): Response = {
+    val us = LegacyGuice.userService
+    val result: Iterable[UserBean] = groups match {
+      case xs if groups.nonEmpty => xs.flatMap(g => us.searchUsers(q, g, true).asScala)
+      case _                     => us.searchUsers(q).asScala
+    }
+    result match {
+      case users if result.nonEmpty => Response.ok.entity(users.map(UserDetails.apply)).build()
+      case _                        => throw new NotFoundException("No users were found matching the specified criteria")
+    }
   }
 
   @GET

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
@@ -98,8 +98,8 @@ class UserQueryResource {
   ): Response = {
     val us = LegacyGuice.userService
     val result: Iterable[UserBean] = groups match {
-      case xs if groups.nonEmpty => xs.flatMap(g => us.searchUsers(q, g, true).asScala)
-      case _                     => us.searchUsers(q).asScala
+      case xs if xs.nonEmpty => xs.flatMap(g => us.searchUsers(q, g, true).asScala)
+      case _                 => us.searchUsers(q).asScala
     }
     result match {
       case users if users.nonEmpty =>

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
@@ -22,6 +22,7 @@ import com.tle.beans.usermanagement.standard.wrapper.SharedSecretSettings
 import com.tle.common.security.SecurityConstants
 import com.tle.common.usermanagement.user.valuebean.{GroupBean, RoleBean, UserBean}
 import com.tle.legacy.LegacyGuice
+import com.tle.web.api.ApiErrorResponse.resourceNotFound
 import io.swagger.annotations.{Api, ApiOperation, ApiParam}
 
 import javax.ws.rs._
@@ -105,7 +106,7 @@ class UserQueryResource {
         val uniqueUsers = users.toSet
         val details     = uniqueUsers.map(UserDetails.apply)
         Response.ok.entity(details).build()
-      case _ => throw new NotFoundException("No users were found matching the specified criteria")
+      case _ => resourceNotFound("No users were found matching the specified criteria")
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
@@ -101,8 +101,11 @@ class UserQueryResource {
       case _                     => us.searchUsers(q).asScala
     }
     result match {
-      case users if result.nonEmpty => Response.ok.entity(users.map(UserDetails.apply)).build()
-      case _                        => throw new NotFoundException("No users were found matching the specified criteria")
+      case users if users.nonEmpty =>
+        val uniqueUsers = users.toSet
+        val details     = uniqueUsers.map(UserDetails.apply)
+        Response.ok.entity(details).build()
+      case _ => throw new NotFoundException("No users were found matching the specified criteria")
     }
   }
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/UserQueryApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/UserQueryApiTest.java
@@ -1,0 +1,147 @@
+package io.github.openequella.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.NameValuePair;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.codehaus.jackson.type.TypeReference;
+import org.testng.annotations.Test;
+
+public class UserQueryApiTest extends AbstractRestApiTest {
+
+  private final String USERQUERY_API_ENDPOINT =
+      getTestConfig().getInstitutionUrl() + "api/userquery";
+
+  private final String GROUPID_AUTOGROUP_1 = "d72eb802-0ea6-4384-907a-341ee60628c0";
+  private final String GROUPID_OUTGROUP_1 = "33faa43a-fd68-4145-a022-7162215c70a2";
+  private final String USERID_AUTOTEST = "adfcaf58-241b-4eca-9740-6a26d1c3dd58";
+  private final String USERID_DONOTUSE = "fc9629b0-8bb7-5099-edd3-cf7a42c350fa";
+
+  private final String REASON_UNEXPECTED_NUM_USERS = "Unexpected number of users returned";
+  private final String REASON_MISSING_USERS = "Expected users missing!";
+
+  @Test
+  public void filter_unfilteredQueryTest() throws IOException {
+    // Search for all the users with 'e'
+    final List<UserDetails> result = filterEndpointQuery(200, "e", null);
+    // ... for which there's many
+    assertThat(REASON_UNEXPECTED_NUM_USERS, result.size(), is(8));
+  }
+
+  @Test
+  public void filter_singleFilterQueryTest() throws IOException {
+    // Search for all the users with 'e', but only in the AutoGroup1
+    final List<UserDetails> result =
+        filterEndpointQuery(200, "e", Collections.singleton(GROUPID_AUTOGROUP_1));
+    // ... for which there's only 1
+    assertThat(REASON_UNEXPECTED_NUM_USERS, result.size(), is(1));
+    assertTrue(REASON_MISSING_USERS, collectUserIds(result).contains(USERID_AUTOTEST));
+  }
+
+  @Test
+  public void filter_multiFilterQueryTest() throws IOException {
+    // Search for all the users with 'e' across two groups
+    final List<UserDetails> result =
+        filterEndpointQuery(
+            200, "e", new HashSet<>(Arrays.asList(GROUPID_AUTOGROUP_1, GROUPID_OUTGROUP_1)));
+    assertThat(REASON_UNEXPECTED_NUM_USERS, result.size(), is(2));
+    assertTrue(
+        REASON_MISSING_USERS,
+        collectUserIds(result).containsAll(Arrays.asList(USERID_AUTOTEST, USERID_DONOTUSE)));
+  }
+
+  @Test
+  public void filter_nothingFoundTest() throws IOException {
+    // Search for a user that could never possibly exist
+    filterEndpointQuery(404, "This user could never possibly exist", null);
+  }
+
+  private List<UserDetails> filterEndpointQuery(int expectedCode, String q, Set<String> byGroups)
+      throws IOException {
+    final HttpMethod method = new GetMethod(USERQUERY_API_ENDPOINT + "/filtered");
+    final List<NameValuePair> queryParams = new LinkedList<>();
+
+    // The query is kind of mandatory, so always set
+    queryParams.add(new NameValuePair("q", q));
+    // If one or more filters have been specified, add them too
+    Optional.ofNullable(byGroups)
+        .orElse(Collections.emptySet())
+        .forEach(uuid -> queryParams.add(new NameValuePair("byGroups", uuid)));
+
+    method.setQueryString(queryParams.toArray(new NameValuePair[0]));
+
+    int statusCode = makeClientRequest(method);
+    assertThat("Unexpected response from server", statusCode, is(expectedCode));
+
+    return statusCode == 200
+        ? mapper.readValue(
+            method.getResponseBodyAsString(), new TypeReference<List<UserDetails>>() {})
+        : Collections.emptyList();
+  }
+
+  private Set<String> collectUserIds(List<UserDetails> users) {
+    return users.stream().map(UserDetails::getId).collect(Collectors.toSet());
+  }
+
+  // Mirror of com.tle.web.api.users.UserDetails
+  private static class UserDetails {
+
+    private String id;
+    private String username;
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getFirstName() {
+      return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+      this.firstName = firstName;
+    }
+
+    public String getLastName() {
+      return lastName;
+    }
+
+    public void setLastName(String lastName) {
+      this.lastName = lastName;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public void setEmail(String email) {
+      this.email = email;
+    }
+  }
+}

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/UserQueryApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/UserQueryApiTest.java
@@ -32,39 +32,43 @@ public class UserQueryApiTest extends AbstractRestApiTest {
   private final String REASON_UNEXPECTED_NUM_USERS = "Unexpected number of users returned";
   private final String REASON_MISSING_USERS = "Expected users missing!";
 
-  @Test
+  // Using a query of 'e' searches for all users which have an 'e' anywhere in their names. Being
+  // the names are english, this gets most of them.
+  private final String COMMON_QUERY = "e";
+
+  @Test(
+      description =
+          "Search for all users matching a query, with no group filter specified (so all users)")
   public void filter_unfilteredQueryTest() throws IOException {
-    // Search for all the users with 'e'
-    final List<UserDetails> result = filterEndpointQuery(200, "e", null);
-    // ... for which there's many
+    final List<UserDetails> result = filterEndpointQuery(200, COMMON_QUERY, null);
     assertThat(REASON_UNEXPECTED_NUM_USERS, result.size(), is(8));
   }
 
-  @Test
+  @Test(description = "Search for all users matching a query, limiting to a single group")
   public void filter_singleFilterQueryTest() throws IOException {
-    // Search for all the users with 'e', but only in the AutoGroup1
     final List<UserDetails> result =
-        filterEndpointQuery(200, "e", Collections.singleton(GROUPID_AUTOGROUP_1));
-    // ... for which there's only 1
+        filterEndpointQuery(200, COMMON_QUERY, Collections.singleton(GROUPID_AUTOGROUP_1));
     assertThat(REASON_UNEXPECTED_NUM_USERS, result.size(), is(1));
     assertTrue(REASON_MISSING_USERS, collectUserIds(result).contains(USERID_AUTOTEST));
   }
 
-  @Test
+  @Test(description = "Search for all users matching a query, but limited to two groups")
   public void filter_multiFilterQueryTest() throws IOException {
-    // Search for all the users with 'e' across two groups
     final List<UserDetails> result =
         filterEndpointQuery(
-            200, "e", new HashSet<>(Arrays.asList(GROUPID_AUTOGROUP_1, GROUPID_OUTGROUP_1)));
+            200,
+            COMMON_QUERY,
+            new HashSet<>(Arrays.asList(GROUPID_AUTOGROUP_1, GROUPID_OUTGROUP_1)));
     assertThat(REASON_UNEXPECTED_NUM_USERS, result.size(), is(2));
     assertTrue(
         REASON_MISSING_USERS,
         collectUserIds(result).containsAll(Arrays.asList(USERID_AUTOTEST, USERID_DONOTUSE)));
   }
 
-  @Test
+  @Test(
+      description =
+          "Search for a user that could never possibly exist, ensuring we get a not found (404) response")
   public void filter_nothingFoundTest() throws IOException {
-    // Search for a user that could never possibly exist
     filterEndpointQuery(404, "This user could never possibly exist", null);
   }
 

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -65,7 +65,7 @@ export interface FilteredParams {
   /** Wildcard supporting text string to filter results by. */
   q?: string;
   /** A list of group UUIDs to filter the search by. */
-  byGroups?: string[];
+  byGroups?: UuidString[];
 }
 
 export interface LookupParams {

--- a/oeq-ts-rest-api/src/UserQuery.ts
+++ b/oeq-ts-rest-api/src/UserQuery.ts
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GET, POST } from './AxiosInstance';
 import { is } from 'typescript-is';
+import { GET, POST } from './AxiosInstance';
 import { UuidString } from './Common';
 
 export interface UserDetails {
@@ -61,6 +61,13 @@ export interface SearchParams {
   users: boolean;
 }
 
+export interface FilteredParams {
+  /** Wildcard supporting text string to filter results by. */
+  q?: string;
+  /** A list of group UUIDs to filter the search by. */
+  byGroups?: string[];
+}
+
 export interface LookupParams {
   /** List of User IDs to lookup. */
   users: string[];
@@ -88,6 +95,22 @@ export const search = (
   GET<SearchResult>(
     apiBasePath + USERQUERY_ROOT_PATH + '/search',
     isSearchResult,
+    params
+  );
+
+/**
+ * Searches for users, but filters the results based on the byGroups parameter.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API
+ * @param params Query parameters to customize result
+ */
+export const filtered = (
+  apiBasePath: string,
+  params: FilteredParams
+): Promise<UserDetails[]> =>
+  GET<UserDetails[]>(
+    apiBasePath + USERQUERY_ROOT_PATH + '/filtered',
+    (result: unknown): result is UserDetails[] => is<UserDetails[]>(result),
     params
   );
 

--- a/oeq-ts-rest-api/test/UserQuery.test.ts
+++ b/oeq-ts-rest-api/test/UserQuery.test.ts
@@ -135,3 +135,25 @@ describe('/userquery/lookup', () => {
     expect(entities).toMatchObject([{ id: id }]);
   });
 });
+
+describe('/userquery/filtered', () => {
+  it('returns users matching the "q" param', async () => {
+    const users = await OEQ.UserQuery.filtered(API_PATH, { q: 'auto' });
+    expect(users).toHaveLength(2);
+  });
+
+  it('filters the users matching the "q" param based on the byGroups param', async () => {
+    const usersWithAdministratorRoleGroup =
+      'e91205b0-684e-51e2-a1be-3ab646aa98dd';
+    const users = await OEQ.UserQuery.filtered(API_PATH, {
+      q: 'auto',
+      byGroups: [usersWithAdministratorRoleGroup],
+    });
+    expect(users).toHaveLength(1);
+  });
+
+  it('returns all users if no params are specified', async () => {
+    const users = await OEQ.UserQuery.filtered(API_PATH, {});
+    expect(users).toHaveLength(12);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Adds a new endpoint to allow searching for users but filtered by groups. This is a feature of the Wizard User Selector Control, and so API support is needed to add it. The logic in the implementation is basically the same as that used in the legacy UI via `UserSearchModel.populateModel`. It basically does a call for each group supplied, and then merges the results.

This PR also includes the support in the front-end REST module for immediate consumption.

![image](https://user-images.githubusercontent.com/43919233/142957798-946c0d92-0ec0-43bc-a6e1-d871087afa80.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
