### PR TITLE
feat(frontend): keep advanced search panel open after clicking clear button

### DIFF
--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -322,7 +322,6 @@ describe("Rendering of wizard", () => {
 
     // Click clear button
     await clickClearButton(container);
-    togglePanel();
     expect(pipe(getCurrentLabelsAndValues(), filterEmptyValues)).toEqual([]);
   });
 });

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -234,10 +234,6 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const [alreadyDownloaded, setAlreadyDownloaded] = useState<boolean>(false);
   const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
-  //set true to keep panel open after search
-  //only work for once,
-  const keepAdvSearchPanelOpenOnceAfterSearch = useRef<boolean>(false);
-
   const { appErrorHandler } = useContext(AppRenderErrorContext);
   const searchPageErrorHandler = useCallback(
     (error: Error) => {
@@ -420,15 +416,12 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
       if (
         searchPageModeState.mode === "advSearch" &&
-        !keepAdvSearchPanelOpenOnceAfterSearch.current
+        !searchPageModeState.isKeepAdvSearchPanelToggleState
       ) {
         searchPageModeDispatch({
           type: "hideAdvSearchPanel",
         });
       }
-
-      //only used for once, set to false.
-      keepAdvSearchPanelOpenOnceAfterSearch.current = false;
 
       setSearchPageOptions(state.options);
       (async () => {
@@ -475,7 +468,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     history,
     state,
     advancedSearchId,
-    searchPageModeState.mode,
+    searchPageModeState,
   ]);
 
   // In Selection Session, once a new search result is returned, make each
@@ -724,10 +717,14 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     });
   };
 
-  const handleSubmitAdvancedSearch = async (advFieldValue: FieldValueMap) => {
+  const handleSubmitAdvancedSearch = async (
+    advFieldValue: FieldValueMap,
+    isKeepAdvSearchPanelToggleState = false
+  ) => {
     searchPageModeDispatch({
       type: "setQueryValues",
       values: advFieldValue,
+      isKeepAdvSearchPanelToggleState: isKeepAdvSearchPanelToggleState,
     });
 
     const task = pipe(
@@ -748,8 +745,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   };
 
   const handleClearAdvancedSearch = async () => {
-    keepAdvSearchPanelOpenOnceAfterSearch.current = true;
-    await handleSubmitAdvancedSearch(new Map());
+    await handleSubmitAdvancedSearch(new Map(), true);
   };
 
   /**

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -235,7 +235,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
   //set true to keep panel open after search
-  //only worked for one time,
+  //only work for once,
   const keepAdvSearchPanelOpenOnceAfterSearch = useRef<boolean>(false);
 
   const { appErrorHandler } = useContext(AppRenderErrorContext);

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -234,6 +234,10 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const [alreadyDownloaded, setAlreadyDownloaded] = useState<boolean>(false);
   const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
+  //set true to keep panel open after search
+  //only worked for one time,
+  const keepAdvSearchPanelOpenOnceAfterSearch = useRef<boolean>(false);
+
   const { appErrorHandler } = useContext(AppRenderErrorContext);
   const searchPageErrorHandler = useCallback(
     (error: Error) => {
@@ -414,12 +418,17 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
         }
       );
 
-      // todo: do not hide the panel for the first search.
-      if (searchPageModeState.mode === "advSearch") {
+      if (
+        searchPageModeState.mode === "advSearch" &&
+        !keepAdvSearchPanelOpenOnceAfterSearch.current
+      ) {
         searchPageModeDispatch({
           type: "hideAdvSearchPanel",
         });
       }
+
+      //only used for once, set to false.
+      keepAdvSearchPanelOpenOnceAfterSearch.current = false;
 
       setSearchPageOptions(state.options);
       (async () => {
@@ -738,6 +747,11 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     pipe(await task(), E.fold(searchPageErrorHandler, search));
   };
 
+  const handleClearAdvancedSearch = async () => {
+    keepAdvSearchPanelOpenOnceAfterSearch.current = true;
+    await handleSubmitAdvancedSearch(new Map());
+  };
+
   /**
    * Determines if any collapsible filters have been modified from their defaults
    */
@@ -1040,7 +1054,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
                     wizardControls={searchPageModeState.definition.controls}
                     values={searchPageModeState.queryValues}
                     onSubmit={handleSubmitAdvancedSearch}
-                    onClear={() => handleSubmitAdvancedSearch(new Map())}
+                    onClear={handleClearAdvancedSearch}
                     onClose={() =>
                       searchPageModeDispatch({ type: "hideAdvSearchPanel" })
                     }

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -716,12 +716,12 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
   const handleSubmitAdvancedSearch = async (
     advFieldValue: FieldValueMap,
-    isKeepAdvSearchPanelOpen = false
+    overrideHide = false
   ) => {
     searchPageModeDispatch({
       type: "setQueryValues",
       values: advFieldValue,
-      isKeepAdvSearchPanelOpen,
+      overrideHide,
     });
 
     const task = pipe(

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -721,7 +721,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     searchPageModeDispatch({
       type: "setQueryValues",
       values: advFieldValue,
-      isKeepAdvSearchPanelOpen: isKeepAdvSearchPanelOpen,
+      isKeepAdvSearchPanelOpen,
     });
 
     const task = pipe(
@@ -739,10 +739,6 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
     // Run the task.
     pipe(await task(), E.fold(searchPageErrorHandler, search));
-  };
-
-  const handleClearAdvancedSearch = async () => {
-    await handleSubmitAdvancedSearch(new Map(), true);
   };
 
   /**
@@ -1047,7 +1043,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
                     wizardControls={searchPageModeState.definition.controls}
                     values={searchPageModeState.queryValues}
                     onSubmit={handleSubmitAdvancedSearch}
-                    onClear={handleClearAdvancedSearch}
+                    onClear={() => handleSubmitAdvancedSearch(new Map(), true)}
                     onClose={() =>
                       searchPageModeDispatch({ type: "hideAdvSearchPanel" })
                     }

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -414,10 +414,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
         }
       );
 
-      if (
-        searchPageModeState.mode === "advSearch" &&
-        !searchPageModeState.isKeepAdvSearchPanelToggleState
-      ) {
+      if (searchPageModeState.mode === "advSearch") {
         searchPageModeDispatch({
           type: "hideAdvSearchPanel",
         });
@@ -468,7 +465,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     history,
     state,
     advancedSearchId,
-    searchPageModeState,
+    searchPageModeState.mode,
   ]);
 
   // In Selection Session, once a new search result is returned, make each
@@ -719,12 +716,12 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
   const handleSubmitAdvancedSearch = async (
     advFieldValue: FieldValueMap,
-    isKeepAdvSearchPanelToggleState = false
+    isKeepAdvSearchPanelOpen = false
   ) => {
     searchPageModeDispatch({
       type: "setQueryValues",
       values: advFieldValue,
-      isKeepAdvSearchPanelToggleState: isKeepAdvSearchPanelToggleState,
+      isKeepAdvSearchPanelOpen: isKeepAdvSearchPanelOpen,
     });
 
     const task = pipe(

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -29,7 +29,8 @@ export type State =
       definition: OEQ.AdvancedSearch.AdvancedSearchDefinition;
       isAdvSearchPanelOpen: boolean;
       queryValues: FieldValueMap;
-      isKeepAdvSearchPanelToggleState: boolean;
+      // set true to keep search panel open, ignore hide panel action
+      isKeepAdvSearchPanelOpen: boolean;
     };
 
 export type Action =
@@ -50,7 +51,7 @@ export type Action =
   | {
       type: "setQueryValues";
       values: FieldValueMap;
-      isKeepAdvSearchPanelToggleState: boolean;
+      isKeepAdvSearchPanelOpen: boolean;
     };
 
 const isAdvancedSearchMode =
@@ -71,6 +72,9 @@ const toggleOrHidePanel = (state: State, action: "toggle" | "hide") => {
       `Request to ${action} Advanced Search Panel when _not_ in Advanced Search mode. Request ignored.`
     );
   }
+  if (action === "hide" && state.isKeepAdvSearchPanelOpen) {
+    return state;
+  }
   return {
     ...state,
     isAdvSearchPanelOpen:
@@ -81,7 +85,7 @@ const toggleOrHidePanel = (state: State, action: "toggle" | "hide") => {
 const setQueryValues: (_: {
   state: State;
   values: FieldValueMap;
-  isKeepAdvSearchPanelToggleState: boolean;
+  isKeepAdvSearchPanelOpen: boolean;
 }) => State = flow(
   isAdvancedSearchMode(
     "Attempted to set advanced search query values, when _not_ in Advanced Search mode!"
@@ -90,10 +94,10 @@ const setQueryValues: (_: {
     (e) => {
       throw e;
     },
-    ({ state, values, isKeepAdvSearchPanelToggleState }) => ({
+    ({ state, values, isKeepAdvSearchPanelOpen }) => ({
       ...state,
       queryValues: values,
-      isKeepAdvSearchPanelToggleState: isKeepAdvSearchPanelToggleState,
+      isKeepAdvSearchPanelOpen: isKeepAdvSearchPanelOpen,
     })
   )
 );
@@ -109,7 +113,7 @@ export const searchPageModeReducer = (state: State, action: Action): State => {
         definition,
         isAdvSearchPanelOpen: false,
         queryValues: action.initialQueryValues,
-        isKeepAdvSearchPanelToggleState: false,
+        isKeepAdvSearchPanelOpen: false,
       };
     case "toggleAdvSearchPanel":
       return toggleOrHidePanel(state, "toggle");
@@ -119,7 +123,7 @@ export const searchPageModeReducer = (state: State, action: Action): State => {
       return setQueryValues({
         state,
         values: action.values,
-        isKeepAdvSearchPanelToggleState: action.isKeepAdvSearchPanelToggleState,
+        isKeepAdvSearchPanelOpen: action.isKeepAdvSearchPanelOpen,
       });
     default:
       return absurd(action);

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -29,7 +29,8 @@ export type State =
       definition: OEQ.AdvancedSearch.AdvancedSearchDefinition;
       isAdvSearchPanelOpen: boolean;
       queryValues: FieldValueMap;
-      // set true to keep search panel open, ignore hide panel action
+      // `true` to keep the Adv search panel open for next search action
+      // (so it will ignore the next action of hiding the panel).
       isKeepAdvSearchPanelOpen: boolean;
     };
 
@@ -73,7 +74,7 @@ const toggleOrHidePanel = (state: State, action: "toggle" | "hide") => {
     );
   }
   if (action === "hide" && state.isKeepAdvSearchPanelOpen) {
-    return state;
+    return { ...state, isKeepAdvSearchPanelOpen: false };
   }
   return {
     ...state,

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -29,6 +29,7 @@ export type State =
       definition: OEQ.AdvancedSearch.AdvancedSearchDefinition;
       isAdvSearchPanelOpen: boolean;
       queryValues: FieldValueMap;
+      isKeepAdvSearchPanelToggleState: boolean;
     };
 
 export type Action =
@@ -49,6 +50,7 @@ export type Action =
   | {
       type: "setQueryValues";
       values: FieldValueMap;
+      isKeepAdvSearchPanelToggleState: boolean;
     };
 
 const isAdvancedSearchMode =
@@ -76,18 +78,25 @@ const toggleOrHidePanel = (state: State, action: "toggle" | "hide") => {
   };
 };
 
-const setQueryValues: (_: { state: State; values: FieldValueMap }) => State =
-  flow(
-    isAdvancedSearchMode(
-      "Attempted to set advanced search query values, when _not_ in Advanced Search mode!"
-    ),
-    E.matchW(
-      (e) => {
-        throw e;
-      },
-      ({ state, values }) => ({ ...state, queryValues: values })
-    )
-  );
+const setQueryValues: (_: {
+  state: State;
+  values: FieldValueMap;
+  isKeepAdvSearchPanelToggleState: boolean;
+}) => State = flow(
+  isAdvancedSearchMode(
+    "Attempted to set advanced search query values, when _not_ in Advanced Search mode!"
+  ),
+  E.matchW(
+    (e) => {
+      throw e;
+    },
+    ({ state, values, isKeepAdvSearchPanelToggleState }) => ({
+      ...state,
+      queryValues: values,
+      isKeepAdvSearchPanelToggleState: isKeepAdvSearchPanelToggleState,
+    })
+  )
+);
 
 export const searchPageModeReducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -100,13 +109,18 @@ export const searchPageModeReducer = (state: State, action: Action): State => {
         definition,
         isAdvSearchPanelOpen: false,
         queryValues: action.initialQueryValues,
+        isKeepAdvSearchPanelToggleState: false,
       };
     case "toggleAdvSearchPanel":
       return toggleOrHidePanel(state, "toggle");
     case "hideAdvSearchPanel":
       return toggleOrHidePanel(state, "hide");
     case "setQueryValues":
-      return setQueryValues({ state, values: action.values });
+      return setQueryValues({
+        state,
+        values: action.values,
+        isKeepAdvSearchPanelToggleState: action.isKeepAdvSearchPanelToggleState,
+      });
     default:
       return absurd(action);
   }

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -99,6 +99,11 @@ export const AdvancedSearchPanel = ({
     [currentValues, setCurrentValues]
   );
 
+  const onClearHandler = (): void => {
+    setCurrentValues(new Map());
+    onClear();
+  };
+
   const idPrefix = "advanced-search-panel";
   return (
     <Card id={idPrefix}>
@@ -146,7 +151,11 @@ export const AdvancedSearchPanel = ({
         >
           {languageStrings.common.action.search}
         </Button>
-        <Button id={`${idPrefix}-clearBtn`} onClick={onClear} color="secondary">
+        <Button
+          id={`${idPrefix}-clearBtn`}
+          onClick={onClearHandler}
+          color="secondary"
+        >
           {languageStrings.common.action.clear}
         </Button>
       </CardActions>

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -29,7 +29,7 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
 import { constFalse, flow, pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { TooltipIconButton } from "../../components/TooltipIconButton";
 import * as WizardHelper from "../../components/wizard/WizardHelper";
 import { languageStrings } from "../../util/langstrings";
@@ -99,10 +99,10 @@ export const AdvancedSearchPanel = ({
     [currentValues, setCurrentValues]
   );
 
-  const onClearHandler = (): void => {
-    setCurrentValues(new Map());
-    onClear();
-  };
+  // handle props `value` changing event
+  useEffect(() => {
+    setCurrentValues(values);
+  }, [values]);
 
   const idPrefix = "advanced-search-panel";
   return (
@@ -151,11 +151,7 @@ export const AdvancedSearchPanel = ({
         >
           {languageStrings.common.action.search}
         </Button>
-        <Button
-          id={`${idPrefix}-clearBtn`}
-          onClick={onClearHandler}
-          color="secondary"
-        >
+        <Button id={`${idPrefix}-clearBtn`} onClick={onClear} color="secondary">
           {languageStrings.common.action.clear}
         </Button>
       </CardActions>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Add a flag to keep the search panel open.
Add a useEffect in AdvancedSearchPanel to update state value 
Change the corresponding test.

https://user-images.githubusercontent.com/92769668/143172913-a5778d59-f8f3-4c3a-95ea-977138bad2d6.mp4

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
