### PR TITLE
Feature/build advanced search criteria on front end

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/GroupsAndDisabling.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/GroupsAndDisabling.java
@@ -44,7 +44,7 @@ public class GroupsAndDisabling extends AbstractWizardControlsTest {
     assertFalse(groupItem1.isEditboxDisabled(1));
     assertFalse(groupItem1.shuffleList(3).isDisabled());
     assertFalse(groupItem1.shuffleGroup(5, 3).isDisabled());
-    groupItem1.editbox(1, "Edit Box");
+    groupItem1.editbox(1, "Edit");
     group.toggleGroup("group2");
     groupItem2.selectDropDown(1, "1");
     groupItem2.setCheck(2, "2", true);
@@ -78,7 +78,7 @@ public class GroupsAndDisabling extends AbstractWizardControlsTest {
     assertEquals(itemXml, "item/same/checkboxes", Arrays.asList("1", "2", "5", "6"));
     PropBagEx cXml = itemXml.getSubtree("item/controls");
     assertEquals(cXml, "group", Arrays.asList("group1"));
-    assertEquals(cXml, "editbox", "Edit Box");
+    assertEquals(cXml, "editbox", "Edit");
     assertFalse(cXml.nodeExists("checkboxes"));
     assertFalse(cXml.nodeExists("listbox"));
     PropBagEx kXml = itemXml.getSubtree("item/keep");

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiAdditionalTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiAdditionalTest.java
@@ -66,6 +66,8 @@ public class Search2ApiAdditionalTest extends AbstractRestApiTest {
     JsonNode result = doSearch(Collections.singleton(controlValue));
     // There should be two Items in the result. One Item matches the token 'box' and the other one
     // matches the token 'something'.
+
+    System.out.println(result);
     assertEquals(getAvailable(result), 2);
   }
 
@@ -80,6 +82,8 @@ public class Search2ApiAdditionalTest extends AbstractRestApiTest {
     JsonNode result = doSearch((Collections.singleton(controlValue)));
     // There should be two Items in the result. One Item matches the token 'box' and the other one
     // matches the token 'something'.
+
+    System.out.println(result);
     assertEquals(getAvailable(result), 2);
   }
 
@@ -150,6 +154,7 @@ public class Search2ApiAdditionalTest extends AbstractRestApiTest {
     NameValuePair modifiedAfter = new NameValuePair("modifiedAfter", "2011-04-06");
 
     JsonNode result = doSearch((Collections.singleton(controlValue)), modifiedAfter);
+    System.out.println(result);
     assertEquals(getAvailable(result), 1);
   }
 

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiAdditionalTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiAdditionalTest.java
@@ -67,7 +67,6 @@ public class Search2ApiAdditionalTest extends AbstractRestApiTest {
     // There should be two Items in the result. One Item matches the token 'box' and the other one
     // matches the token 'something'.
 
-    System.out.println(result);
     assertEquals(getAvailable(result), 2);
   }
 
@@ -83,7 +82,6 @@ public class Search2ApiAdditionalTest extends AbstractRestApiTest {
     // There should be two Items in the result. One Item matches the token 'box' and the other one
     // matches the token 'something'.
 
-    System.out.println(result);
     assertEquals(getAvailable(result), 2);
   }
 
@@ -154,7 +152,6 @@ public class Search2ApiAdditionalTest extends AbstractRestApiTest {
     NameValuePair modifiedAfter = new NameValuePair("modifiedAfter", "2011-04-06");
 
     JsonNode result = doSearch((Collections.singleton(controlValue)), modifiedAfter);
-    System.out.println(result);
     assertEquals(getAvailable(result), 1);
   }
 

--- a/oeq-ts-rest-api/src/AxiosInstance.ts
+++ b/oeq-ts-rest-api/src/AxiosInstance.ts
@@ -97,14 +97,19 @@ export const PUT = <T, R>(path: string, data?: T): Promise<R> =>
  * @param path The URL path for the target POST
  * @param validator A function to perform runtime type checking against the result - typically with typescript-is
  * @param data The data to be sent in POST request
+ * @param queryParams The query parameters to send with the POST request
  */
 export const POST = <T, R>(
   path: string,
   validator: (data: unknown) => data is R,
-  data?: T
+  data?: T,
+  queryParams?: Parameters<typeof stringify>[0]
 ): Promise<R> =>
   axios
-    .post(path, data)
+    .post(path, data, {
+      params: queryParams,
+      paramsSerializer: (params) => stringify(params),
+    })
     .then(({ data }: AxiosResponse<unknown>) => {
       if (!validator(data)) {
         throw new TypeError(

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -140,11 +140,11 @@ export interface WizardControlFieldValue {
 /**
  * Body of the search2 POST request.
  */
-interface SearchBody {
+export interface SearchAdditionalParams {
   /**
    * A list of `WizardControlFieldValue` to build Advanced search criteria.
    */
-  advancedSearchCriteria: WizardControlFieldValue[];
+  advancedSearchCriteria?: WizardControlFieldValue[];
 }
 
 /**
@@ -473,19 +473,19 @@ export const search = (
  * criteria and Advanced search criteria are both supported.
  *
  * @param apiBasePath Base URI to the oEQ institution and API.
- * @param controlValues An array of `WizardControlFieldValue` which will be used to build Advanced search criteria.
- * @param params Query parameters as general search criteria.
+ * @param additionalParams Additional parameters (e.g. Advanced search criteria).
+ * @param normalParams Query parameters as general search criteria.
  */
-export const searchWithAdvControlValues = (
+export const searchWithAdditionalParams = (
   apiBasePath: string,
-  controlValues: WizardControlFieldValue[],
-  params?: SearchParams
+  additionalParams: SearchAdditionalParams,
+  normalParams?: SearchParams
 ): Promise<SearchResult<SearchResultItem>> =>
-  POST<SearchBody, SearchResult<SearchResultItemRaw>>(
+  POST<SearchAdditionalParams, SearchResult<SearchResultItemRaw>>(
     apiBasePath + SEARCH2_API_PATH,
     searchResultValidator,
-    { advancedSearchCriteria: controlValues },
-    params
+    additionalParams,
+    normalParams
   ).then(processRawSearchResult);
 
 /**

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -485,7 +485,7 @@ export const searchWithAdditionalParams = (
     apiBasePath + SEARCH2_API_PATH,
     searchResultValidator,
     additionalParams,
-    normalParams
+    processSearchParams(normalParams)
   ).then(processRawSearchResult);
 
 /**

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -17,7 +17,7 @@
  */
 import { stringify } from 'query-string';
 import { is } from 'typescript-is';
-import { GET, HEAD } from './AxiosInstance';
+import { GET, HEAD, POST } from './AxiosInstance';
 import * as Common from './Common';
 import * as Utils from './Utils';
 
@@ -120,6 +120,31 @@ export interface SearchParams extends SearchParamsBase {
    * ```
    */
   musts?: Must[];
+}
+
+export interface WizardControlFieldValue {
+  /**
+   * A list of schema nodes targeted by a Wizard control.
+   */
+  schemaNodes: string[];
+  /**
+   * Values of a Wizard control.
+   */
+  values: string[];
+  /**
+   * Currently supported Query types.
+   */
+  queryType: 'DateRange' | 'Phrase' | 'Tokenised';
+}
+
+/**
+ * Body of the search2 POST request.
+ */
+interface SearchBody {
+  /**
+   * A list of `WizardControlFieldValue` to build Advanced search criteria.
+   */
+  advancedSearchCriteria: WizardControlFieldValue[];
 }
 
 /**
@@ -416,6 +441,17 @@ const processSearchParams = (
 const SEARCH2_API_PATH = '/search2';
 const EXPORT_PATH = `${SEARCH2_API_PATH}/export`;
 
+const searchResultValidator = (
+  data: unknown
+): data is SearchResult<SearchResultItemRaw> =>
+  is<SearchResult<SearchResultItemRaw>>(data);
+
+const processRawSearchResult = (data: SearchResult<SearchResultItemRaw>) =>
+  Utils.convertDateFields<SearchResult<SearchResultItem>>(data, [
+    'createdDate',
+    'modifiedDate',
+  ]);
+
 /**
  * Communicate with REST endpoint 'search2' to do a search with specified search criteria.
  *
@@ -425,19 +461,32 @@ const EXPORT_PATH = `${SEARCH2_API_PATH}/export`;
 export const search = (
   apiBasePath: string,
   params?: SearchParams
-): Promise<SearchResult<SearchResultItem>> => {
-  return GET<SearchResult<SearchResultItemRaw>>(
+): Promise<SearchResult<SearchResultItem>> =>
+  GET<SearchResult<SearchResultItemRaw>>(
     apiBasePath + SEARCH2_API_PATH,
-    (data): data is SearchResult<SearchResultItemRaw> =>
-      is<SearchResult<SearchResultItemRaw>>(data),
+    searchResultValidator,
     processSearchParams(params)
-  ).then((data) =>
-    Utils.convertDateFields<SearchResult<SearchResultItem>>(data, [
-      'createdDate',
-      'modifiedDate',
-    ])
-  );
-};
+  ).then(processRawSearchResult);
+
+/**
+ * Communicate with the variation of REST endpoint 'search2' which handles a POST request. General search
+ * criteria and Advanced search criteria are both supported.
+ *
+ * @param apiBasePath Base URI to the oEQ institution and API.
+ * @param controlValues An array of `WizardControlFieldValue` which will be used to build Advanced search criteria.
+ * @param params Query parameters as general search criteria.
+ */
+export const searchWithAdvControlValues = (
+  apiBasePath: string,
+  controlValues: WizardControlFieldValue[],
+  params?: SearchParams
+): Promise<SearchResult<SearchResultItem>> =>
+  POST<SearchBody, SearchResult<SearchResultItemRaw>>(
+    apiBasePath + SEARCH2_API_PATH,
+    searchResultValidator,
+    { advancedSearchCriteria: controlValues },
+    params
+  ).then(processRawSearchResult);
 
 /**
  * Build a full URL for downloading a search result.

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -231,23 +231,25 @@ describe('Dead attachment handling', () => {
 });
 
 describe('search through a POST request', () => {
-  it('supports searching with a payload and query params', async () => {
-    const controlValues: OEQ.Search.WizardControlFieldValue[] = [
-      {
-        schemaNodes: ['/item/name'],
-        values: ['SearchApiTest - Crabs'],
-        queryType: 'Tokenised',
-      },
-    ];
+  it('supports searching with additional params and normal params', async () => {
+    const additionalParams: OEQ.Search.SearchAdditionalParams = {
+      advancedSearchCriteria: [
+        {
+          schemaNodes: ['/item/name'],
+          values: ['SearchApiTest - Crabs'],
+          queryType: 'Tokenised',
+        },
+      ],
+    };
 
-    const params: OEQ.Search.SearchParams = {
+    const normalParams: OEQ.Search.SearchParams = {
       status: ['LIVE'],
     };
 
-    const searchResult = await OEQ.Search.searchWithAdvControlValues(
+    const searchResult = await OEQ.Search.searchWithAdditionalParams(
       TC.API_PATH,
-      controlValues,
-      params
+      additionalParams,
+      normalParams
     );
     expect(searchResult.available).toBe(6);
   });

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -229,3 +229,26 @@ describe('Dead attachment handling', () => {
     }
   );
 });
+
+describe('search through a POST request', () => {
+  it('supports searching with a payload and query params', async () => {
+    const controlValues: OEQ.Search.WizardControlFieldValue[] = [
+      {
+        schemaNodes: ['/item/name'],
+        values: ['SearchApiTest - Crabs'],
+        queryType: 'Tokenised',
+      },
+    ];
+
+    const params: OEQ.Search.SearchParams = {
+      status: ['LIVE'],
+    };
+
+    const searchResult = await OEQ.Search.searchWithAdvControlValues(
+      TC.API_PATH,
+      controlValues,
+      params
+    );
+    expect(searchResult.available).toBe(6);
+  });
+});

--- a/react-front-end/__mocks__/WizardHelper.mock.ts
+++ b/react-front-end/__mocks__/WizardHelper.mock.ts
@@ -374,3 +374,12 @@ export const mockedFieldValueMap: FieldValueMap = new Map([
   ],
   [{ schemaNode: ["/controls/userselector"], type: "userselector" }, ["admin"]],
 ]);
+
+export const mockedAdvancedSearchCriteria: OEQ.Search.WizardControlFieldValue[] =
+  [
+    {
+      queryType: "Tokenised",
+      schemaNodes: ["/item/name"],
+      values: ["hello world"],
+    },
+  ];

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -21,14 +21,10 @@ import { pipe } from "fp-ts/function";
 import * as M from "fp-ts/Map";
 import * as NEA from "fp-ts/NonEmptyArray";
 import * as R from "fp-ts/Record";
-import {
-  controls,
-  mockedFieldValueMap,
-} from "../../../../__mocks__/WizardHelper.mock";
+import { controls } from "../../../../__mocks__/WizardHelper.mock";
 import {
   ControlTarget,
   FieldValue,
-  generateAdvancedSearchCriteria,
   render,
 } from "../../../../tsrc/components/wizard/WizardHelper";
 import { simpleMatch } from "../../../../tsrc/util/match";
@@ -139,71 +135,5 @@ describe("render()", () => {
     expect(() =>
       render(controls, M.singleton(nameEditboxTarget, [1]), logOnChange)
     ).toThrow(TypeError);
-  });
-});
-
-describe("generateAdvancedSearchCriteria()", () => {
-  it("builds SearchAdditionalParams for Wizard controls", () => {
-    const query = generateAdvancedSearchCriteria(mockedFieldValueMap);
-
-    const expectedCriteria: OEQ.Search.WizardControlFieldValue[] = [
-      {
-        queryType: "DateRange",
-        schemaNodes: ["/controls/calendar1"],
-        values: ["2021-11-01", ""],
-      },
-      {
-        queryType: "DateRange",
-        schemaNodes: ["/controls/calendar2"],
-        values: ["", "2021-11-01"],
-      },
-      {
-        queryType: "DateRange",
-        schemaNodes: ["/controls/calendar3"],
-        values: ["2021-11-01", "2021-11-11"],
-      },
-      {
-        queryType: "Phrase",
-        schemaNodes: ["/controls/checkbox"],
-        values: ["optionA", "optionB"],
-      },
-      {
-        queryType: "Tokenised",
-        schemaNodes: ["/controls/editbox"],
-        values: ["hello world"],
-      },
-      {
-        queryType: "Phrase",
-        schemaNodes: ["/controls/listbox"],
-        values: ["optionC"],
-      },
-      {
-        queryType: "Phrase",
-        schemaNodes: ["/controls/radiogroup"],
-        values: ["optionD"],
-      },
-      {
-        queryType: "Phrase",
-        schemaNodes: ["/controls/shufflebox"],
-        values: ["optionE", "optionF"],
-      },
-      {
-        queryType: "Tokenised",
-        schemaNodes: ["/controls/shufflelist"],
-        values: ["The house is nice", "walking"],
-      },
-      {
-        queryType: "Phrase",
-        schemaNodes: ["/controls/termselector"],
-        values: ["programming"],
-      },
-      {
-        queryType: "Phrase",
-        schemaNodes: ["/controls/userselector"],
-        values: ["admin"],
-      },
-    ];
-
-    expect(query).toStrictEqual(expectedCriteria);
   });
 });

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -143,7 +143,7 @@ describe("render()", () => {
 });
 
 describe("generateAdvancedSearchCriteria()", () => {
-  it("builds raw Lucene query for Wizard controls", () => {
+  it("builds SearchAdditionalParams for Wizard controls", () => {
     const query = generateAdvancedSearchCriteria(mockedFieldValueMap);
 
     const expectedCriteria: OEQ.Search.WizardControlFieldValue[] = [

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -28,10 +28,9 @@ import {
 import {
   ControlTarget,
   FieldValue,
-  generateRawLuceneQuery,
+  generateAdvancedSearchCriteria,
   render,
 } from "../../../../tsrc/components/wizard/WizardHelper";
-import * as TokenisationModule from "../../../../tsrc/modules/TokenisationModule";
 import { simpleMatch } from "../../../../tsrc/util/match";
 
 /**
@@ -143,27 +142,68 @@ describe("render()", () => {
   });
 });
 
-describe("generateRawLuceneQuery()", () => {
-  jest
-    .spyOn(TokenisationModule, "getTokensForText")
-    .mockResolvedValue({ tokens: ["hello", "world"] });
+describe("generateAdvancedSearchCriteria()", () => {
+  it("builds raw Lucene query for Wizard controls", () => {
+    const query = generateAdvancedSearchCriteria(mockedFieldValueMap);
 
-  it("builds raw Lucene query for Wizard controls", async () => {
-    const query = await generateRawLuceneQuery(mockedFieldValueMap);
+    const expectedCriteria: OEQ.Search.WizardControlFieldValue[] = [
+      {
+        queryType: "DateRange",
+        schemaNodes: ["/controls/calendar1"],
+        values: ["2021-11-01", ""],
+      },
+      {
+        queryType: "DateRange",
+        schemaNodes: ["/controls/calendar2"],
+        values: ["", "2021-11-01"],
+      },
+      {
+        queryType: "DateRange",
+        schemaNodes: ["/controls/calendar3"],
+        values: ["2021-11-01", "2021-11-11"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/checkbox"],
+        values: ["optionA", "optionB"],
+      },
+      {
+        queryType: "Tokenised",
+        schemaNodes: ["/controls/editbox"],
+        values: ["hello world"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/listbox"],
+        values: ["optionC"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/radiogroup"],
+        values: ["optionD"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/shufflebox"],
+        values: ["optionE", "optionF"],
+      },
+      {
+        queryType: "Tokenised",
+        schemaNodes: ["/controls/shufflelist"],
+        values: ["The house is nice", "walking"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/termselector"],
+        values: ["programming"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/userselector"],
+        values: ["admin"],
+      },
+    ];
 
-    const expectedQuery =
-      "(/controls/calendar1:[2021-11-01 TO *]) AND " +
-      "(/controls/calendar2:[* TO 2021-11-01]) AND " +
-      "(/controls/calendar3:[2021-11-01 TO 2021-11-11]) AND " +
-      '(/controls/checkbox:("optionA" "optionB")) AND ' +
-      "(/controls/editbox\\*:(hello world)) AND " +
-      '(/controls/listbox:"optionC") AND ' +
-      '(/controls/radiogroup:"optionD") AND ' +
-      '(/controls/shufflebox:("optionE" "optionF")) AND ' +
-      "(/controls/shufflelist\\*:(hello world)) AND " +
-      '(/controls/termselector:("programming")) AND ' +
-      '(/controls/userselector:("admin"))';
-
-    expect(query).toBe(expectedQuery);
+    expect(query).toStrictEqual(expectedCriteria);
   });
 });

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -23,6 +23,7 @@ import * as A from "fp-ts/Array";
 import { pipe } from "fp-ts/function";
 import { getAdvancedSearchDefinition } from "../../../__mocks__/AdvancedSearchModule.mock";
 import { getSearchResult } from "../../../__mocks__/SearchResult.mock";
+import { mockedAdvancedSearchCriteria } from "../../../__mocks__/WizardHelper.mock";
 import { elapsedTime, startTimer } from "../../../tsrc/util/debug";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 import {
@@ -60,7 +61,6 @@ const {
   mockSearch,
   mockSearchSettings,
   mockGetAdvancedSearchByUuid,
-  mockGetTokensForText,
 } = mockCollaborators();
 initialiseEssentialMocks({
   mockCollections,
@@ -328,21 +328,17 @@ describe("Rendering of wizard", () => {
 });
 
 describe("search with Advanced search criteria", () => {
-  it("supports searching with raw Lucene query", async () => {
+  it("supports searching with Advanced search criteria", async () => {
     jest.clearAllMocks();
-    const defaultValue = "hello world";
+    const defaultValue = ["hello world"];
     mockGetAdvancedSearchByUuid.mockResolvedValue(
-      oneEditBoxWizard(false, [defaultValue])
+      oneEditBoxWizard(false, defaultValue)
     );
     await renderAdvancedSearchPage();
 
-    // Should do a tokenisation.
-    expect(mockGetTokensForText).toHaveBeenCalledWith(defaultValue);
-
-    // The raw Lucene query should be part of the SearchOptions.
     const [searchOptions] = mockSearch.mock.calls[0];
-    expect(searchOptions.customLuceneQuery).toBe(
-      "(/item/name\\*:(hello world))"
+    expect(searchOptions.advancedSearchCriteria).toStrictEqual(
+      mockedAdvancedSearchCriteria
     );
   });
 });

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearchHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearchHelper.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { mockedFieldValueMap } from "../../../__mocks__/WizardHelper.mock";
+import { generateAdvancedSearchCriteria } from "../../../tsrc/search/AdvancedSearchHelper";
+
+describe("generateAdvancedSearchCriteria()", () => {
+  it("builds SearchAdditionalParams for Wizard controls", () => {
+    const query = generateAdvancedSearchCriteria(mockedFieldValueMap);
+
+    const expectedCriteria: OEQ.Search.WizardControlFieldValue[] = [
+      {
+        queryType: "DateRange",
+        schemaNodes: ["/controls/calendar1"],
+        values: ["2021-11-01", ""],
+      },
+      {
+        queryType: "DateRange",
+        schemaNodes: ["/controls/calendar2"],
+        values: ["", "2021-11-01"],
+      },
+      {
+        queryType: "DateRange",
+        schemaNodes: ["/controls/calendar3"],
+        values: ["2021-11-01", "2021-11-11"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/checkbox"],
+        values: ["optionA", "optionB"],
+      },
+      {
+        queryType: "Tokenised",
+        schemaNodes: ["/controls/editbox"],
+        values: ["hello world"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/listbox"],
+        values: ["optionC"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/radiogroup"],
+        values: ["optionD"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/shufflebox"],
+        values: ["optionE", "optionF"],
+      },
+      {
+        queryType: "Tokenised",
+        schemaNodes: ["/controls/shufflelist"],
+        values: ["The house is nice", "walking"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/termselector"],
+        values: ["programming"],
+      },
+      {
+        queryType: "Phrase",
+        schemaNodes: ["/controls/userselector"],
+        values: ["admin"],
+      },
+    ];
+
+    expect(query).toStrictEqual(expectedCriteria);
+  });
+});

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -510,7 +510,7 @@ const queryFactory = (
 
       return pipe(
         dateRange,
-        O.fromPredicate(A.exists(not(S.isEmpty))), // No query needed when both are undefined.
+        O.fromPredicate(A.exists(not(S.isEmpty))), // No query needed when both are empty strings.
         O.map<NEA.NonEmptyArray<string>, OEQ.Search.WizardControlFieldValue>(
           (vs) => ({
             schemaNodes: schemaNode,

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -32,9 +32,7 @@ import * as S from "fp-ts/string";
 import * as T from "fp-ts/Task";
 import * as TE from "fp-ts/TaskEither";
 import * as React from "react";
-import { getTokensForText } from "../../modules/TokenisationModule";
 import { OrdAsIs } from "../../util/Ord";
-import { pfTernary } from "../../util/pointfree";
 import { WizardCalendar } from "./WizardCalendar";
 import { WizardCheckBoxGroup } from "./WizardCheckBoxGroup";
 import { WizardEditBox } from "./WizardEditBox";
@@ -481,193 +479,86 @@ export const extractDefaultValues = (
   );
 };
 
-const AND = " AND ";
-
-/**
- * Create the fieldname matching the format of the fields used in the oEQ lucene index. Specifically, for any
- * schema node which is tokenised, there are two fields. One which contains full raw values, and another which
- * has gone through the analyzer (and tokenizer). This name of this second type of has an asteriks (`*`) suffix.
- *
- * This function then looks after adding this special suffix when required based on the `isTokenised` flag.
- */
-const fieldName = (field: string, isTokenised = false): string =>
-  `${field}${isTokenised ? "\\*" : ""}`;
-
-/**
- * Given an array of values, wrap each value by a pair of double quotes. This can make sure if a value is a phrase,
- * the phrase will not get separated into multiple words on server.
- */
-const fieldValue = (value: ControlValue): string[] =>
-  value.map((v) => `"${v}"`);
-
-// Function to create a Task which builds a raw Lucene query for each control type.
+// Function to create an Advanced search criterion for each control type.
 const queryFactory = (
   { type, schemaNode, isValueTokenised }: ControlTarget,
   values: ControlValue
-): TE.TaskEither<string, string> => {
-  // Values processed to to have each one wrapped by double quotes. However, Calendar and those doing
-  // tokenisation should not use this.
-  const _values = fieldValue(values);
+): OEQ.Search.WizardControlFieldValue | undefined => {
+  const buildTextFieldQuery = (): OEQ.Search.WizardControlFieldValue => ({
+    schemaNodes: schemaNode,
+    values: getStringArrayControlValue(values),
+    queryType: isValueTokenised ? "Tokenised" : "Phrase",
+  });
 
-  // Function to build a query string containing only one 'field:value' for one path.
-  const singleValueQueryBuilder = (
-    path: string,
-    values: ControlValue
-  ): string => `${path}:${values[0]}`;
-
-  // Function to build and join multiple 'field:value' into one query string for one path.
-  const multipleValueQueryBuilder = (
-    path: string,
-    values: ControlValue
-  ): string => `${path}:(${values.join(" ")})`; // Put all words in one group and separate each word by a whitespace.
-
-  // Function to build query strings for multiple paths and join all into one query.
-  const buildQueries = (
-    schemaNode: string[],
-    values: ControlValue,
-    builder: (p: string, v: ControlValue) => string = singleValueQueryBuilder
-  ): string =>
-    `(${schemaNode
-      .map((n) => builder(fieldName(n, isValueTokenised), values))
-      .join(" OR ")})`;
-
-  const factory = async (): Promise<string> => {
-    switch (type) {
-      case "calendar":
-        // If the provided date is undefined or is an empty string, use `*` instead.
-        const processDateString = (d: string | undefined): string =>
-          pipe(
-            O.fromNullable(d),
-            O.filter(not(S.isEmpty)),
-            O.getOrElse(() => "*")
-          );
-
-        const dateRangeQueryBuilder = (
-          path: string,
-          [startDate, endDate]: ControlValue
-        ) => `${path}:[${startDate} TO ${endDate}]`;
-
-        // Validate the Calendar value type.
-        const dateRange: NEA.NonEmptyArray<string> = pipe(
-          values,
+  switch (type) {
+    case "calendar":
+      // Validate the Calendar value type.
+      const dateRange: NEA.NonEmptyArray<string> = pipe(
+        values,
+        E.fromPredicate(
+          isStringArray,
+          () => "Calendar must have at least one value"
+        ),
+        E.chain(
           E.fromPredicate(
-            isStringArray,
-            () => "Calendar must have at least one value"
-          ),
-          E.chain(
-            E.fromPredicate(
-              (dates) => A.size(dates) <= 2,
-              () => "Calendar cannot have more than 2 values"
-            )
-          ),
-          E.fold((e) => {
-            throw new TypeError(e);
-          }, identity)
-        );
-
-        return pipe(
-          dateRange,
-          E.fromPredicate(A.exists(not(S.isEmpty)), () => ""), // No query needed when both are undefined so return an empty string.
-          E.map(A.map(processDateString)),
-          E.fold(identity, (dates) =>
-            buildQueries(schemaNode, dates, dateRangeQueryBuilder)
+            (dates) => A.size(dates) <= 2,
+            () => "Calendar cannot have more than 2 values"
           )
-        );
-      case "checkboxgroup":
-        return buildQueries(schemaNode, _values, multipleValueQueryBuilder);
-      case "editbox":
-        const { tokens } = await getTokensForText(`${values[0]}`);
-        return buildQueries(schemaNode, tokens, multipleValueQueryBuilder);
-      case "html":
-        return "";
-      case "listbox":
-        return buildQueries(schemaNode, _values);
-      case "radiogroup":
-        return buildQueries(schemaNode, _values);
-      case "shufflebox":
-        return buildQueries(schemaNode, _values, multipleValueQueryBuilder);
-      case "shufflelist":
-        const getShuffleTokens = async () => {
-          const { tokens } = await getTokensForText(values.join(" "));
-          return tokens;
-        };
+        ),
+        E.fold((e) => {
+          throw new TypeError(e);
+        }, identity)
+      );
 
-        return buildQueries(
-          schemaNode,
-          isValueTokenised ? await getShuffleTokens() : _values,
-          multipleValueQueryBuilder
-        );
-      case "termselector":
-        return buildQueries(schemaNode, _values, multipleValueQueryBuilder);
-      case "userselector":
-        return buildQueries(schemaNode, _values, multipleValueQueryBuilder);
-      default:
-        return absurd(type);
-    }
-  };
-
-  return TE.tryCatch(
-    factory,
-    (e) =>
-      `Failed to build Lucene query or path ${schemaNode.join()} (control type: ${type}) due to error: ${e}`
-  );
+      return pipe(
+        dateRange,
+        O.fromPredicate(A.exists(not(S.isEmpty))), // No query needed when both are undefined.
+        O.map<NEA.NonEmptyArray<string>, OEQ.Search.WizardControlFieldValue>(
+          (vs) => ({
+            schemaNodes: schemaNode,
+            values: vs,
+            queryType: "DateRange",
+          })
+        ),
+        O.toUndefined
+      );
+    case "checkboxgroup":
+      return buildTextFieldQuery();
+    case "editbox":
+      return buildTextFieldQuery();
+    case "html":
+      return undefined;
+    case "listbox":
+      return buildTextFieldQuery();
+    case "radiogroup":
+      return buildTextFieldQuery();
+    case "shufflebox":
+      return buildTextFieldQuery();
+    case "shufflelist":
+      return buildTextFieldQuery();
+    case "termselector":
+      return buildTextFieldQuery();
+    case "userselector":
+      return buildTextFieldQuery();
+    default:
+      return absurd(type);
+  }
 };
 
 /**
- * Function to build a raw Lucene query string based on the values of Wizard controls.
- * Since some controls support tokenisation, the function will send a request to server
- * to retrieve tokens. As a result, this function returns a Promise of string eventually.
+ * Function to build Advanced search criteria based on Wizard controls' schema nodes and values.
  *
  * @param m Map which provides ControlTarget and ControlValue.
  */
-export const generateRawLuceneQuery = async (
+export const generateAdvancedSearchCriteria = (
   m: FieldValueMap
-): Promise<string | undefined> => {
-  // Because it's likely to have multiple errors when building the whole query,
-  // lift `queryFactory` so that it returns a TaskEither where left is an array of string.
-  const liftedQueryFactory = (
-    t: ControlTarget,
-    v: ControlValue
-  ): TE.TaskEither<string[], string> =>
-    pipe(
-      queryFactory(t, v),
-      TE.mapLeft((a) => [a])
-    );
-
-  // A task to build and return raw Lucene queries for all the controls,
-  // or throw errors.
-  const queryTask = pipe(
+): OEQ.Search.WizardControlFieldValue[] =>
+  pipe(
     m,
     M.filter<ControlValue>(isControlValueNonEmpty),
-    M.collect<ControlTarget>(OrdAsIs)(liftedQueryFactory),
-    // Convert an array of TE to an TE where left and right are both string[].
-    A.sequence(
-      TE.getApplicativeTaskValidation(
-        T.ApplicativeSeq,
-        A.getSemigroup<string>()
-      )
-    ),
-    T.map(
-      flow(
-        E.fold((e) => {
-          throw new Error(e.join());
-        }, identity)
-      )
+    M.collect<ControlTarget>(OrdAsIs)(queryFactory),
+    A.filter(
+      (criterion): criterion is OEQ.Search.WizardControlFieldValue =>
+        criterion !== undefined
     )
   );
-
-  // Now run the task.
-  const result: string[] = await queryTask();
-  // Remove any sub query that is just an empty string and then join the remaining with `AND`.
-  const queries: string = result.filter(isNonEmptyString).join(AND);
-
-  // If the final query is still an empty string, return undefined instead.
-  return pipe(
-    queries,
-    pfTernary<string, string | undefined>(
-      isNonEmptyString,
-      identity,
-      () => undefined
-    )
-  );
-};

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -29,8 +29,6 @@ import { Refinement } from "fp-ts/Refinement";
 import { first } from "fp-ts/Semigroup";
 import * as SET from "fp-ts/Set";
 import * as S from "fp-ts/string";
-import * as T from "fp-ts/Task";
-import * as TE from "fp-ts/TaskEither";
 import * as React from "react";
 import { OrdAsIs } from "../../util/Ord";
 import { WizardCalendar } from "./WizardCalendar";

--- a/react-front-end/tsrc/search/AdvancedSearchHelper.ts
+++ b/react-front-end/tsrc/search/AdvancedSearchHelper.ts
@@ -1,0 +1,152 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as OEQ from "@openequella/rest-api-client";
+import * as A from "fp-ts/Array";
+import * as E from "fp-ts/Either";
+import { absurd, identity, pipe } from "fp-ts/function";
+import * as M from "fp-ts/Map";
+import * as NEA from "fp-ts/NonEmptyArray";
+import * as O from "fp-ts/Option";
+import { not } from "fp-ts/Predicate";
+import * as S from "fp-ts/string";
+import {
+  ControlTarget,
+  ControlValue,
+  extractDefaultValues,
+  FieldValueMap,
+  getStringArrayControlValue,
+  isControlValueNonEmpty,
+  isStringArray,
+} from "../components/wizard/WizardHelper";
+import { OrdAsIs } from "../util/Ord";
+import { Action as SearchPageModeAction } from "./SearchPageModeReducer";
+
+/**
+ * Function to initialise an Advanced search. There are two tasks done here.
+ *
+ * 1. Confirm the initial FieldValueMap. If there is one, use it. Otherwise, build a new one by extracting the default
+ * Wizard control values.
+ *
+ * 2. Update the state of SearchPageModeReducer to `initialiseAdvSearch`;
+ *
+ * @param advancedSearchDefinition The initial Advanced search definition.
+ * @param dispatch The `dispatch` provided by SearchPageModeReducer.
+ * @param currentFieldValue FieldValueMap that may already exist.
+ */
+export const initialiseAdvancedSearch = (
+  advancedSearchDefinition: OEQ.AdvancedSearch.AdvancedSearchDefinition,
+  dispatch: (action: SearchPageModeAction) => void,
+  currentFieldValue?: FieldValueMap
+): FieldValueMap => {
+  const initialQueryValues =
+    currentFieldValue ??
+    extractDefaultValues(advancedSearchDefinition.controls);
+
+  dispatch({
+    type: "initialiseAdvSearch",
+    selectedAdvSearch: advancedSearchDefinition,
+    initialQueryValues,
+  });
+
+  return initialQueryValues;
+};
+
+// Function to create an Advanced search criterion for each control type.
+const queryFactory = (
+  { type, schemaNode, isValueTokenised }: ControlTarget,
+  values: ControlValue
+): OEQ.Search.WizardControlFieldValue | undefined => {
+  const buildTextFieldQuery = (): OEQ.Search.WizardControlFieldValue => ({
+    schemaNodes: schemaNode,
+    values: getStringArrayControlValue(values),
+    queryType: isValueTokenised ? "Tokenised" : "Phrase",
+  });
+
+  switch (type) {
+    case "calendar":
+      // Validate the Calendar value type.
+      const dateRange: NEA.NonEmptyArray<string> = pipe(
+        values,
+        E.fromPredicate(
+          isStringArray,
+          () => "Calendar must have at least one value"
+        ),
+        E.chain(
+          E.fromPredicate(
+            (dates) => A.size(dates) <= 2,
+            () => "Calendar cannot have more than 2 values"
+          )
+        ),
+        E.fold((e) => {
+          throw new TypeError(e);
+        }, identity)
+      );
+
+      return pipe(
+        dateRange,
+        O.fromPredicate(A.exists(not(S.isEmpty))), // No query needed when both are empty strings.
+        O.map<NEA.NonEmptyArray<string>, OEQ.Search.WizardControlFieldValue>(
+          (vs) => ({
+            schemaNodes: schemaNode,
+            values: vs,
+            queryType: "DateRange",
+          })
+        ),
+        O.toUndefined
+      );
+    case "checkboxgroup":
+      return buildTextFieldQuery();
+    case "editbox":
+      return buildTextFieldQuery();
+    case "html":
+      return undefined;
+    case "listbox":
+      return buildTextFieldQuery();
+    case "radiogroup":
+      return buildTextFieldQuery();
+    case "shufflebox":
+      return buildTextFieldQuery();
+    case "shufflelist":
+      return buildTextFieldQuery();
+    case "termselector":
+      return buildTextFieldQuery();
+    case "userselector":
+      return buildTextFieldQuery();
+    default:
+      return absurd(type);
+  }
+};
+
+/**
+ * Function to build Advanced search criteria based on Wizard controls' schema nodes and values.
+ *
+ * @param m Map which provides ControlTarget and ControlValue.
+ */
+export const generateAdvancedSearchCriteria = (
+  m: FieldValueMap
+): OEQ.Search.WizardControlFieldValue[] =>
+  pipe(
+    m,
+    M.filter<ControlValue>(isControlValueNonEmpty),
+    M.collect<ControlTarget>(OrdAsIs)(queryFactory),
+    A.filter(
+      (criterion): criterion is OEQ.Search.WizardControlFieldValue =>
+        criterion !== undefined
+    )
+  );

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -39,7 +39,6 @@ import MessageInfo, { MessageInfoVariant } from "../components/MessageInfo";
 import type { FieldValueMap } from "../components/wizard/WizardHelper";
 import {
   ControlValue,
-  generateAdvancedSearchCriteria,
   isControlValueNonEmpty,
   isNonEmptyString,
 } from "../components/wizard/WizardHelper";
@@ -90,6 +89,10 @@ import SearchBar from "../search/components/SearchBar";
 import type { DateRange } from "../util/Date";
 import { languageStrings } from "../util/langstrings";
 import { OrdAsIs } from "../util/Ord";
+import {
+  generateAdvancedSearchCriteria,
+  initialiseAdvancedSearch,
+} from "./AdvancedSearchHelper";
 import { AdvancedSearchPanel } from "./components/AdvancedSearchPanel";
 import { AdvancedSearchSelector } from "./components/AdvancedSearchSelector";
 import { AuxiliarySearchSelector } from "./components/AuxiliarySearchSelector";
@@ -114,7 +117,6 @@ import {
   generateSearchPageOptionsFromQueryString,
   getPartialSearchOptions,
   getRawModeFromStorage,
-  initialiseAdvancedSearch,
   SearchPageOptions,
   writeRawModeToStorage,
 } from "./SearchPageHelper";

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -39,7 +39,6 @@ import {
 import {
   extractDefaultValues,
   FieldValueMap,
-  generateRawLuceneQuery,
 } from "../components/wizard/WizardHelper";
 import { routes } from "../mainui/routes";
 import {
@@ -466,14 +465,12 @@ export const buildOpenSummaryPageHandler = (
   );
 
 /**
- * Function to initialise an Advanced search. There are three tasks done here.
+ * Function to initialise an Advanced search. There are two tasks done here.
  *
  * 1. Confirm the initial FieldValueMap. If there is one, use it. Otherwise, build a new one by extracting the default
  * Wizard control values.
  *
  * 2. Update the state of SearchPageModeReducer to `initialiseAdvSearch`;
- *
- * 3. Build and return the initial raw Lucene query.
  *
  * @param advancedSearchDefinition The initial Advanced search definition.
  * @param dispatch The `dispatch` provided by SearchPageModeReducer.
@@ -483,7 +480,7 @@ export const initialiseAdvancedSearch = (
   advancedSearchDefinition: OEQ.AdvancedSearch.AdvancedSearchDefinition,
   dispatch: (action: SearchPageModeAction) => void,
   currentFieldValue?: FieldValueMap
-): Promise<string | undefined> => {
+): FieldValueMap => {
   const initialQueryValues =
     currentFieldValue ??
     extractDefaultValues(advancedSearchDefinition.controls);
@@ -494,5 +491,5 @@ export const initialiseAdvancedSearch = (
     initialQueryValues,
   });
 
-  return generateRawLuceneQuery(initialQueryValues);
+  return initialQueryValues;
 };

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -36,10 +36,7 @@ import {
   Union,
   Unknown,
 } from "runtypes";
-import {
-  extractDefaultValues,
-  FieldValueMap,
-} from "../components/wizard/WizardHelper";
+import type { FieldValueMap } from "../components/wizard/WizardHelper";
 import { routes } from "../mainui/routes";
 import {
   clearDataFromLocalStorage,
@@ -69,7 +66,6 @@ import { findUserById } from "../modules/UserModule";
 import { DateRange, isDate } from "../util/Date";
 import { simpleMatch } from "../util/match";
 import { History } from "history";
-import { Action as SearchPageModeAction } from "./SearchPageModeReducer";
 
 /**
  * This helper is intended to assist with processing related to the Presentation Layer -
@@ -463,33 +459,3 @@ export const buildOpenSummaryPageHandler = (
       })
     )
   );
-
-/**
- * Function to initialise an Advanced search. There are two tasks done here.
- *
- * 1. Confirm the initial FieldValueMap. If there is one, use it. Otherwise, build a new one by extracting the default
- * Wizard control values.
- *
- * 2. Update the state of SearchPageModeReducer to `initialiseAdvSearch`;
- *
- * @param advancedSearchDefinition The initial Advanced search definition.
- * @param dispatch The `dispatch` provided by SearchPageModeReducer.
- * @param currentFieldValue FieldValueMap that may already exist.
- */
-export const initialiseAdvancedSearch = (
-  advancedSearchDefinition: OEQ.AdvancedSearch.AdvancedSearchDefinition,
-  dispatch: (action: SearchPageModeAction) => void,
-  currentFieldValue?: FieldValueMap
-): FieldValueMap => {
-  const initialQueryValues =
-    currentFieldValue ??
-    extractDefaultValues(advancedSearchDefinition.controls);
-
-  dispatch({
-    type: "initialiseAdvSearch",
-    selectedAdvSearch: advancedSearchDefinition,
-    initialQueryValues,
-  });
-
-  return initialQueryValues;
-};


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for building Advanced search criteria on both REST Module and React front end.

The key changes are:

1. Add a new function to execute a search with additional params through a POST request.
2. Update a new field to `SearchOptions` to represent Advanced search criteria.
3. Update `SearchModule` to control whether to search through a POST or GET.
4. Update `WizardHelper` to support building the criteria.
5. Update `SearchPage` and its helper for the integration.


I also dropped some of the code written previously to support this feature.

https://user-images.githubusercontent.com/47203811/143174597-5367fcd9-99ed-4d2a-86fc-ba60664dbd67.mp4


