### PR TITLE
feat(frontend): Set Advanced Search criteria panel to be open when first selecting an advanced search

### DIFF
--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -322,7 +322,6 @@ describe("Rendering of wizard", () => {
 
     // Click clear button
     await clickClearButton(container);
-    togglePanel();
     expect(pipe(getCurrentLabelsAndValues(), filterEmptyValues)).toEqual([]);
   });
 });

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -235,7 +235,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
   //set true to keep panel open after search
-  //only worked for one time,
+  //only work for once,
   const keepAdvSearchPanelOpenOnceAfterSearch = useRef<boolean>(false);
 
   const { appErrorHandler } = useContext(AppRenderErrorContext);

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -234,9 +234,9 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const [alreadyDownloaded, setAlreadyDownloaded] = useState<boolean>(false);
   const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
-  //set true to keep panel open after search
+  //set true to keep panel toggle state after search
   //only work for once,
-  const keepAdvSearchPanelOpenOnceAfterSearch = useRef<boolean>(false);
+  const keepAdvSearchPanelToggleOnceAfterSearch = useRef<boolean>(false);
 
   const { appErrorHandler } = useContext(AppRenderErrorContext);
   const searchPageErrorHandler = useCallback(
@@ -316,9 +316,13 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
               ? await initialiseAdvancedSearch(
                   advancedSearchDefinition,
                   searchPageModeDispatch,
+                  true,
                   searchPageOptions.advFieldValue
                 )
               : undefined;
+
+          //initialiseAdvancedSearch will finally trigger a search
+          keepAdvSearchPanelToggleOnceAfterSearch.current = true;
 
           // This is the SearchPageOptions for the first searching, not the one created in the first rendering.
           const initialSearchPageOptions = pipe(
@@ -420,7 +424,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
       if (
         searchPageModeState.mode === "advSearch" &&
-        !keepAdvSearchPanelOpenOnceAfterSearch.current
+        !keepAdvSearchPanelToggleOnceAfterSearch.current
       ) {
         searchPageModeDispatch({
           type: "hideAdvSearchPanel",
@@ -428,7 +432,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
       }
 
       //only used for once, set to false.
-      keepAdvSearchPanelOpenOnceAfterSearch.current = false;
+      keepAdvSearchPanelToggleOnceAfterSearch.current = false;
 
       setSearchPageOptions(state.options);
       (async () => {
@@ -748,7 +752,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   };
 
   const handleClearAdvancedSearch = async () => {
-    keepAdvSearchPanelOpenOnceAfterSearch.current = true;
+    keepAdvSearchPanelToggleOnceAfterSearch.current = true;
     await handleSubmitAdvancedSearch(new Map());
   };
 

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -234,6 +234,10 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const [alreadyDownloaded, setAlreadyDownloaded] = useState<boolean>(false);
   const exportLinkRef = useRef<HTMLAnchorElement>(null);
 
+  //set true to keep panel open after search
+  //only worked for one time,
+  const keepAdvSearchPanelOpenOnceAfterSearch = useRef<boolean>(false);
+
   const { appErrorHandler } = useContext(AppRenderErrorContext);
   const searchPageErrorHandler = useCallback(
     (error: Error) => {
@@ -414,12 +418,17 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
         }
       );
 
-      // todo: do not hide the panel for the first search.
-      if (searchPageModeState.mode === "advSearch") {
+      if (
+        searchPageModeState.mode === "advSearch" &&
+        !keepAdvSearchPanelOpenOnceAfterSearch.current
+      ) {
         searchPageModeDispatch({
           type: "hideAdvSearchPanel",
         });
       }
+
+      //only used for once, set to false.
+      keepAdvSearchPanelOpenOnceAfterSearch.current = false;
 
       setSearchPageOptions(state.options);
       (async () => {
@@ -738,6 +747,11 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     pipe(await task(), E.fold(searchPageErrorHandler, search));
   };
 
+  const handleClearAdvancedSearch = async () => {
+    keepAdvSearchPanelOpenOnceAfterSearch.current = true;
+    await handleSubmitAdvancedSearch(new Map());
+  };
+
   /**
    * Determines if any collapsible filters have been modified from their defaults
    */
@@ -1040,7 +1054,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
                     wizardControls={searchPageModeState.definition.controls}
                     values={searchPageModeState.queryValues}
                     onSubmit={handleSubmitAdvancedSearch}
-                    onClear={() => handleSubmitAdvancedSearch(new Map())}
+                    onClear={handleClearAdvancedSearch}
                     onClose={() =>
                       searchPageModeDispatch({ type: "hideAdvSearchPanel" })
                     }

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -20,7 +20,7 @@ import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
-import { Location } from "history";
+import { History, Location } from "history";
 import { pick } from "lodash";
 import {
   Array as RuntypeArray,
@@ -69,7 +69,6 @@ import {
 import { findUserById } from "../modules/UserModule";
 import { DateRange, isDate } from "../util/Date";
 import { simpleMatch } from "../util/match";
-import { History } from "history";
 import { Action as SearchPageModeAction } from "./SearchPageModeReducer";
 
 /**
@@ -482,15 +481,16 @@ export const buildOpenSummaryPageHandler = (
 export const initialiseAdvancedSearch = (
   advancedSearchDefinition: OEQ.AdvancedSearch.AdvancedSearchDefinition,
   dispatch: (action: SearchPageModeAction) => void,
+  isAdvSearchPanelOpen: boolean,
   currentFieldValue?: FieldValueMap
 ): Promise<string | undefined> => {
   const initialQueryValues =
     currentFieldValue ??
     extractDefaultValues(advancedSearchDefinition.controls);
-
   dispatch({
     type: "initialiseAdvSearch",
     selectedAdvSearch: advancedSearchDefinition,
+    isAdvSearchPanelOpen: isAdvSearchPanelOpen,
     initialQueryValues,
   });
 

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -39,6 +39,7 @@ export type Action =
       type: "initialiseAdvSearch";
       selectedAdvSearch: OEQ.AdvancedSearch.AdvancedSearchDefinition;
       initialQueryValues: FieldValueMap;
+      isAdvSearchPanelOpen: boolean;
     }
   | {
       type: "toggleAdvSearchPanel";
@@ -98,7 +99,7 @@ export const searchPageModeReducer = (state: State, action: Action): State => {
       return {
         mode: "advSearch",
         definition,
-        isAdvSearchPanelOpen: false,
+        isAdvSearchPanelOpen: action.isAdvSearchPanelOpen,
         queryValues: action.initialQueryValues,
       };
     case "toggleAdvSearchPanel":

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -99,6 +99,11 @@ export const AdvancedSearchPanel = ({
     [currentValues, setCurrentValues]
   );
 
+  const onClearHandler = (): void => {
+    setCurrentValues(new Map());
+    onClear();
+  };
+
   const idPrefix = "advanced-search-panel";
   return (
     <Card id={idPrefix}>
@@ -146,7 +151,11 @@ export const AdvancedSearchPanel = ({
         >
           {languageStrings.common.action.search}
         </Button>
-        <Button id={`${idPrefix}-clearBtn`} onClick={onClear} color="secondary">
+        <Button
+          id={`${idPrefix}-clearBtn`}
+          onClick={onClearHandler}
+          color="secondary"
+        >
           {languageStrings.common.action.clear}
         </Button>
       </CardActions>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
It's based on #3595 

Since #3595 is still in progress, it may need a big change later.

https://user-images.githubusercontent.com/92769668/143371258-08fb7ab5-225c-4a0c-8187-e66528687af6.mp4

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
