### PR TITLE
Add support to the Wizard User Selector for filtering by group

### DIFF
--- a/react-front-end/__mocks__/GroupModule.mock.ts
+++ b/react-front-end/__mocks__/GroupModule.mock.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const groups: OEQ.UserQuery.GroupDetails[] = [
+  {
+    id: "3d96df92-4d0b-496f-b865-9f1ad4a67d8d",
+    name: "Teachers",
+  },
+  {
+    id: "d0265a33-8f89-4cea-8a36-45fd3c4cf5a1",
+    name: "Systems Administrators",
+  },
+  {
+    id: "e810bee1-f2da-4145-8bc3-dc6fec827429",
+    name: "Content Administrators",
+  },
+];
+
+/**
+ * A mock of `GroupModule.resolveGroups` which simply looks up the provided ids in `groups` within
+ * `GroupModule.mock.ts`
+ *
+ * @param ids group UUIDs which are in the mocked list of groups
+ */
+export const resolveGroups = async (
+  ids: ReadonlyArray<string>
+): Promise<OEQ.UserQuery.GroupDetails[]> => {
+  const result = groups.filter(({ id }) => ids.includes(id));
+  return Promise.resolve(result);
+};

--- a/react-front-end/__mocks__/UserModule.mock.ts
+++ b/react-front-end/__mocks__/UserModule.mock.ts
@@ -17,6 +17,42 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 
+/**
+ * A list of users to test with, deliberately out of order. Names are randomly generated.
+ */
+export const users: OEQ.UserQuery.UserDetails[] = [
+  {
+    id: "680f5eb7-22e2-4ab6-bcea-25205165e36e",
+    username: "user200",
+    firstName: "Fabienne",
+    lastName: "Hobson",
+  },
+  {
+    id: "cda09b86-3662-46bd-b60e-4bce89efba7a",
+    username: "user100",
+    firstName: "Racheal",
+    lastName: "Carlyle",
+  },
+  {
+    id: "97254515-6e32-48e9-ba65-5b5c6aa182a6",
+    username: "user400",
+    firstName: "Ronny",
+    lastName: "Southgate",
+  },
+  {
+    id: "8db50158-757d-44f3-8ccf-7b2e0a3a6405",
+    username: "user300",
+    firstName: "Yasmin",
+    lastName: "Day",
+  },
+  {
+    id: "3f25f543-7231-46f4-8f3b-aaccc8fcf52a",
+    username: "admin999",
+    firstName: "Wat",
+    lastName: "Swindlehurst",
+  },
+];
+
 export const getCurrentUserMock: OEQ.LegacyContent.CurrentUserDetails = {
   id: "test",
   username: "test",
@@ -29,3 +65,13 @@ export const getCurrentUserMock: OEQ.LegacyContent.CurrentUserDetails = {
   menuGroups: [],
   canDownloadSearchResult: true,
 };
+
+/**
+ * Helper function to inject into component for user retrieval by an array of ids.
+ *
+ * @param ids A list of user IDs to lookup, should be one of those in `users`
+ */
+export const resolveUsersProvider = async (
+  ids: ReadonlyArray<string>
+): Promise<OEQ.UserQuery.UserDetails[]> =>
+  Promise.resolve(users.filter(({ id }) => ids.includes(id)));

--- a/react-front-end/__mocks__/UserSearch.mock.ts
+++ b/react-front-end/__mocks__/UserSearch.mock.ts
@@ -16,42 +16,7 @@
  * limitations under the License.
  */
 import * as OEQ from "@openequella/rest-api-client";
-
-/**
- * A list of users to test with, deliberately out of order. Names are randomly generated.
- */
-export const users: OEQ.UserQuery.UserDetails[] = [
-  {
-    id: "680f5eb7-22e2-4ab6-bcea-25205165e36e",
-    username: "user200",
-    firstName: "Fabienne",
-    lastName: "Hobson",
-  },
-  {
-    id: "cda09b86-3662-46bd-b60e-4bce89efba7a",
-    username: "user100",
-    firstName: "Racheal",
-    lastName: "Carlyle",
-  },
-  {
-    id: "97254515-6e32-48e9-ba65-5b5c6aa182a6",
-    username: "user400",
-    firstName: "Ronny",
-    lastName: "Southgate",
-  },
-  {
-    id: "8db50158-757d-44f3-8ccf-7b2e0a3a6405",
-    username: "user300",
-    firstName: "Yasmin",
-    lastName: "Day",
-  },
-  {
-    id: "3f25f543-7231-46f4-8f3b-aaccc8fcf52a",
-    username: "admin999",
-    firstName: "Wat",
-    lastName: "Swindlehurst",
-  },
-];
+import { users } from "./UserModule.mock";
 
 /**
  * Helper function to inject into component for user retrieval.
@@ -67,13 +32,3 @@ export const userDetailsProvider = async (
     query ? users.filter((u) => u.username.search(query) === 0) : users
   );
 };
-
-/**
- * Helper function to inject into component for user retrieval by an array of ids.
- *
- * @param ids A list of user IDs to lookup, should be one of those in `users`
- */
-export const resolveUsersProvider = async (
-  ids: ReadonlyArray<string>
-): Promise<OEQ.UserQuery.UserDetails[]> =>
-  Promise.resolve(users.filter(({ id }) => ids.includes(id)));

--- a/react-front-end/__mocks__/searchOptions.mock.ts
+++ b/react-front-end/__mocks__/searchOptions.mock.ts
@@ -21,7 +21,7 @@ import {
   SearchPageOptions,
 } from "../tsrc/search/SearchPageHelper";
 import { getMimeTypeFilters } from "./MimeTypeFilter.mock";
-import { users } from "./UserSearch.mock";
+import * as UserModuleMock from "./UserModule.mock";
 
 export const allSearchPageOptions: SearchPageOptions = {
   rowsPerPage: 10,
@@ -40,7 +40,7 @@ export const allSearchPageOptions: SearchPageOptions = {
     start: new Date("2020-05-26T13:24:00.889+10:00"),
     end: new Date("2020-05-27T13:24:00.889+10:00"),
   },
-  owner: users[0],
+  owner: UserModuleMock.users[0],
   mimeTypes: ["Image/png", "Image/jpeg", "Application/pdf"],
   mimeTypeFilters: getMimeTypeFilters,
   displayMode: "list",

--- a/react-front-end/__stories__/components/UserSearch.stories.tsx
+++ b/react-front-end/__stories__/components/UserSearch.stories.tsx
@@ -15,22 +15,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Meta } from "@storybook/react";
+import { Meta, Story } from "@storybook/react";
+import * as React from "react";
 import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
 import UserSearch, { UserSearchProps } from "../../tsrc/components/UserSearch";
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { number } from "@storybook/addon-knobs";
 
 export default {
-  title: "UserSearch",
+  title: "component/UserSearch",
   component: UserSearch,
+  argTypes: {
+    onSelect: {
+      action: "onSelect called",
+    },
+  },
 } as Meta<UserSearchProps>;
 
-export const DefaultState = () => (
-  <UserSearch
-    listHeight={number("List Height", 150)}
-    onSelect={action("onSelect")}
-    userListProvider={UserSearchMock.userDetailsProvider}
-  />
+export const Default: Story<UserSearchProps> = (args) => (
+  <UserSearch {...args} />
 );
+Default.args = {
+  listHeight: 150,
+  userListProvider: UserSearchMock.userDetailsProvider,
+};
+
+export const GroupFilter: Story<UserSearchProps> = (args) => (
+  <UserSearch {...args} />
+);
+GroupFilter.args = {
+  ...Default.args,
+  groupFilter: new Set([
+    "35e0b3dc-f243-44be-9f9d-75b094c08a6c",
+    "a47150a6-6d28-4de1-ba12-36fe440f5132",
+  ]),
+};

--- a/react-front-end/__stories__/components/UserSearch.stories.tsx
+++ b/react-front-end/__stories__/components/UserSearch.stories.tsx
@@ -17,6 +17,7 @@
  */
 import { Meta, Story } from "@storybook/react";
 import * as React from "react";
+import * as GroupModuleMock from "../../__mocks__/GroupModule.mock";
 import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
 import UserSearch, { UserSearchProps } from "../../tsrc/components/UserSearch";
 
@@ -43,8 +44,6 @@ export const GroupFilter: Story<UserSearchProps> = (args) => (
 );
 GroupFilter.args = {
   ...Default.args,
-  groupFilter: new Set([
-    "35e0b3dc-f243-44be-9f9d-75b094c08a6c",
-    "a47150a6-6d28-4de1-ba12-36fe440f5132",
-  ]),
+  groupFilter: new Set(GroupModuleMock.groups.map(({ id }) => id)),
+  resolveGroupsProvider: GroupModuleMock.resolveGroups,
 };

--- a/react-front-end/__stories__/components/wizard/WizardUserSelector.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardUserSelector.stories.tsx
@@ -17,6 +17,8 @@
  */
 import { Meta, Story } from "@storybook/react";
 import * as React from "react";
+import * as UserModuleMock from "../../../__mocks__/UserModule.mock";
+import { users } from "../../../__mocks__/UserModule.mock";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import {
   WizardUserSelector,
@@ -43,7 +45,7 @@ NoUsers.args = {
   description: "A user selector (single selection) with no users specified",
   users: new Set<string>([]),
   userListProvider: UserSearchMock.userDetailsProvider,
-  resolveUsersProvider: UserSearchMock.resolveUsersProvider,
+  resolveUsersProvider: UserModuleMock.resolveUsersProvider,
 };
 
 export const WithUsers: Story<WizardUserSelectorProps> = (args) => (
@@ -53,10 +55,7 @@ WithUsers.args = {
   ...NoUsers.args,
   description:
     "A User Selector (multi selection) with users specified - they should be nicely sorted",
-  users: new Set<string>([
-    UserSearchMock.users[1].id,
-    UserSearchMock.users[2].id,
-  ]),
+  users: new Set<string>([users[1].id, users[2].id]),
   multiple: true,
 };
 
@@ -68,6 +67,7 @@ WithGroupFilter.args = {
   description:
     "A user selector (single selection) with no users specified but with a group filter active",
   groupFilter: GroupFilter.args?.groupFilter,
+  resolveGroupsProvider: GroupFilter.args?.resolveGroupsProvider,
 };
 
 export const ErrorOnResolvingUserIds: Story<WizardUserSelectorProps> = (

--- a/react-front-end/__stories__/components/wizard/WizardUserSelector.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardUserSelector.stories.tsx
@@ -22,6 +22,7 @@ import {
   WizardUserSelector,
   WizardUserSelectorProps,
 } from "../../../tsrc/components/wizard/WizardUserSelector";
+import { GroupFilter } from "../UserSearch.stories";
 
 export default {
   title: "Component/Wizard/WizardUserSelector",
@@ -57,6 +58,16 @@ WithUsers.args = {
     UserSearchMock.users[2].id,
   ]),
   multiple: true,
+};
+
+export const WithGroupFilter: Story<WizardUserSelectorProps> = (args) => (
+  <WizardUserSelector {...args} />
+);
+WithGroupFilter.args = {
+  ...NoUsers.args,
+  description:
+    "A user selector (single selection) with no users specified but with a group filter active",
+  groupFilter: GroupFilter.args?.groupFilter,
 };
 
 export const ErrorOnResolvingUserIds: Story<WizardUserSelectorProps> = (

--- a/react-front-end/__stories__/search/OwnerSelector.stories.tsx
+++ b/react-front-end/__stories__/search/OwnerSelector.stories.tsx
@@ -15,13 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import * as React from "react";
+import * as UserModuleMock from "../../__mocks__/UserModule.mock";
+import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
 import OwnerSelector, {
   OwnerSelectorProps,
 } from "../../tsrc/search/components/OwnerSelector";
-import { action } from "@storybook/addon-actions";
-import * as UserSearchMock from "../../__mocks__/UserSearch.mock";
 
 export default {
   title: "Search/OwnerSelector",
@@ -37,5 +38,5 @@ const commonParams = {
 export const NoSelectedUser = () => <OwnerSelector {...commonParams} />;
 
 export const SelectedUser = () => (
-  <OwnerSelector {...commonParams} value={UserSearchMock.users[0]} />
+  <OwnerSelector {...commonParams} value={UserModuleMock.users[0]} />
 );

--- a/react-front-end/__tests__/tsrc/components/UserSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/UserSearch.test.tsx
@@ -20,6 +20,7 @@ import "@testing-library/jest-dom/extend-expect";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { sprintf } from "sprintf-js";
+import * as UserModuleMock from "../../../__mocks__/UserModule.mock";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import { GroupFilter } from "../../../__stories__/components/UserSearch.stories";
 import UserSearch from "../../../tsrc/components/UserSearch";
@@ -100,7 +101,7 @@ describe("<UserSearch/>", () => {
 
     // Prepare test values - aligning with mock data and function
     const username = "admin999";
-    const testUser = UserSearchMock.users.find(
+    const testUser = UserModuleMock.users.find(
       (user: OEQ.UserQuery.UserDetails) => user.username === username
     );
     if (!testUser) {

--- a/react-front-end/__tests__/tsrc/components/UserSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/UserSearch.test.tsx
@@ -15,24 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
 import * as OEQ from "@openequella/rest-api-client";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import UserSearch from "../../../tsrc/components/UserSearch";
-import { languageStrings } from "../../../tsrc/util/langstrings";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
 import { sprintf } from "sprintf-js";
 import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
+import { GroupFilter } from "../../../__stories__/components/UserSearch.stories";
+import UserSearch from "../../../tsrc/components/UserSearch";
+import { languageStrings } from "../../../tsrc/util/langstrings";
 import { doSearch, getUserList } from "./UserSearchTestHelpers";
 
 describe("<UserSearch/>", () => {
   // Helper to render and wait for component under test
   const renderUserSearch = async (
-    onSelect: (username: OEQ.UserQuery.UserDetails) => void = jest.fn()
+    onSelect: (username: OEQ.UserQuery.UserDetails) => void = jest.fn(),
+    groupFilter?: ReadonlySet<string>
   ): Promise<HTMLElement> => {
     const { container } = render(
       <UserSearch
         onSelect={onSelect}
+        groupFilter={groupFilter}
         userListProvider={UserSearchMock.userDetailsProvider}
       />
     );
@@ -50,6 +53,14 @@ describe("<UserSearch/>", () => {
 
     // Ensure the user list section is not present
     expect(getUserList(container)).toBeFalsy();
+  });
+
+  it("displays a notice if the results will be filtered by group", async () => {
+    await renderUserSearch(jest.fn(), GroupFilter.args!.groupFilter);
+
+    expect(
+      screen.queryByText(languageStrings.userSearchComponent.filterActiveNotice)
+    ).toBeInTheDocument();
   });
 
   it("displays an error when it can't find requested user", async () => {

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardUserSelector.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardUserSelector.test.tsx
@@ -18,20 +18,20 @@
 import "@testing-library/jest-dom/extend-expect";
 import { render, waitFor } from "@testing-library/react";
 import * as React from "react";
-import * as UserSearchMock from "../../../../__mocks__/UserSearch.mock";
+import * as UserModuleMock from "../../../../__mocks__/UserModule.mock";
 import { WizardUserSelector } from "../../../../tsrc/components/wizard/WizardUserSelector";
 
 describe("<WizardUserSelector/>", () => {
   it("displays a specified set of users", async () => {
-    const testUser = UserSearchMock.users[1];
+    const testUser = UserModuleMock.users[1];
     const { queryByText } = render(
       <WizardUserSelector
-        groupsFilter={new Set()}
+        groupFilter={new Set()}
         multiple
         onChange={jest.fn()}
         users={new Set([testUser.id])}
         mandatory={false}
-        resolveUsersProvider={UserSearchMock.resolveUsersProvider}
+        resolveUsersProvider={UserModuleMock.resolveUsersProvider}
       />
     );
 

--- a/react-front-end/__tests__/tsrc/modules/UserModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/UserModule.test.ts
@@ -26,7 +26,7 @@ import * as S from "fp-ts/string";
 import {
   resolveUsersProvider,
   users,
-} from "../../../__mocks__/UserSearch.mock";
+} from "../../../__mocks__/UserModule.mock";
 import {
   resolveUsersCached,
   UserCache,

--- a/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
@@ -40,8 +40,8 @@ import {
   getSearchResult,
   getSearchResultsCustom,
 } from "../../../__mocks__/SearchResult.mock";
+import * as UserModuleMock from "../../../__mocks__/UserModule.mock";
 import { getCurrentUserMock } from "../../../__mocks__/UserModule.mock";
-import * as UserSearchMock from "../../../__mocks__/UserSearch.mock";
 import type { Collection } from "../../../tsrc/modules/CollectionsModule";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { getGlobalCourseList } from "../../../tsrc/modules/LegacySelectionSessionModule";
@@ -103,7 +103,7 @@ initialiseEssentialMocks({
 });
 const searchPromise = mockSearch.mockResolvedValue(getSearchResult);
 
-mockListUsers.mockResolvedValue(UserSearchMock.users);
+mockListUsers.mockResolvedValue(UserModuleMock.users);
 
 const defaultSearchPageOptions: SearchPageOptions = {
   ...SearchModule.defaultSearchOptions,
@@ -243,7 +243,7 @@ describe("Refine search by status", () => {
 });
 
 describe("Refine search by Owner", () => {
-  const testUser = UserSearchMock.users[0];
+  const testUser = UserModuleMock.users[0];
   let page: RenderResult;
 
   beforeEach(async () => {

--- a/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
@@ -18,7 +18,11 @@
 import { createBrowserHistory } from "history";
 import { getCollectionMap } from "../../../__mocks__/getCollectionsResp";
 import { getMimeTypeFilters } from "../../../__mocks__/MimeTypeFilter.mock";
-import { users } from "../../../__mocks__/UserSearch.mock";
+import {
+  allSearchPageOptions,
+  basicSearchPageOptions,
+} from "../../../__mocks__/searchOptions.mock";
+import * as UserModuleMock from "../../../__mocks__/UserModule.mock";
 import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import * as SearchFilterSettingsModule from "../../../tsrc/modules/SearchFilterSettingsModule";
 import type { SearchOptions } from "../../../tsrc/modules/SearchModule";
@@ -31,10 +35,6 @@ import {
   legacyQueryStringToSearchPageOptions,
   newSearchQueryToSearchPageOptions,
 } from "../../../tsrc/search/SearchPageHelper";
-import {
-  allSearchPageOptions,
-  basicSearchPageOptions,
-} from "../../../__mocks__/searchOptions.mock";
 import type { DateRange } from "../../../tsrc/util/Date";
 import { updateMockGetBaseUrl } from "../BaseUrlHelper";
 import { basicRenderData, updateMockGetRenderData } from "../RenderDataHelper";
@@ -51,7 +51,7 @@ describe("newSearchQueryToSearchOptions", () => {
   );
 
   beforeEach(() => {
-    mockedResolvedUser.mockResolvedValue([users[0]]);
+    mockedResolvedUser.mockResolvedValue([UserModuleMock.users[0]]);
     mockedCollectionListSummary.mockResolvedValueOnce(getCollectionMap);
     mockGetMimeTypeFiltersFromServer.mockResolvedValueOnce(getMimeTypeFilters);
   });
@@ -175,7 +175,7 @@ describe("legacyQueryStringToSearchOptions", () => {
   });
 
   it("should convert legacy search parameters to searchOptions", async () => {
-    mockedResolvedUser.mockResolvedValue([users[0]]);
+    mockedResolvedUser.mockResolvedValue([UserModuleMock.users[0]]);
     mockedCollectionListSummary.mockResolvedValue(getCollectionMap);
 
     //Query string was obtained from legacy UI searching.do->Share URL

--- a/react-front-end/__tests__/tsrc/search/components/OwnerSelector.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/OwnerSelector.test.tsx
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import { fireEvent, render } from "@testing-library/react";
-import { languageStrings } from "../../../../tsrc/util/langstrings";
-import OwnerSelector from "../../../../tsrc/search/components/OwnerSelector";
-import * as UserSearchMock from "../../../../__mocks__/UserSearch.mock";
-
 import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render } from "@testing-library/react";
+import * as React from "react";
+import * as UserModuleMock from "../../../../__mocks__/UserModule.mock";
+import * as UserSearchMock from "../../../../__mocks__/UserSearch.mock";
+import OwnerSelector from "../../../../tsrc/search/components/OwnerSelector";
+import { languageStrings } from "../../../../tsrc/util/langstrings";
 import { queryMuiButtonByText } from "../../MuiQueries";
 import {
   clearSelection,
@@ -31,7 +31,7 @@ import {
 } from "./OwnerSelectTestHelpers";
 
 describe("<OwnerSelector/>", () => {
-  const testUser = UserSearchMock.users[0];
+  const testUser = UserModuleMock.users[0];
 
   it("should show the select button when no user selected", () => {
     const { container } = render(

--- a/react-front-end/tsrc/components/SelectUserDialog.tsx
+++ b/react-front-end/tsrc/components/SelectUserDialog.tsx
@@ -33,8 +33,13 @@ interface SelectUserDialogProps {
   open: boolean;
   /** Handler for when dialog closes. */
   onClose: (selection?: OEQ.UserQuery.UserDetails) => void;
+  /** A list of group UUIDs to filter the users by. */
+  groupFilter?: ReadonlySet<string>;
   /** Function which will provide the list of users for UserSearch. */
-  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
+  userListProvider?: (
+    query?: string,
+    groupFilter?: ReadonlySet<string>
+  ) => Promise<OEQ.UserQuery.UserDetails[]>;
 }
 
 /**
@@ -43,6 +48,7 @@ interface SelectUserDialogProps {
 export const SelectUserDialog = ({
   open,
   onClose,
+  groupFilter,
   userListProvider,
 }: SelectUserDialogProps) => {
   const [selectedUser, setSelectedUser] = useState<
@@ -62,6 +68,7 @@ export const SelectUserDialog = ({
       <DialogContent>
         <UserSearch
           onSelect={setSelectedUser}
+          groupFilter={groupFilter}
           userListProvider={userListProvider}
           listHeight={300}
         />

--- a/react-front-end/tsrc/components/SelectUserDialog.tsx
+++ b/react-front-end/tsrc/components/SelectUserDialog.tsx
@@ -40,16 +40,24 @@ interface SelectUserDialogProps {
     query?: string,
     groupFilter?: ReadonlySet<string>
   ) => Promise<OEQ.UserQuery.UserDetails[]>;
+  /**
+   * Function which will resolve group IDs to full group details so that the group names can be
+   * used for display.
+   */
+  resolveGroupsProvider?: (
+    ids: ReadonlyArray<string>
+  ) => Promise<OEQ.UserQuery.GroupDetails[]>;
 }
 
 /**
- * Simple dialog to prompt user to search and select a user to use in the owner filter.
+ * Simple dialog to prompt user to search and select a user by embedding the SearchUser component.
  */
 export const SelectUserDialog = ({
   open,
   onClose,
   groupFilter,
   userListProvider,
+  resolveGroupsProvider,
 }: SelectUserDialogProps) => {
   const [selectedUser, setSelectedUser] = useState<
     OEQ.UserQuery.UserDetails | undefined
@@ -70,6 +78,7 @@ export const SelectUserDialog = ({
           onSelect={setSelectedUser}
           groupFilter={groupFilter}
           userListProvider={userListProvider}
+          resolveGroupsProvider={resolveGroupsProvider}
           listHeight={300}
         />
       </DialogContent>

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -382,7 +382,7 @@ const controlFactory = (
         ({ isSelectMultiple, isRestricted, restrictedTo }) => (
           <WizardUserSelector
             {...commonProps}
-            groupsFilter={isRestricted ? new Set(restrictedTo) : new Set()}
+            groupFilter={isRestricted ? new Set(restrictedTo) : new Set()}
             multiple={isSelectMultiple}
             onChange={flow(RSET.toSet, onChangeForStringSet)}
             users={valueAsStringSet()}

--- a/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
@@ -162,6 +162,13 @@ export interface WizardUserSelectorProps extends WizardControlBasicProps {
     groupFilter?: ReadonlySet<string>
   ) => Promise<OEQ.UserQuery.UserDetails[]>;
   /**
+   * Function which will resolve group IDs to full group details so that the group names can be
+   * used for display.
+   */
+  resolveGroupsProvider?: (
+    ids: ReadonlyArray<string>
+  ) => Promise<OEQ.UserQuery.GroupDetails[]>;
+  /**
    * Function which can provide the full details of specified users based on id.
    */
   resolveUsersProvider?: (
@@ -179,6 +186,7 @@ export const WizardUserSelector = ({
   onChange,
   users,
   userListProvider,
+  resolveGroupsProvider,
   resolveUsersProvider = resolveUsers,
 }: WizardUserSelectorProps): JSX.Element => {
   const [showSelectUserDialog, setShowSelectUserDialog] =
@@ -298,6 +306,7 @@ export const WizardUserSelector = ({
         open={showSelectUserDialog}
         onClose={handleCloseSelectUserDialog}
         groupFilter={groupFilter}
+        resolveGroupsProvider={resolveGroupsProvider}
         userListProvider={userListProvider}
       />
     </>

--- a/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardUserSelector.tsx
@@ -140,7 +140,7 @@ export interface WizardUserSelectorProps extends WizardControlBasicProps {
   /**
    * Groups to filter the user selection to.
    */
-  groupsFilter: ReadonlySet<string>;
+  groupFilter: ReadonlySet<string>;
   /**
    * Whether to support selection of multiple users.
    */
@@ -157,7 +157,10 @@ export interface WizardUserSelectorProps extends WizardControlBasicProps {
   /**
    * Function which will provide the list of users for UserSearch.
    */
-  userListProvider?: (query?: string) => Promise<OEQ.UserQuery.UserDetails[]>;
+  userListProvider?: (
+    query?: string,
+    groupFilter?: ReadonlySet<string>
+  ) => Promise<OEQ.UserQuery.UserDetails[]>;
   /**
    * Function which can provide the full details of specified users based on id.
    */
@@ -171,6 +174,7 @@ export const WizardUserSelector = ({
   label,
   mandatory,
   description,
+  groupFilter,
   multiple,
   onChange,
   users,
@@ -293,6 +297,7 @@ export const WizardUserSelector = ({
       <SelectUserDialog
         open={showSelectUserDialog}
         onClose={handleCloseSelectUserDialog}
+        groupFilter={groupFilter}
         userListProvider={userListProvider}
       />
     </>

--- a/react-front-end/tsrc/modules/GroupModule.ts
+++ b/react-front-end/tsrc/modules/GroupModule.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import * as RA from "fp-ts/ReadonlyArray";
+import { API_BASE_URL } from "../AppConfig";
+
+/**
+ * Lookup groups known in oEQ.
+ *
+ * @param ids An array of oEQ ids
+ */
+export const resolveGroups = async (
+  ids: ReadonlyArray<string>
+): Promise<OEQ.UserQuery.GroupDetails[]> =>
+  (
+    await OEQ.UserQuery.lookup(API_BASE_URL, {
+      users: [],
+      groups: RA.toArray<string>(ids),
+      roles: [],
+    })
+  ).groups;

--- a/react-front-end/tsrc/modules/UserModule.ts
+++ b/react-front-end/tsrc/modules/UserModule.ts
@@ -51,16 +51,16 @@ export const userIds: (
  * List users known in oEQ. Useful for filtering by users, or assigning permissions etc.
  *
  * @param query A wildcard supporting string to filter the result based on name
+ * @param groupFilter A list of group UUIDs to filter the search by
  */
-export const listUsers = (
-  query?: string
+export const listUsers = async (
+  query?: string,
+  groupFilter?: ReadonlySet<string>
 ): Promise<OEQ.UserQuery.UserDetails[]> =>
-  OEQ.UserQuery.search(API_BASE_URL, {
+  await OEQ.UserQuery.filtered(API_BASE_URL, {
     q: query,
-    users: true,
-    groups: false,
-    roles: false,
-  }).then((result: OEQ.UserQuery.SearchResult) => result.users);
+    byGroups: groupFilter ? Array.from<string>(groupFilter) : undefined,
+  });
 
 /**
  * Gets the current user's info from the server as OEQ.LegacyContent.CurrentUserDetails.

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -710,6 +710,8 @@ export const languageStrings = {
   },
   userSearchComponent: {
     failedToFindUsersMessage: "Unable to find any users matching '%s'",
+    filterActiveNotice: "Results will be filtered.",
+    filteredByPrelude: "Your search results will be filtered by these groups:",
     queryFieldLabel: "Username, first or last name",
   },
   wizard: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds support for the feature of the Wizard User Selector control where one or more groups can be configured to limit the users returned in search results - and thereby the users available for selection.

Points of note:

- Refactoring was done to create a new `UserModule.mock.ts` from what was in `UserSearch.mock.ts` to better align the emergent naming standard for our mocks - which was highlighted when creating the new `GoupModule.mock.ts`. This resulted in a lot of minor updates to `*.test.ts*` and `*.stories.tsx` files.
- In the interest of time, no additional tests (other than a minor one) have been explicitly added for this, but manual testing and testing via the new storybook test was undertaken.
- Main effort is focused in `UserSearch.tsx` with support from `GroupModule.ts` (with most of the code really just being around the display of the notice - and tooltip - for when a group filter is active)
- There is a change in `UserModule.ts` which changes which endpoint is used to do searching for users - which is also used by the `SearchPage` Owner Selector (as it uses the `SelectUserDialog` which uses `UserSearch`)
- Speaking of which, the component tree updated to support this is `WizardUserSelector` -> `SelectUserDialog` -> `UserSearch` - these were updated to support the passing of props related to group filtering for the search, and a provider function for resolving group UUIDs for display.

That's the gist of it.

Following this, I will need one more PR to wire it into the new search code.

https://user-images.githubusercontent.com/43919233/143394267-468137e0-fb7d-477d-9eb1-dc2f1a3fb448.mp4



<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
