### PR TITLE
Feature/simple term selector

### DIFF
--- a/react-front-end/__mocks__/TaxonomyTerms.mock.ts
+++ b/react-front-end/__mocks__/TaxonomyTerms.mock.ts
@@ -69,5 +69,7 @@ export const mockedSearchTaxonomyTerms = (
     start: 0,
     length: 6,
     available: 6,
-    results: mockedTaxonomyTerms.filter(({ term }) => term.includes(query)),
+    results: mockedTaxonomyTerms.filter(({ term }) =>
+      term.includes(query.replace(/\*/g, ""))
+    ),
   });

--- a/react-front-end/__mocks__/TaxonomyTerms.mock.ts
+++ b/react-front-end/__mocks__/TaxonomyTerms.mock.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+
+export const mockedTaxonomyTerms: OEQ.Taxonomy.Term[] = [
+  {
+    term: "ringneck",
+    fullTerm: "bird/ringneck",
+    readonly: false,
+    index: 1,
+    uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41862",
+  },
+  {
+    term: "indian ringneck",
+    fullTerm: "bird/ringneck/indian ringneck",
+    readonly: false,
+    index: 2,
+    uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41864",
+  },
+  {
+    term: "african ringneck",
+    fullTerm: "bird/ringneck/african ringneck",
+    readonly: false,
+    index: 3,
+    uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41865",
+  },
+  {
+    term: "macaw",
+    fullTerm: "bird/macaw",
+    readonly: false,
+    index: 4,
+    uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41863",
+  },
+  {
+    term: "blue gold macaw",
+    fullTerm: "bird/macaw/blue gold macaw",
+    readonly: false,
+    index: 5,
+    uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41866",
+  },
+  {
+    term: "scarlet macaw",
+    fullTerm: "bird/macaw/scarlet macaw",
+    readonly: false,
+    index: 6,
+    uuid: "26361407-fb54-45f0-8e4e-2ea0a4a41867",
+  },
+];
+
+export const mockedSearchTaxonomyTerms = (
+  query: string
+): Promise<OEQ.Common.PagedResult<OEQ.Taxonomy.Term>> =>
+  Promise.resolve({
+    start: 0,
+    length: 6,
+    available: 6,
+    results: mockedTaxonomyTerms.filter(({ term }) => term.includes(query)),
+  });

--- a/react-front-end/__stories__/components/wizard/WizardSimpleTermSelector.stories.tsx
+++ b/react-front-end/__stories__/components/wizard/WizardSimpleTermSelector.stories.tsx
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { Meta, Story } from "@storybook/react";
+import { mockedSearchTaxonomyTerms } from "../../../__mocks__/TaxonomyTerms.mock";
+import {
+  WizardSimpleTermSelector,
+  WizardSimpleTermSelectorProps,
+} from "../../../tsrc/components/wizard/WizardSimpleTermSelector";
+
+export default {
+  title: "Component/Wizard/WizardSimpleTermSelector",
+  component: WizardSimpleTermSelector,
+  argTypes: {
+    onSelect: {
+      action: "onSelect called",
+    },
+  },
+} as Meta<WizardSimpleTermSelectorProps>;
+
+export const NoValues: Story<WizardSimpleTermSelectorProps> = (args) => (
+  <WizardSimpleTermSelector {...args} />
+);
+NoValues.args = {
+  id: "wizard-simple-term-selector-story",
+  label: "Example",
+  description: "This an example of Simple Term Selector",
+  mandatory: true,
+  values: new Set(),
+  termProvider: mockedSearchTaxonomyTerms,
+};
+
+export const WithValues: Story<WizardSimpleTermSelectorProps> = (args) => (
+  <WizardSimpleTermSelector {...args} />
+);
+WithValues.args = {
+  ...NoValues.args,
+  values: new Set(["term1", "term2", "term3"]),
+};

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardSimpleTermSelector.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardSimpleTermSelector.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import "@testing-library/jest-dom/extend-expect";
+import { act, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { mockedTaxonomyTerms } from "../../../../__mocks__/TaxonomyTerms.mock";
+import { WizardSimpleTermSelector } from "../../../../tsrc/components/wizard/WizardSimpleTermSelector";
+import { languageStrings } from "../../../../tsrc/util/langstrings";
+
+describe("<WizardSimpleTermSelector/>", () => {
+  jest.useFakeTimers("modern");
+
+  const label = languageStrings.termSelector.placeholder;
+  const termProvider = jest.fn().mockResolvedValue({
+    start: 0,
+    length: 6,
+    available: 6,
+    results: mockedTaxonomyTerms,
+  });
+  const onSelect = jest.fn();
+
+  const renderWizardSimpleTermSelector = (
+    isAllowMultiple: boolean = false,
+    values = new Set<string>()
+  ) =>
+    render(
+      <WizardSimpleTermSelector
+        isAllowMultiple={isAllowMultiple}
+        mandatory={false}
+        onSelect={onSelect}
+        selectedTaxonomy=""
+        selectionRestriction="UNRESTRICTED"
+        termProvider={termProvider}
+        termStorageFormat="FULL_PATH"
+        values={values}
+        id="test"
+      />
+    );
+
+  const searchTerms = async (input: HTMLElement, query: string) =>
+    await act(async () => {
+      await userEvent.type(input, query);
+      jest.advanceTimersByTime(1000);
+    });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it("debounces the search", async () => {
+    const { getByLabelText } = renderWizardSimpleTermSelector();
+    const input = getByLabelText(label);
+    await searchTerms(input, "ring");
+    // Putting 4 chars in the input should trigger one search.
+    expect(termProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays provided values", async () => {
+    const terms: string[] = ["term1", "term2"];
+    const { queryByText } = await renderWizardSimpleTermSelector(
+      true,
+      new Set(terms)
+    );
+
+    expect(terms.every((t) => queryByText(t))).toBeTruthy();
+  });
+
+  it("removes a selected term", async () => {
+    const term = "Jest";
+    const values = new Set([term]);
+    const { getByLabelText } = await renderWizardSimpleTermSelector(
+      true,
+      values
+    );
+
+    userEvent.click(
+      getByLabelText(`${languageStrings.common.action.delete} ${term}`)
+    );
+    // The only value has been deleted so the handler should be called with an empty set.
+    expect(onSelect).toHaveBeenLastCalledWith(new Set());
+  });
+});

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardSimpleTermSelector.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardSimpleTermSelector.test.tsx
@@ -24,6 +24,8 @@ import { WizardSimpleTermSelector } from "../../../../tsrc/components/wizard/Wiz
 import { languageStrings } from "../../../../tsrc/util/langstrings";
 
 describe("<WizardSimpleTermSelector/>", () => {
+  // WizardSimpleTermSelector uses a debounce, so we need to be able to advanced
+  // the timer to trigger a search.
   jest.useFakeTimers("modern");
 
   const label = languageStrings.termSelector.placeholder;

--- a/react-front-end/tsrc/components/wizard/WizardSimpleTermSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardSimpleTermSelector.tsx
@@ -1,0 +1,218 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  debounce,
+  Grid,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  TextField,
+} from "@material-ui/core";
+import DeleteIcon from "@material-ui/icons/Delete";
+import { Autocomplete } from "@material-ui/lab";
+import * as OEQ from "@openequella/rest-api-client";
+import * as A from "fp-ts/Array";
+import * as E from "fp-ts/Either";
+import { flow, pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import { not } from "fp-ts/Predicate";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as RSET from "fp-ts/ReadonlySet";
+import * as S from "fp-ts/string";
+import * as TE from "fp-ts/TaskEither";
+import * as React from "react";
+import { useMemo, useState } from "react";
+import { languageStrings } from "../../util/langstrings";
+import { OrdAsIs } from "../../util/Ord";
+import { TooltipIconButton } from "../TooltipIconButton";
+import { WizardControlBasicProps } from "./WizardHelper";
+import { WizardLabel } from "./WizardLabel";
+
+export interface WizardSimpleTermSelectorProps extends WizardControlBasicProps {
+  /**
+   * `true` to allow selecting multiple taxonomy terms.
+   */
+  isAllowMultiple: boolean;
+  /**
+   * The currently selected taxonomy terms.
+   */
+  values: ReadonlySet<string>;
+  /**
+   * Handler for selecting taxonomy terms.
+   */
+  onSelect: (_: ReadonlySet<string>) => void;
+  /**
+   * ID of the taxonomy where terms are searched from.
+   */
+  selectedTaxonomy: string;
+  /**
+   * Restriction option for term selection.
+   */
+  selectionRestriction: OEQ.Taxonomy.SelectionRestriction;
+  /**
+   * Format used to search for a term.
+   */
+  termStorageFormat: OEQ.Taxonomy.TermStorageFormat;
+  /**
+   * Function to provide a list of terms.
+   *
+   * @param query Query to filter the list of terms.
+   * @param restriction Restriction applied to how to search terms.
+   * @param maxTermNum Maximum number of terms in one search.
+   * @param isSearchFullTerm `true` to search terms by full path.
+   * @param taxonomyUuid UUID of the taxonomy collection.
+   */
+  termProvider: (
+    query: string,
+    restriction: OEQ.Taxonomy.SelectionRestriction,
+    maxTermNum: number,
+    isSearchFullTerm: boolean,
+    taxonomy: string
+  ) => Promise<OEQ.Common.PagedResult<OEQ.Taxonomy.Term>>;
+}
+
+const { loadingText, placeholder } = languageStrings.termSelector;
+
+export const WizardSimpleTermSelector = ({
+  values,
+  isAllowMultiple,
+  selectedTaxonomy,
+  termStorageFormat,
+  selectionRestriction,
+  termProvider,
+  mandatory,
+  id,
+  description,
+  label,
+  onSelect,
+}: WizardSimpleTermSelectorProps) => {
+  const [options, setOptions] = useState<string[]>([]);
+  const [value, setValue] = useState<string>("");
+
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const searchTerms = useMemo(
+    () =>
+      debounce(async (query: string) => {
+        const task: TE.TaskEither<string, string[]> = pipe(
+          TE.tryCatch(
+            () =>
+              termProvider(
+                query,
+                selectionRestriction,
+                20,
+                termStorageFormat === "FULL_PATH",
+                selectedTaxonomy
+              ),
+            (e) => `Failed to search terms for query ${e}`
+          ),
+          TE.map(
+            flow(
+              ({ results }) => results,
+              A.map(({ term }) => term)
+            )
+          )
+        );
+
+        // Now begin.
+        setLoading(true);
+        pipe(
+          await task(),
+          E.fold((e) => {
+            throw new Error(e);
+          }, setOptions)
+        );
+        setLoading(false);
+      }, 500),
+    [selectionRestriction, termStorageFormat, selectedTaxonomy, termProvider]
+  );
+
+  const removeSelectedTerm = (term: string) =>
+    pipe(values, RSET.remove(S.Eq)(term), onSelect);
+
+  const insertSingleTerm = (term: string) =>
+    pipe(
+      values,
+      isAllowMultiple ? RSET.insert(S.Eq)(term) : () => RSET.singleton(term),
+      onSelect
+    );
+
+  const terms = pipe(
+    values,
+    RSET.toReadonlyArray<string>(OrdAsIs),
+    RA.map((t) => (
+      <ListItem key={t}>
+        <ListItemText>{t}</ListItemText>
+        <ListItemSecondaryAction>
+          <TooltipIconButton
+            title={`${languageStrings.common.action.delete} ${t}`}
+            onClick={() => removeSelectedTerm(t)}
+          >
+            <DeleteIcon />
+          </TooltipIconButton>
+        </ListItemSecondaryAction>
+      </ListItem>
+    ))
+  );
+
+  return (
+    <>
+      <WizardLabel
+        mandatory={mandatory}
+        label={label}
+        description={description}
+        labelFor={id}
+      />
+      <Grid container direction="column">
+        <Grid item>
+          <Autocomplete
+            freeSolo
+            loading={loading}
+            loadingText={loadingText}
+            options={options}
+            onChange={(e, value: string | null) => {
+              pipe(value, O.fromNullable, O.map(insertSingleTerm));
+
+              // Clear the value as we don't want to show the value if the TextField.
+              setValue("");
+            }}
+            // Both `value` and `inputValue` must be controlled by state so that we can reset the value in the onChange event.
+            value={value}
+            inputValue={value}
+            onInputChange={(event, value) => {
+              setValue(value);
+              pipe(
+                value.trim(),
+                O.fromPredicate(not(S.isEmpty)),
+                O.map(searchTerms)
+              );
+            }}
+            onOpen={() => setOptions([])}
+            renderInput={(params) => (
+              <TextField {...params} variant="outlined" label={placeholder} />
+            )}
+          />
+        </Grid>
+        <Grid item>
+          <List id={`${id}-term-list`}>{terms}</List>
+        </Grid>
+      </Grid>
+    </>
+  );
+};

--- a/react-front-end/tsrc/modules/TaxonomyModule.ts
+++ b/react-front-end/tsrc/modules/TaxonomyModule.ts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as OEQ from "@openequella/rest-api-client";
+import { API_BASE_URL } from "../AppConfig";
+
+/**
+ * Search taxonomy terms.
+ *
+ * @param query Query of a search.
+ * @param restriction Restriction applied to how to search terms.
+ * @param maxTermNum Maximum number of terms in one search.
+ * @param isSearchFullTerm `true` to search terms by full path.
+ * @param taxonomyUuid UUID of the taxonomy.
+ */
+export const searchTaxonomyTerms = (
+  query: string,
+  restriction: OEQ.Taxonomy.SelectionRestriction,
+  maxTermNum: number,
+  isSearchFullTerm: boolean,
+  taxonomyUuid: string
+): Promise<OEQ.Common.PagedResult<OEQ.Taxonomy.Term>> =>
+  OEQ.Taxonomy.searchTaxonomyTerms(
+    API_BASE_URL,
+    taxonomyUuid,
+    query,
+    restriction,
+    maxTermNum,
+    isSearchFullTerm
+  );

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -698,6 +698,10 @@ export const languageStrings = {
       usernameUnknown: "Username unknown",
     },
   },
+  termSelector: {
+    placeholder: "Search term",
+    loadingText: "Searching terms...",
+  },
   uiconfig: {
     facet: {
       name: "Name",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds a new module in `react-front-end` to support listing taxonomy terms and a new component called `WizardSimpleTermSelector`. 

The component uses the MUI Autocomplete to achieve dynamically updating the terms for selections. Debouncing is used to avoid massive API calls to search for terms.