### PR TITLE
feat: integrate WizardSimpleTermSelector with Adv search panel.

### DIFF
--- a/react-front-end/__mocks__/WizardHelper.mock.ts
+++ b/react-front-end/__mocks__/WizardHelper.mock.ts
@@ -324,6 +324,33 @@ export const controls: OEQ.WizardControl.WizardControl[] = [
     defaultValues: [],
     controlType: "html",
   },
+  {
+    mandatory: false,
+    reload: false,
+    include: true,
+    size1: 0,
+    size2: 0,
+    title: "Select taxonomy terms",
+    description: "This is a Simple TermSelector.",
+    targetNodes: [
+      {
+        target: "/item/terms",
+        attribute: "",
+        fullTarget: "/item/terms",
+        xoqlPath: "/item/terms",
+        freetextField: "/item/terms",
+      },
+    ],
+    options: [],
+    defaultValues: [],
+    controlType: "termselector",
+    isAllowAddTerms: false,
+    isAllowMultiple: true,
+    displayType: "autocompleteEditBox",
+    selectedTaxonomy: "",
+    selectionRestriction: "UNRESTRICTED",
+    termStorageFormat: "FULL_PATH",
+  },
   { controlType: "unknown" },
 ];
 

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -65,6 +65,7 @@ describe("render()", () => {
             shufflebox: () => "WizardShuffleBox",
             shufflelist: () => "WizardShuffleList",
             userselector: () => "WizardUserSelector",
+            termselector: () => "WizardSimpleTermSelector",
             _: () => "WizardUnsupported",
           })
         )

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -29,7 +29,6 @@ import { first } from "fp-ts/Semigroup";
 import * as SET from "fp-ts/Set";
 import * as S from "fp-ts/string";
 import * as React from "react";
-import { searchTaxonomyTerms } from "../../modules/TaxonomyModule";
 import { OrdAsIs } from "../../util/Ord";
 import { WizardCalendar } from "./WizardCalendar";
 import { WizardCheckBoxGroup } from "./WizardCheckBoxGroup";
@@ -389,25 +388,25 @@ const controlFactory = (
         )
       );
     case "termselector":
-      const {
-        isAllowMultiple,
-        selectedTaxonomy,
-        selectionRestriction,
-        termStorageFormat,
-      } = control as OEQ.WizardControl.WizardTermSelectorControl;
-
-      //todo: support different display type.
-      return (
-        <WizardSimpleTermSelector
-          {...commonProps}
-          values={valueAsStringSet()}
-          onSelect={flow(RSET.toSet, onChangeForStringSet)}
-          isAllowMultiple={isAllowMultiple}
-          selectedTaxonomy={selectedTaxonomy}
-          selectionRestriction={selectionRestriction}
-          termStorageFormat={termStorageFormat}
-          termProvider={searchTaxonomyTerms}
-        />
+      return pipe(
+        control as OEQ.WizardControl.WizardTermSelectorControl,
+        ({
+          isAllowMultiple,
+          selectedTaxonomy,
+          selectionRestriction,
+          termStorageFormat,
+        }) => (
+          //todo: support different display type.
+          <WizardSimpleTermSelector
+            {...commonProps}
+            values={valueAsStringSet()}
+            onSelect={flow(RSET.toSet, onChangeForStringSet)}
+            isAllowMultiple={isAllowMultiple}
+            selectedTaxonomy={selectedTaxonomy}
+            selectionRestriction={selectionRestriction}
+            termStorageFormat={termStorageFormat}
+          />
+        )
       );
     default:
       return absurd(controlType);

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -29,6 +29,7 @@ import { first } from "fp-ts/Semigroup";
 import * as SET from "fp-ts/Set";
 import * as S from "fp-ts/string";
 import * as React from "react";
+import { searchTaxonomyTerms } from "../../modules/TaxonomyModule";
 import { OrdAsIs } from "../../util/Ord";
 import { WizardCalendar } from "./WizardCalendar";
 import { WizardCheckBoxGroup } from "./WizardCheckBoxGroup";
@@ -38,6 +39,7 @@ import { WizardRadioButtonGroup } from "./WizardRadioButtonGroup";
 import { WizardRawHtml } from "./WizardRawHtml";
 import { WizardShuffleBox } from "./WizardShuffleBox";
 import { WizardShuffleList } from "./WizardShuffleList";
+import { WizardSimpleTermSelector } from "./WizardSimpleTermSelector";
 import { WizardUnsupported } from "./WizardUnsupported";
 import { WizardUserSelector } from "./WizardUserSelector";
 
@@ -387,7 +389,26 @@ const controlFactory = (
         )
       );
     case "termselector":
-      return <WizardUnsupported id={id} />;
+      const {
+        isAllowMultiple,
+        selectedTaxonomy,
+        selectionRestriction,
+        termStorageFormat,
+      } = control as OEQ.WizardControl.WizardTermSelectorControl;
+
+      //todo: support different display type.
+      return (
+        <WizardSimpleTermSelector
+          {...commonProps}
+          values={valueAsStringSet()}
+          onSelect={flow(RSET.toSet, onChangeForStringSet)}
+          isAllowMultiple={isAllowMultiple}
+          selectedTaxonomy={selectedTaxonomy}
+          selectionRestriction={selectionRestriction}
+          termStorageFormat={termStorageFormat}
+          termProvider={searchTaxonomyTerms}
+        />
+      );
     default:
       return absurd(controlType);
   }

--- a/react-front-end/tsrc/components/wizard/WizardSimpleTermSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardSimpleTermSelector.tsx
@@ -38,6 +38,7 @@ import * as TE from "fp-ts/TaskEither";
 import * as T from "fp-ts/Task";
 import * as React from "react";
 import { useMemo, useState } from "react";
+import { searchTaxonomyTerms } from "../../modules/TaxonomyModule";
 import { languageStrings } from "../../util/langstrings";
 import { OrdAsIs } from "../../util/Ord";
 import { TooltipIconButton } from "../TooltipIconButton";
@@ -78,7 +79,7 @@ export interface WizardSimpleTermSelectorProps extends WizardControlBasicProps {
    * @param isSearchFullTerm `true` to search terms by full path.
    * @param taxonomyUuid UUID of the taxonomy collection.
    */
-  termProvider: (
+  termProvider?: (
     query: string,
     restriction: OEQ.Taxonomy.SelectionRestriction,
     maxTermNum: number,
@@ -97,7 +98,7 @@ export const WizardSimpleTermSelector = ({
   selectedTaxonomy,
   termStorageFormat,
   selectionRestriction,
-  termProvider,
+  termProvider = searchTaxonomyTerms,
   mandatory,
   id,
   description,


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR integrates the `WizardSimpleTermSelector` into the Advanced search panel. Due to time limit I only updated `WizardHelper.test`.

https://user-images.githubusercontent.com/47203811/144141588-037d119b-e394-47b6-821b-20bfb5db5c3e.mp4




