### PR TITLE
feat(frontend): Keep Advanced Search panel open when user first selects an advanced search

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/AdvancedSearchPageTest.java
@@ -49,16 +49,16 @@ public class AdvancedSearchPageTest extends AbstractSessionTest {
     assertEquals(selected, "");
   }
 
-  @Test(description = "Open and close Advanced search panel")
+  @Test(description = "Close and open Advanced search panel")
   @NewUIOnly
   public void toggleAdvancedSearchPanel() {
-    // Closed initially.
-    assertNull(advancedSearchPage.getAdvancedSearchPanel());
-    // Open the panel.
-    advancedSearchPage.openAdvancedSearchPanel();
+    // Opened initially.
     assertNotNull(advancedSearchPage.getAdvancedSearchPanel());
-    // Close again.
+    // Close the panel.
     advancedSearchPage.closeAdvancedSearchPanel();
     assertNull(advancedSearchPage.getAdvancedSearchPanel());
+    // Open again.
+    advancedSearchPage.openAdvancedSearchPanel();
+    assertNotNull(advancedSearchPage.getAdvancedSearchPanel());
   }
 }

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -80,12 +80,6 @@ const togglePanel = () =>
 
 const renderAdvancedSearchPage = async () => {
   const page = await renderSearchPage(searchPromise, undefined, testUuid);
-  // Due to the UI change - hiding the panel when a search is triggered, the tests should
-  // also get updated accordingly. However, as we will make further changes for the UI,
-  // just manually open the panel for now so that we can keep the tests as they are.
-  // We will rework here later when we figure out how to nicely display the panel.
-  togglePanel();
-
   return page;
 };
 

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -34,6 +34,11 @@ export type State =
        * Indicates that the next Hide action should be ignored, so as to support
        * initial searches and clearing of advanced searches. Will be reset to
        * false on the next `action === hide`.
+       *
+       * This is due to interactions with the SearchPageReducer which this
+       * reducer now probably needs to be merged with. Before the clear
+       * button and the hiding of this pane based on the `search` action
+       * in the SearchPageReducer it was independent, but not any-more.
        */
       overrideHide: boolean;
     };

--- a/react-front-end/tsrc/search/SearchPageModeReducer.ts
+++ b/react-front-end/tsrc/search/SearchPageModeReducer.ts
@@ -138,9 +138,9 @@ export const searchPageModeReducer = (state: State, action: Action): State => {
       return {
         mode: "advSearch",
         definition,
-        isAdvSearchPanelOpen: false,
+        isAdvSearchPanelOpen: true,
         queryValues: action.initialQueryValues,
-        overrideHide: false,
+        overrideHide: true,
       };
     case "toggleAdvSearchPanel":
       return toggleOrHidePanel(state, "toggle");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

https://user-images.githubusercontent.com/92769668/143371258-08fb7ab5-225c-4a0c-8187-e66528687af6.mp4

Updated comment for `overrideHide` state:  [#3595](https://github.com/openequella/openEQUELLA/pull/3595#pullrequestreview-821010760).

Changed two initial values in `SearchPageModeReducer` for `initialiseAdvSearch` action.

Updated test helper `renderAdvancedSearchPage` function since now the panel is open after the first search.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
