### PR TITLE
feat(frontend): add basic visibility scripting support

### DIFF
--- a/react-front-end/__mocks__/AdvancedSearchModule.mock.ts
+++ b/react-front-end/__mocks__/AdvancedSearchModule.mock.ts
@@ -28,7 +28,7 @@ export const getAdvancedSearchesFromServerResult: OEQ.Common.BaseEntitySummary[]
 interface TargetNodeEssentials
   extends Pick<OEQ.WizardCommonTypes.TargetNode, "target" | "attribute"> {}
 
-const buildTargetNodes = (
+export const buildTargetNodes = (
   nodes: TargetNodeEssentials[]
 ): OEQ.WizardCommonTypes.TargetNode[] =>
   nodes.map(({ target, attribute }) => {

--- a/react-front-end/__tests__/tsrc/modules/ScriptingModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/ScriptingModule.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { pipe } from "fp-ts/function";
+import {
+  buildVisibilityScript,
+  ScriptContext,
+} from "../../../tsrc/modules/ScriptingModule";
+import "../FpTsMatchers";
+import { expectRight } from "../FpTsMatchers";
+
+describe("buildVisibilityScript", () => {
+  const testData = {
+    path: "/item/name",
+    value: "some value",
+    uuid: "86a958ae-9166-4389-ab38-2c87169a5ebc",
+  };
+
+  // A static easy to test implementation closing over `testData` above.
+  const scriptContext: ScriptContext = {
+    user: {
+      hasRole: (uuid: string): boolean => uuid === testData.uuid,
+    },
+    xml: {
+      contains: (xpath: string, value: string): boolean =>
+        xpath === testData.path && value === testData.value,
+      get: (xpath: string): string =>
+        xpath === testData.path ? testData.value : "unknown xpath",
+    },
+  };
+
+  it("builds a script that can be used for evaluation", () => {
+    const expectTrueScript = `
+var bRet = false; // 'var bRet' is used to be similar to the UI generated scripts
+const results = [
+    xml.contains('${testData.path}', '${testData.value}'),
+    xml.get('${testData.path}') == '${testData.value}',
+    user.hasRole('${testData.uuid}')
+];
+if (results.every(v => v === true)) {
+    bRet = true;
+}
+return bRet;
+`;
+
+    const result = pipe(
+      scriptContext,
+      buildVisibilityScript(expectTrueScript),
+      expectRight
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns a left if there's issues with the script", () => {
+    const result = pipe(
+      scriptContext,
+      buildVisibilityScript("this is not a valid script!!")
+    );
+    expect(result).toBeLeft();
+  });
+
+  it.each<[string, string, boolean]>([
+    ["truthy value", "return 'a string';", true],
+    ["falsy value", "return 0;", false],
+    ["return nothing", "const str = 'nothing returned explicitly';", false],
+  ])(
+    "forces a boolean when the script does not return a boolean - %s",
+    (_, script, expectedResult) => {
+      const result = pipe(
+        scriptContext,
+        buildVisibilityScript(script),
+        expectRight
+      );
+
+      expect(result).toBe(expectedResult);
+    }
+  );
+});

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -554,7 +554,7 @@ export const render = (
       pipe(
         visibilityScriptContext,
         buildVisibilityScript(script),
-        E.mapLeft(console.error),
+        E.mapLeft((e: Error) => console.error(e.message, script)),
         O.fromEither
       )
     ),

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -19,10 +19,19 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
 import { Eq, struct } from "fp-ts/Eq";
-import { absurd, constFalse, flow, pipe } from "fp-ts/function";
+import {
+  absurd,
+  constFalse,
+  constTrue,
+  flow,
+  identity,
+  pipe,
+} from "fp-ts/function";
 import * as M from "fp-ts/Map";
 import * as NEA from "fp-ts/NonEmptyArray";
+import * as N from "fp-ts/number";
 import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
 import * as RSET from "fp-ts/ReadonlySet";
 import { Refinement } from "fp-ts/Refinement";
 import { first } from "fp-ts/Semigroup";
@@ -39,7 +48,13 @@ import {
   Union,
   Optional,
 } from "runtypes";
+import {
+  buildVisibilityScript,
+  UserScriptObject,
+  XmlScriptType,
+} from "../../modules/ScriptingModule";
 import { OrdAsIs } from "../../util/Ord";
+import { pfTernaryTypeGuard } from "../../util/pointfree";
 import { WizardCalendar } from "./WizardCalendar";
 import { WizardCheckBoxGroup } from "./WizardCheckBoxGroup";
 import { WizardEditBox } from "./WizardEditBox";
@@ -436,6 +451,47 @@ const controlFactory = (
   }
 };
 
+const buildXmlScriptObject = (values: PathValueMap): XmlScriptType =>
+  pipe(
+    values,
+    // First, let's convert our unwieldy ControlValue union to a string only array
+    // as that is all that is expected in script land.
+    M.map<ControlValue, ReadonlyArray<string>>(
+      pfTernaryTypeGuard<string[], number[], string[]>(
+        isStringArray,
+        identity,
+        A.map(N.Show.show)
+      )
+    ),
+    // Now build the object
+    (m) => ({
+      contains: (node, value): boolean =>
+        pipe(
+          m,
+          M.lookup(S.Eq)(node),
+          O.map(RA.elem(S.Eq)(value)),
+          O.getOrElse(constFalse)
+        ),
+      get: (node): string =>
+        pipe(
+          m,
+          M.lookup(S.Eq)(node),
+          O.chain(RA.head),
+          O.getOrElse(() => S.empty) // as per legacy code
+        ),
+    })
+  );
+
+// TODO: Build proper object from a passed in `OEQ.LegacyContent.CurrentUserDetails`. It is assumed
+// such an object is retrieved earlier and cached somewhere ready for quick consumption here. This
+// function should not be async - that'd be excessive.
+const buildUserScriptObject =
+  (/* userDetails: OEQ.LegacyContent.CurrentUserDetails */): UserScriptObject => ({
+    hasRole: (roleUniqueID) => {
+      throw new Error("TODO: Still need to implement hasRole!!");
+    },
+  });
+
 /**
  * Produces an array of `JSX.Element`s representing the wizard defined by the provided `controls`.
  * Setting their values to those provided in `values` and configuring them with an onChange handler
@@ -481,15 +537,45 @@ export const render = (
     O.toUndefined
   );
 
+  const visibilityScriptContext = {
+    user: buildUserScriptObject(),
+    xml: pipe(values, valuesByNode, buildXmlScriptObject),
+  };
+
+  // Using a control's visibility script (if available) and the current values of other controls,
+  // determine if this control should be visible. Defaults to true/visible if there are any
+  // issues.
+  const isVisible: (_: OEQ.WizardControl.WizardControl) => boolean = flow(
+    O.fromPredicate(OEQ.WizardControl.isWizardBasicControl),
+    O.chain<OEQ.WizardControl.WizardBasicControl, string>(
+      ({ visibilityScript }) => O.fromNullable(visibilityScript)
+    ),
+    O.chain((script) =>
+      pipe(
+        visibilityScriptContext,
+        buildVisibilityScript(script),
+        E.mapLeft(console.error),
+        O.fromEither
+      )
+    ),
+    // Default to isVisible if there's no script (or it's not a WizardBasicControl)
+    O.getOrElse(constTrue)
+  );
+
   // Build the controls
-  return controls.map((c, idx) =>
-    controlFactory(
-      `wiz-${idx}-${c.controlType}`,
-      c,
-      buildOnChangeHandler(c),
-      values,
-      retrieveControlsValue(c)
-    )
+  return pipe(
+    controls,
+    RA.filter(isVisible),
+    RA.mapWithIndex((idx, c) =>
+      controlFactory(
+        `wiz-${idx}-${c.controlType}`,
+        c,
+        buildOnChangeHandler(c),
+        values,
+        retrieveControlsValue(c)
+      )
+    ),
+    RA.toArray
   );
 };
 

--- a/react-front-end/tsrc/modules/ScriptingModule.ts
+++ b/react-front-end/tsrc/modules/ScriptingModule.ts
@@ -21,7 +21,7 @@ import { pipe } from "fp-ts/function";
 /**
  * A cut down version of the server side interface `com.tle.common.scripting.types.XmlScriptType`
  * which is used to pass state of Items and Advanced Searches into scripts. It is recommended to
- * also review the service side interface.
+ * also review the server side interface.
  *
  * Note that all XPath parameters are not `true` XPaths and are limited to simple node/attribute
  * selection and node indexes. E.g. /xml/test/node[2]/@attribute is as complex as it

--- a/react-front-end/tsrc/modules/ScriptingModule.ts
+++ b/react-front-end/tsrc/modules/ScriptingModule.ts
@@ -1,0 +1,115 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+
+/**
+ * A cut down version of the server side interface `com.tle.common.scripting.types.XmlScriptType`
+ * which is used to pass state of Items and Advanced Searches into scripts. It is recommended to
+ * also review the service side interface.
+ *
+ * Note that all XPath parameters are not `true` XPaths and are limited to simple node/attribute
+ * selection and node indexes. E.g. /xml/test/node[2]/@attribute is as complex as it
+ * will get.
+ */
+export interface XmlScriptType {
+  /**
+   * Find out if any value of the nodes with a given XPath match a certain value.
+   *
+   * @param xpath The XPath to the node(s)
+   * @param value The value to check for
+   * @return true if the value is found
+   */
+  contains: (xpath: string, value: string) => boolean;
+  /**
+   * Get the text value of a node using an XPath like syntax. If there is more than one node with
+   * that XPath, it will return the value in the first one. If the node cannot be found, a blank
+   * string will be returned. You can use exists(String) to determine if a node exists.
+   *
+   * @param xpath The XPath to get the value from
+   * @return The value from the XML document
+   */
+  get: (xpath: string) => string;
+}
+
+/**
+ * Referenced by the `user` variable in script. Represents the currently logged in user. Based on
+ * server side interface `com.tle.common.scripting.objects.UserScriptObject`.
+ */
+export interface UserScriptObject {
+  /**
+   * Determines if the logged in user has the role with the UUID of `roleUniqueID`
+   *
+   * @param roleUniqueID The unique id (UUID) of the role to look for
+   * @return Has the role?
+   */
+  hasRole: (roleUniqueID: string) => boolean;
+}
+
+/**
+ * The various objects etc that are in scope for a script.
+ */
+export interface ScriptContext {
+  xml: XmlScriptType;
+  user: UserScriptObject;
+}
+
+/**
+ * A Visibility Script is a script which queries the current context (represented by an
+ * `ScriptContext`) and returns true or false to indicate whether a control should be displayed.
+ * The result is captured in an `Either` which if there is an issue parsing or evaluating the script
+ * then the left will contain the `Error`.
+ */
+type VisibilityScript = (context: ScriptContext) => E.Either<Error, boolean>;
+
+/**
+ * Given a visibility script (`string`) return a function which can accept details of the current
+ * context in the form of a `ScriptContext`. Visibility Scripts are expected to return a boolean
+ * result, but we wrap it in an Either to catch any errors in the parsing or evaluation of the
+ * provided script.
+ *
+ * @param script A visibility script provided by the server, which expects a `xml` object to be in
+ *               scope - and possibly others (like `user`).
+ */
+export const buildVisibilityScript =
+  (script: string): VisibilityScript =>
+  (context: ScriptContext): E.Either<Error, boolean> => {
+    // DANGER: Conversion of string into a function which will take a single ScriptContext argument
+    // (`scriptContext`) ready for calling.
+    const toFunction = (s: string) =>
+      pipe(
+        // Yes, we know this is dangerous, but this is a key feature...
+        // eslint-disable-next-line no-new-func
+        new Function(
+          "scriptContext",
+          `"use strict"; const {xml, user} = scriptContext; ${s}`
+        ),
+        // A `Function` returns `any`, and we want more than just compile time forcing a return
+        // of boolean, so with `!!` we force a runtime return value of boolean.
+        (f) =>
+          (context: ScriptContext): boolean =>
+            !!f(context)
+      );
+
+    // Rather than just execute the script and hope someone else deals with any issues, we know
+    // this could be bad, so let's wrap the result in an Either.
+    return E.tryCatch(
+      () => pipe(context, toFunction(script)),
+      (e) => new Error(`Failed to execute visibility script: ${e}`)
+    );
+  };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Provides a minimal basic implementation of visibility scripting based on the values of other controls which you could build via the Admin Console scripting UI. (That is, supporting `contains` and `get` on the `xml` object.)

Two main outstanding parts to come (in future PRs):

- Support for the `user` object (only `hasRole` as that's all the Admin UI uses); and
- Clearing the values for controls which become hidden


https://user-images.githubusercontent.com/43919233/144365517-b9d4b905-b97c-4588-9ea6-889658216039.mp4


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
