### PR TITLE
feat: Updte /api/content/currentuser to also return roles

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/LegacyContentApi.scala
@@ -259,6 +259,7 @@ object LegacyContentController extends AbstractSectionsController with SectionFi
 
 @Api("Legacy content")
 @Path("content")
+@Produces(value = Array("application/json"))
 class LegacyContentApi {
   val LOGGER = LoggerFactory.getLogger(classOf[LegacyContentApi])
 
@@ -454,7 +455,6 @@ class LegacyContentApi {
   @POST
   @GET
   @Path("/ajax/{path : .+}")
-  @Produces(value = Array("application/json"))
   def ajaxCall(@PathParam("path") _path: String,
                @Context uriInfo: UriInfo,
                @Context req: HttpServletRequest,
@@ -479,7 +479,6 @@ class LegacyContentApi {
 
   @POST
   @Path("/submit/{path : .+}")
-  @Produces(value = Array("application/json"))
   def submit(@PathParam("path") _path: String,
              @Context uriInfo: UriInfo,
              @Context req: HttpServletRequest,

--- a/oeq-ts-rest-api/src/LegacyContent.ts
+++ b/oeq-ts-rest-api/src/LegacyContent.ts
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GET } from './AxiosInstance';
 import { is } from 'typescript-is';
+import { GET } from './AxiosInstance';
 
 export interface ItemCounts {
   tasks: number;
@@ -45,6 +45,10 @@ export interface CurrentUserDetails {
   menuGroups: Array<Array<MenuItem>>;
   counts?: ItemCounts;
   canDownloadSearchResult: boolean;
+  /**
+   * UUIDs of the roles assigned to the user - as well as `TLE_LOGGED_IN_USER_ROLE` where applicable.
+   */
+  roles: string[];
 }
 
 /**

--- a/oeq-ts-rest-api/test/auth.test.ts
+++ b/oeq-ts-rest-api/test/auth.test.ts
@@ -26,7 +26,8 @@ test("That we're able to login", async () => {
   const userDetails = await OEQ.LegacyContent.getCurrentUserDetails(
     TC.API_PATH
   );
-  expect(userDetails).toHaveProperty('username', TC.USERNAME);
+  expect(userDetails.username).toBe(TC.USERNAME);
+  expect(userDetails.roles).toEqual(['TLE_LOGGED_IN_USER_ROLE']);
 });
 
 test('An attempt to login with bad credentials fails', async () => {

--- a/react-front-end/__mocks__/UserModule.mock.ts
+++ b/react-front-end/__mocks__/UserModule.mock.ts
@@ -64,6 +64,7 @@ export const getCurrentUserMock: OEQ.LegacyContent.CurrentUserDetails = {
   prefsEditable: true,
   menuGroups: [],
   canDownloadSearchResult: true,
+  roles: [],
 };
 
 /**

--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -18,8 +18,8 @@
 import { CircularProgress, Grid } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
 import Axios from "axios";
-import { useContext } from "react";
 import * as React from "react";
+import { useContext } from "react";
 import { v4 } from "uuid";
 import {
   ErrorResponse,
@@ -58,6 +58,7 @@ export const guestUser: OEQ.LegacyContent.CurrentUserDetails = {
   },
   menuGroups: [],
   canDownloadSearchResult: false,
+  roles: [],
 };
 
 export interface ExternalRedirect {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Quick tweak to `currentuser` endpoint to support returning `roles` so that we have it available for the `user` object in  visibility scripts.

Minor tidy-up of endpoint code too, mainly so that we can have better Swagger doco.

![image](https://user-images.githubusercontent.com/43919233/144515927-6a94a948-3e02-4fc3-b11c-59d2f98cb3c4.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
