### PR TITLE
fix: add missing LIST_USERS ACL check on userquery endpoints

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/users/UserQueryResource.scala
@@ -22,6 +22,7 @@ import com.tle.beans.usermanagement.standard.wrapper.SharedSecretSettings
 import com.tle.common.security.SecurityConstants
 import com.tle.common.usermanagement.user.valuebean.{GroupBean, RoleBean, UserBean}
 import com.tle.legacy.LegacyGuice
+import com.tle.core.security.ACLChecks.hasAclOrThrow
 import io.swagger.annotations.{Api, ApiParam}
 import javax.ws.rs._
 
@@ -72,6 +73,7 @@ class UserQueryResource {
       @QueryParam("groups") @DefaultValue("true") @ApiParam("Include groups") sgroups: Boolean,
       @QueryParam("roles") @DefaultValue("true") @ApiParam("Include roles") sroles: Boolean)
     : LookupQueryResult = {
+    hasAclOrThrow(SecurityConstants.LIST_USERS)
     val us     = LegacyGuice.userService
     val users  = if (susers) us.searchUsers(q).asScala else Iterable.empty
     val groups = if (sgroups) us.searchGroups(q).asScala else Iterable.empty


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Add LIST_USERS ACL checker in UserQueryResource search API
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

https://user-images.githubusercontent.com/92769668/144527213-d3dfda86-78e3-4d1b-8ffc-10c76c535560.mp4


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
