### PR TITLE
feat: Add support for the `user` object in Visibility Scripts

### DIFF
--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -24,11 +24,13 @@ import * as R from "fp-ts/Record";
 import { mockWizardControlFactory } from "../../../../__mocks__/AdvancedSearchModule.mock";
 import { controls } from "../../../../__mocks__/WizardHelper.mock";
 import {
+  buildVisibilityScriptContext,
   ControlTarget,
   FieldValue,
   FieldValueMap,
   render,
 } from "../../../../tsrc/components/wizard/WizardHelper";
+import { guestUser } from "../../../../tsrc/modules/UserModule";
 import { simpleMatch } from "../../../../tsrc/util/match";
 
 /**
@@ -44,13 +46,20 @@ describe("render()", () => {
   const logOnChange = (update: FieldValue): void =>
     console.debug("onChange called", update);
 
+  const noFieldValues = new Map();
+
   const nameEditboxTarget: ControlTarget = {
     type: "editbox",
     schemaNode: ["/item/name"],
   };
 
   it("creates JSX.Elements matching definition", () => {
-    const elements: JSX.Element[] = render(controls, new Map(), logOnChange);
+    const elements: JSX.Element[] = render(
+      controls,
+      noFieldValues,
+      logOnChange,
+      buildVisibilityScriptContext(noFieldValues, guestUser)
+    );
     expect(elements).toHaveLength(controls.length);
 
     const expectedComponentCount = pipe(
@@ -82,7 +91,12 @@ describe("render()", () => {
   });
 
   it("creates WizardUnsupported components for unknown/unsupported ones", () => {
-    const elements: JSX.Element[] = render(controls, new Map(), logOnChange);
+    const elements: JSX.Element[] = render(
+      controls,
+      noFieldValues,
+      logOnChange,
+      buildVisibilityScriptContext(noFieldValues, guestUser)
+    );
     expect(
       elements.filter((e) => e.type.name === "WizardUnsupported")
     ).toHaveLength(1);
@@ -91,8 +105,9 @@ describe("render()", () => {
   it("handles `controlType === 'unknown'` - i.e. `UnknownWizardControl`", () => {
     const elements: JSX.Element[] = render(
       [{ controlType: "unknown" }],
-      new Map(),
-      logOnChange
+      noFieldValues,
+      logOnChange,
+      buildVisibilityScriptContext(noFieldValues, guestUser)
     );
     expect(
       elements.filter((e) => e.type.name === "WizardUnsupported")
@@ -122,10 +137,12 @@ describe("render()", () => {
       // smoke test the test data
       expect(value.value[0]).toBeTruthy();
 
+      const fieldValues = M.singleton(value.target, value.value);
       const elements = render(
         controls,
-        M.singleton(value.target, value.value),
-        logOnChange
+        fieldValues,
+        logOnChange,
+        buildVisibilityScriptContext(fieldValues, guestUser)
       );
       // Test the field(s) were set
       expect(
@@ -135,8 +152,14 @@ describe("render()", () => {
   );
 
   it("throws an error if the incorrect control value type is provided", () => {
+    const fieldValues = M.singleton(nameEditboxTarget, [1]);
     expect(() =>
-      render(controls, M.singleton(nameEditboxTarget, [1]), logOnChange)
+      render(
+        controls,
+        fieldValues,
+        logOnChange,
+        buildVisibilityScriptContext(fieldValues, guestUser)
+      )
     ).toThrow(TypeError);
   });
 
@@ -148,6 +171,7 @@ describe("render()", () => {
     );
   const simpleContainsScript = `return xml.contains('${checkBoxSchemaNode}', 'one');`;
   const simpleGetScript = `return xml.get('${checkBoxSchemaNode}') === 'one';`;
+  const aRoleUuid = "f618d610-2191-4a2c-b699-acb833d5b10f";
   it.each<[string, string | undefined, FieldValueMap, number]>([
     ["control case (no script)", undefined, new Map(), 2],
     [
@@ -169,6 +193,18 @@ describe("render()", () => {
       `return xml.get('${checkBoxSchemaNode}') === '';`,
       new Map(),
       2,
+    ],
+    [
+      "user.hasRole (visible)",
+      `return user.hasRole('${aRoleUuid}');`,
+      new Map(),
+      2,
+    ],
+    [
+      "user.hasRole (hidden - due to not having role)",
+      `return user.hasRole('rubbish-role');`,
+      new Map(),
+      1,
     ],
   ])(
     "hides controls based on visibility scripts - %s",
@@ -197,7 +233,15 @@ describe("render()", () => {
         },
       ];
 
-      const visibleControls = render(testControls, values, jest.fn());
+      const visibleControls = render(
+        testControls,
+        values,
+        jest.fn(),
+        buildVisibilityScriptContext(values, {
+          ...guestUser,
+          roles: [aRoleUuid],
+        })
+      );
       expect(visibleControls).toHaveLength(controlsVisible);
     }
   );

--- a/react-front-end/__tests__/tsrc/modules/ScriptingModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/ScriptingModule.test.ts
@@ -33,6 +33,11 @@ describe("buildVisibilityScript", () => {
   // A static easy to test implementation closing over `testData` above.
   const scriptContext: ScriptContext = {
     user: {
+      getEmail: () => undefined,
+      getID: () => "tester",
+      getFirstName: () => "Test",
+      getLastName: () => "User",
+      getUsername: () => "tester",
       hasRole: (uuid: string): boolean => uuid === testData.uuid,
     },
     xml: {

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -75,8 +75,8 @@ mockGetAdvancedSearchByUuid.mockResolvedValue(getAdvancedSearchDefinition);
 
 const testUuid = "4be6ae54-68ca-4d8b-acd0-0ca96fc39280";
 
-const togglePanel = () =>
-  act(() => userEvent.click(screen.getByLabelText(filterButtonLabel)));
+const togglePanel = async () =>
+  act(async () => userEvent.click(screen.getByLabelText(filterButtonLabel)));
 
 const renderAdvancedSearchPage = async () => {
   const page = await renderSearchPage(searchPromise, undefined, testUuid);
@@ -84,7 +84,7 @@ const renderAdvancedSearchPage = async () => {
   // also get updated accordingly. However, as we will make further changes for the UI,
   // just manually open the panel for now so that we can keep the tests as they are.
   // We will rework here later when we figure out how to nicely display the panel.
-  togglePanel();
+  await togglePanel();
 
   return page;
 };
@@ -141,11 +141,11 @@ describe("Advanced Search filter button", () => {
     const { container } = await renderAdvancedSearchPage();
 
     // First the panel is displayed for Advanced Search mode, so toggle to hide
-    togglePanel();
+    await togglePanel();
     expect(queryAdvSearchPanel(container)).not.toBeInTheDocument();
 
     // Toggle to show again
-    togglePanel();
+    await togglePanel();
     expect(queryAdvSearchPanel(container)).toBeInTheDocument();
   });
 
@@ -168,7 +168,7 @@ describe("Advanced Search filter button", () => {
     expect(getHighlightedFilterButton()).toBeInTheDocument();
 
     // Open the panel and clear out the EditBox's content.
-    togglePanel();
+    await togglePanel();
     userEvent.clear(getByLabelText(`${editBoxEssentials.title}`));
     await clickSearchButton(container);
     // Now the filter button is not highlighted again.
@@ -254,7 +254,7 @@ describe("Rendering of wizard", () => {
     await clickSearchButton(container);
 
     // Open the panel again.
-    togglePanel();
+    await togglePanel();
 
     // Collect all labels and values.
     const labelsAndValues = mockedControls.map(([c, controlValue]) =>

--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 import { CircularProgress, Grid } from "@material-ui/core";
-import * as OEQ from "@openequella/rest-api-client";
 import Axios from "axios";
 import * as React from "react";
 import { useContext } from "react";
@@ -42,24 +41,6 @@ declare global {
 
   const _trigger: (value: string) => boolean;
 }
-
-export const guestUser: OEQ.LegacyContent.CurrentUserDetails = {
-  accessibilityMode: false,
-  firstName: "guest",
-  lastName: "guest",
-  id: "guest",
-  username: "guest",
-  guest: true,
-  autoLoggedIn: false,
-  prefsEditable: false,
-  counts: {
-    tasks: 0,
-    notifications: 0,
-  },
-  menuGroups: [],
-  canDownloadSearchResult: false,
-  roles: [],
-};
 
 export interface ExternalRedirect {
   href: string;

--- a/react-front-end/tsrc/mainui/Template.tsx
+++ b/react-front-end/tsrc/mainui/Template.tsx
@@ -43,11 +43,12 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { ErrorResponse } from "../api/errors";
 import { TooltipIconButton } from "../components/TooltipIconButton";
-import { guestUser, PageContent } from "../legacycontent/LegacyContent";
+import { PageContent } from "../legacycontent/LegacyContent";
 import {
   isItemViewedFromIntegration,
   isSelectionSessionOpen,
 } from "../modules/LegacySelectionSessionModule";
+import { guestUser } from "../modules/UserModule";
 import { languageStrings } from "../util/langstrings";
 import MainMenu from "./MainMenu";
 import { legacyPageUrl, routes } from "./routes";

--- a/react-front-end/tsrc/modules/ScriptingModule.ts
+++ b/react-front-end/tsrc/modules/ScriptingModule.ts
@@ -52,6 +52,11 @@ export interface XmlScriptType {
  * server side interface `com.tle.common.scripting.objects.UserScriptObject`.
  */
 export interface UserScriptObject {
+  getEmail: () => string | undefined;
+  getFirstName: () => string;
+  getID: () => string;
+  getLastName: () => string;
+  getUsername: () => string;
   /**
    * Determines if the logged in user has the role with the UUID of `roleUniqueID`
    *

--- a/react-front-end/tsrc/modules/UserModule.ts
+++ b/react-front-end/tsrc/modules/UserModule.ts
@@ -34,6 +34,27 @@ import { API_BASE_URL } from "../AppConfig";
 import { OrdAsIs } from "../util/Ord";
 
 /**
+ * A bare bones user, essentially a 'default' user - i.e. start as 'guest'.
+ */
+export const guestUser: OEQ.LegacyContent.CurrentUserDetails = {
+  accessibilityMode: false,
+  firstName: "guest",
+  lastName: "guest",
+  id: "guest",
+  username: "guest",
+  guest: true,
+  autoLoggedIn: false,
+  prefsEditable: false,
+  counts: {
+    tasks: 0,
+    notifications: 0,
+  },
+  menuGroups: [],
+  canDownloadSearchResult: false,
+  roles: [],
+};
+
+/**
  * Eq for `OEQ.UserQuery.UserDetails` with equality based on the user's UUID.
  */
 export const eqUserById: Eq<OEQ.UserQuery.UserDetails> = contramap(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds basic support for the `user` object in visibility scripts. The goal was to have enough support for the scripts generated by the UI in the Admin Console. That would only require hasRole, but it wasn't too involved to add a few of the other basics quickly.

Also addressed a warning in the AdvancedSearchPage.test due to the togglePanel not correctly using `act()`.

I undertook manual testing with scripts testing various live combinations of roles and username etc.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
