### PR TITLE
chore: change help text for new Open item summary page button to Open resource summary page

### DIFF
--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -323,7 +323,7 @@ export const languageStrings = {
       "There is an issue with the format of the externalId for the the Kaltura Video",
     kalturaMissingId:
       "The provided Kaltura media is missing externalId details",
-    openSummaryPage: "Open Item Summary page",
+    openSummaryPage: "Open resource summary page",
     unsupportedContent: "Provided content is not supported",
     viewNext: "View next attachment",
     viewPrevious: "View previous attachment",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Change help text for new Open item summary page button from `Open Item Summary page` to `Open resource summary page`.

![image](https://user-images.githubusercontent.com/92769668/144782044-a451a79c-3041-4b7f-aa57-dda0f30b29e3.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
