### PR TITLE
Feature/support search shared from old UI

### DIFF
--- a/react-front-end/__tests__/tsrc/search/AdvancedSearchHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearchHelper.test.ts
@@ -17,7 +17,15 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 import { mockedFieldValueMap } from "../../../__mocks__/WizardHelper.mock";
-import { generateAdvancedSearchCriteria } from "../../../tsrc/search/AdvancedSearchHelper";
+import type {
+  ControlTarget,
+  FieldValueMap,
+  PathValueMap,
+} from "../../../tsrc/components/wizard/WizardHelper";
+import {
+  buildFieldValueMapFromPathValueMap,
+  generateAdvancedSearchCriteria,
+} from "../../../tsrc/search/AdvancedSearchHelper";
 
 describe("generateAdvancedSearchCriteria()", () => {
   it("builds SearchAdditionalParams for Wizard controls", () => {
@@ -82,5 +90,23 @@ describe("generateAdvancedSearchCriteria()", () => {
     ];
 
     expect(query).toStrictEqual(expectedCriteria);
+  });
+});
+
+describe("buildFieldValueMapFromPathValueMap", () => {
+  it("updates the values of FieldValueMap by pulling the values of PathValueMap", () => {
+    const path = "/item/name";
+    const controlTarget: ControlTarget = {
+      schemaNode: [path],
+      type: "editbox",
+    };
+    const fieldValueMap: FieldValueMap = new Map([[controlTarget, []]]);
+    const pathValueMap: PathValueMap = new Map([[path, ["hello"]]]);
+    const updatedMap = buildFieldValueMapFromPathValueMap(
+      pathValueMap,
+      fieldValueMap
+    );
+
+    expect(updatedMap).toStrictEqual(new Map([[controlTarget, ["hello"]]]));
   });
 });

--- a/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
@@ -644,7 +644,7 @@ describe("<SearchPage/>", () => {
       SearchPageHelper.generateSearchPageOptionsFromQueryString
     ).toHaveBeenCalledTimes(1);
     expect(mockClipboard).toHaveBeenCalledWith(
-      "/?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RANK%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22mimeTypeFilters%22%3A%5B%5D%2C%22displayMode%22%3A%22list%22%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D"
+      "/page/search?searchOptions=%7B%22rowsPerPage%22%3A10%2C%22currentPage%22%3A0%2C%22sortOrder%22%3A%22RANK%22%2C%22rawMode%22%3Afalse%2C%22status%22%3A%5B%22LIVE%22%2C%22REVIEW%22%5D%2C%22searchAttachments%22%3Atrue%2C%22query%22%3A%22%22%2C%22collections%22%3A%5B%5D%2C%22lastModifiedDateRange%22%3A%7B%7D%2C%22mimeTypeFilters%22%3A%5B%5D%2C%22displayMode%22%3A%22list%22%2C%22dateRangeQuickModeEnabled%22%3Atrue%7D"
     );
     expect(
       screen.getByText(languageStrings.searchpage.shareSearchConfirmationText)

--- a/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
@@ -344,12 +344,12 @@ describe("processLegacyAdvSearchCriteria", () => {
 
   it("supports a Schema node that targets to an attribute", () => {
     const pathValueMap = processLegacyAdvSearchCriteria(
-      "<xml><country population='100'><city size='small'>hobart</city></country></xml>"
+      "<xml><country population='100'><city size='small'>Hobart</city><city size='small'>Darwin</city><city size='medium'>Canberra</city></country></xml>"
     );
     expect(pathValueMap).toStrictEqual(
       new Map([
-        ["/country/city", ["hobart"]],
-        ["/country/city/@size", ["small"]],
+        ["/country/city", ["Hobart", "Darwin", "Canberra"]],
+        ["/country/city/@size", ["small", "medium"]],
         ["/country/@population", ["100"]],
       ])
     );

--- a/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
@@ -182,7 +182,7 @@ describe("legacyQueryStringToSearchOptions", () => {
 
     //Query string was obtained from legacy UI searching.do->Share URL
     const fullQueryString =
-      "?in=C8e3caf16-f3cb-b3dd-d403-e5eb8d545fff&q=test&sort=datecreated&owner=680f5eb7-22e2-4ab6-bcea-25205165e36e&dp=1601510400000&dr=AFTER&doc=<editbox>box</editbox>";
+      "?in=C8e3caf16-f3cb-b3dd-d403-e5eb8d545fff&q=test&sort=datecreated&owner=680f5eb7-22e2-4ab6-bcea-25205165e36e&dp=1601510400000&dr=AFTER&doc=<xml><editbox>box</editbox></xml>";
 
     const convertedParamsPromise = await legacyQueryStringToSearchPageOptions(
       new URLSearchParams(fullQueryString)

--- a/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/search/SearchPageHelper.test.ts
@@ -341,4 +341,17 @@ describe("processLegacyAdvSearchCriteria", () => {
     );
     expect(pathValueMap).toStrictEqual(new Map([["/country", ["aus"]]]));
   });
+
+  it("supports a Schema node that targets to an attribute", () => {
+    const pathValueMap = processLegacyAdvSearchCriteria(
+      "<xml><country population='100'><city size='small'>hobart</city></country></xml>"
+    );
+    expect(pathValueMap).toStrictEqual(
+      new Map([
+        ["/country/city", ["hobart"]],
+        ["/country/city/@size", ["small"]],
+        ["/country/@population", ["100"]],
+      ])
+    );
+  });
 });

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -146,6 +146,16 @@ export type FieldValueMap = Map<ControlTarget, ControlValue>;
 export type PathValueMap = Map<string, ControlValue>;
 
 /**
+ * Type guard to check whether a Map is a PathValueMap or FieldValueMap.
+ *
+ * @param m A map that is either a PathValueMap or FieldValueMap.
+ */
+export const isPathValueMap = (
+  m: PathValueMap | FieldValueMap
+): m is PathValueMap =>
+  pipe(m, M.keys(OrdAsIs), isHeadType<string>(S.isString));
+
+/**
  * Creates a function which checks the type of the head of an array using the supplied refinement
  * function. The resulting function returns true when it is passed an array who's head element
  * matches the refinement specifications, otherwise (including if the array is empty) it will
@@ -178,12 +188,13 @@ export const isControlValueNonEmpty = (xs: ControlValue): boolean =>
  * Converts a `ControlValue` to a string array regardless of whether it contains strings or
  * numbers.
  */
-const controlValueToStringArray: (_: ControlValue) => ReadonlyArray<string> =
-  pfTernaryTypeGuard<string[], number[], string[]>(
-    isStringArray,
-    identity,
-    A.map(N.Show.show)
-  );
+export const controlValueToStringArray: (
+  _: ControlValue
+) => ReadonlyArray<string> = pfTernaryTypeGuard<string[], number[], string[]>(
+  isStringArray,
+  identity,
+  A.map(N.Show.show)
+);
 
 /**
  * Type guard which not only checks if a Wizard control value is string but also checks if the value

--- a/react-front-end/tsrc/search/AdvancedSearchHelper.ts
+++ b/react-front-end/tsrc/search/AdvancedSearchHelper.ts
@@ -70,8 +70,8 @@ export const buildFieldValueMapFromPathValueMap = (
           O.getOrElse(() => defaultValue)
         )
       ),
-      A.map(RA.toArray),
-      A.flatten
+      RA.flatten,
+      RA.toArray
     );
 
   return pipe(

--- a/react-front-end/tsrc/search/AdvancedSearchHelper.ts
+++ b/react-front-end/tsrc/search/AdvancedSearchHelper.ts
@@ -43,7 +43,7 @@ import { pfTernaryTypeGuard } from "../util/pointfree";
 import { Action as SearchPageModeAction } from "./SearchPageModeReducer";
 
 // Function to pull values of PathValueMap and copy to FieldValueMap for each unique Schema node.
-const buildFieldValueMapFromPathValueMap = (
+export const buildFieldValueMapFromPathValueMap = (
   pathValueMap: PathValueMap,
   fieldValueMap: FieldValueMap
 ): FieldValueMap => {

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -36,7 +36,10 @@ import { useHistory, useLocation, useParams } from "react-router";
 import { getBaseUrl } from "../AppConfig";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import MessageInfo, { MessageInfoVariant } from "../components/MessageInfo";
-import type { FieldValueMap } from "../components/wizard/WizardHelper";
+import type {
+  FieldValueMap,
+  PathValueMap,
+} from "../components/wizard/WizardHelper";
 import {
   ControlValue,
   isControlValueNonEmpty,
@@ -307,18 +310,33 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           setAdvancedSearches(advancedSearches);
           setCurrentUser(currentUserDetails);
 
-          const initialAdvancedSearchCriteria = pipe(
+          const currentFieldValue: FieldValueMap | PathValueMap | undefined =
+            pipe(
+              queryStringSearchOptions,
+              O.fromNullable,
+              O.map(
+                ({ advFieldValue, legacyAdvSearchCriteria }) =>
+                  advFieldValue ?? legacyAdvSearchCriteria
+              ),
+              O.getOrElseW(() => searchPageOptions.advFieldValue)
+            );
+
+          const initialAdvSearchFieldValueMap = pipe(
             advancedSearchDefinition,
             O.fromNullable,
             O.map((def) =>
               initialiseAdvancedSearch(
                 def,
                 searchPageModeDispatch,
-                // queryStringSearchOptions takes precedence.
-                queryStringSearchOptions?.advFieldValue ??
-                  searchPageOptions.advFieldValue
+                currentFieldValue
               )
             ),
+            O.toUndefined
+          );
+
+          const initialAdvancedSearchCriteria = pipe(
+            initialAdvSearchFieldValueMap,
+            O.fromNullable,
             O.map(generateAdvancedSearchCriteria),
             O.toUndefined
           );
@@ -332,6 +350,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
               dateRangeQuickModeEnabled: false,
               sortOrder: options.sortOrder ?? searchSettings.defaultSearchSort,
               advancedSearchCriteria: initialAdvancedSearchCriteria,
+              advFieldValue: initialAdvSearchFieldValueMap,
             })),
             O.getOrElse<SearchPageOptions>(() => ({
               ...searchPageOptions,

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -18,7 +18,7 @@
 import { debounce, Drawer, Grid, Hidden } from "@material-ui/core";
 import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
-import { pipe } from "fp-ts/function";
+import { constant, pipe } from "fp-ts/function";
 import * as M from "fp-ts/Map";
 import * as O from "fp-ts/Option";
 import { isEqual } from "lodash";
@@ -43,7 +43,11 @@ import {
   isNonEmptyString,
 } from "../components/wizard/WizardHelper";
 import { AppRenderErrorContext } from "../mainui/App";
-import { NEW_SEARCH_PATH, routes } from "../mainui/routes";
+import {
+  NEW_ADVANCED_SEARCH_PATH,
+  NEW_SEARCH_PATH,
+  routes,
+} from "../mainui/routes";
 import { templateDefaults, TemplateUpdateProps } from "../mainui/Template";
 import {
   getAdvancedSearchByUuid,
@@ -250,6 +254,13 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
         scrollToTop,
       }),
     [dispatch]
+  );
+
+  const pathname = pipe(
+    advancedSearchId,
+    O.fromNullable,
+    O.map((id) => `${NEW_ADVANCED_SEARCH_PATH}/${id}`),
+    O.getOrElse(constant(NEW_SEARCH_PATH))
   );
 
   /**
@@ -638,10 +649,9 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const handleCopySearch = () => {
     //base institution urls have a trailing / that we need to get rid of
     const instUrl = getBaseUrl().slice(0, -1);
-    const searchUrl = `${instUrl}${
-      location.pathname
-    }?${generateQueryStringFromSearchPageOptions(searchPageOptions)}`;
-
+    const searchUrl = `${instUrl}${pathname}?${generateQueryStringFromSearchPageOptions(
+      searchPageOptions
+    )}`;
     navigator.clipboard
       .writeText(searchUrl)
       .then(() => {
@@ -652,9 +662,9 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
   const handleSaveFavouriteSearch = (name: string) => {
     // We only need pathname and query strings.
-    const url = `${
-      location.pathname
-    }?${generateQueryStringFromSearchPageOptions(searchPageOptions)}`;
+    const url = `${pathname}?${generateQueryStringFromSearchPageOptions(
+      searchPageOptions
+    )}`;
 
     return addFavouriteSearch(name, url).then(() =>
       setSnackBar({

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -36,10 +36,7 @@ import { useHistory, useLocation, useParams } from "react-router";
 import { getBaseUrl } from "../AppConfig";
 import { DateRangeSelector } from "../components/DateRangeSelector";
 import MessageInfo, { MessageInfoVariant } from "../components/MessageInfo";
-import type {
-  FieldValueMap,
-  PathValueMap,
-} from "../components/wizard/WizardHelper";
+import type { FieldValueMap } from "../components/wizard/WizardHelper";
 import {
   ControlValue,
   isControlValueNonEmpty,
@@ -310,36 +307,20 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           setAdvancedSearches(advancedSearches);
           setCurrentUser(currentUserDetails);
 
-          const currentFieldValue: FieldValueMap | PathValueMap | undefined =
+          const [initialAdvSearchFieldValueMap, initialAdvancedSearchCriteria] =
             pipe(
-              queryStringSearchOptions,
+              advancedSearchDefinition,
               O.fromNullable,
-              O.map(
-                ({ advFieldValue, legacyAdvSearchCriteria }) =>
-                  advFieldValue ?? legacyAdvSearchCriteria
+              O.map((def) =>
+                initialiseAdvancedSearch(
+                  def,
+                  searchPageModeDispatch,
+                  searchPageOptions,
+                  queryStringSearchOptions
+                )
               ),
-              O.getOrElseW(() => searchPageOptions.advFieldValue)
+              O.getOrElseW(() => [])
             );
-
-          const initialAdvSearchFieldValueMap = pipe(
-            advancedSearchDefinition,
-            O.fromNullable,
-            O.map((def) =>
-              initialiseAdvancedSearch(
-                def,
-                searchPageModeDispatch,
-                currentFieldValue
-              )
-            ),
-            O.toUndefined
-          );
-
-          const initialAdvancedSearchCriteria = pipe(
-            initialAdvSearchFieldValueMap,
-            O.fromNullable,
-            O.map(generateAdvancedSearchCriteria),
-            O.toUndefined
-          );
 
           // This is the SearchPageOptions for the first searching, not the one created in the first rendering.
           const initialSearchPageOptions = pipe(

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -470,7 +470,7 @@ const buildPathValueMap = (
 
 // Convert a XML string into a Map where key is a string representing a unique schema node
 // and value is an array of string.
-const processLegacyAdvSearchCriteria = (
+export const processLegacyAdvSearchCriteria = (
   s: string
 ): PathValueMap | undefined => {
   const parser = new DOMParser();

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -390,7 +390,7 @@ const buildPathValueMap = (node: Element, parentPath = ""): PathValueMap => {
   const mergeMaps = (
     firstMap: Map<string, string[]>,
     secondMap: Map<string, string[]>
-  ) => pipe(firstMap, M.union(S.Eq, A.getSemigroup<string>())(secondMap));
+  ) => pipe(firstMap, M.union(S.Eq, A.getUnionSemigroup(S.Eq))(secondMap));
 
   const buildMapForLastNode = () =>
     textContent ? new Map([[fullPath, [textContent]]]) : new Map();
@@ -417,7 +417,7 @@ const buildPathValueMap = (node: Element, parentPath = ""): PathValueMap => {
     M.fromFoldable(S.Eq, A.getSemigroup<string>(), A.Foldable)
   );
 
-  return pipe(valueMap, M.union(S.Eq, A.getSemigroup<string>())(attributeMap));
+  return mergeMaps(valueMap, attributeMap);
 };
 
 /**


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for converting a Legacy advanced search criteria into a `PathValueMap` which can be further used to generated a `FieldValueMap`. As a result, any search shared from Old UI or favourited in Old UI can be viewed in the new Search UI.


Key steps are:
1. Use DOMParser to parse the XML string and generate a DOM tree, and then walk through the tree and build a PathValueMap.
2. Update `AdvancedSearchHelper` to support converting the PathValueMap to the initial FieldValueMap.

https://user-images.githubusercontent.com/47203811/144786714-d47af018-0cc7-44f4-9191-90ac5141fa94.mp4



