### PR TITLE
chore: ensure all Lightbox buttons have tooltips

### DIFF
--- a/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/GallerySearchResult.test.tsx
@@ -39,7 +39,7 @@ const {
     gallerySearchResult: { ariaLabel, viewItem },
   },
   common: {
-    action: { openInNewWindow },
+    action: { openInNewTab },
   },
   lightboxComponent: { viewNext, viewPrevious },
 } = languageStrings;
@@ -71,7 +71,7 @@ describe("<GallerySearchResult />", () => {
     });
 
     // Then they see the lightbox
-    expect(queryAllByLabelText(openInNewWindow)[0]).toBeInTheDocument();
+    expect(queryAllByLabelText(openInNewTab)[0]).toBeInTheDocument();
   });
 
   it("navigates to the images item when the information icon is clicked on", async () => {

--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -176,7 +176,7 @@ describe("<SearchResult/>", () => {
 
     // Then they see the lightbox
     expect(
-      queryByLabelText(languageStrings.common.action.openInNewWindow)
+      queryByLabelText(languageStrings.common.action.openInNewTab)
     ).toBeInTheDocument();
   });
 
@@ -304,7 +304,7 @@ describe("<SearchResult/>", () => {
 
       // ...There is a lightbox
       expect(
-        queryByLabelText(languageStrings.common.action.openInNewWindow)
+        queryByLabelText(languageStrings.common.action.openInNewTab)
       ).toBeInTheDocument();
     });
   });

--- a/react-front-end/tsrc/components/Lightbox.tsx
+++ b/react-front-end/tsrc/components/Lightbox.tsx
@@ -15,14 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Backdrop,
-  Grid,
-  IconButton,
-  Theme,
-  Toolbar,
-  Typography,
-} from "@material-ui/core";
+import { Backdrop, Grid, Theme, Toolbar, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import CloseIcon from "@material-ui/icons/Close";
 import CodeIcon from "@material-ui/icons/Code";
@@ -135,9 +128,9 @@ const {
   openSummaryPage: openSummaryPageString,
 } = languageStrings.lightboxComponent;
 
-const { openInNewTab: openInNewTabString } = languageStrings.common.action;
+const { copy: labelCopy } = languageStrings.embedCode;
 
-const { close: labelClose, openInNewWindow: labelOpenInNewWindow } =
+const { close: labelClose, openInNewTab: labelOpenInNewTab } =
   languageStrings.common.action;
 
 const { unsupportedContent: labelUnsupportedContent } =
@@ -274,7 +267,9 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
         <OEQItemSummaryPageButton
           {...{ item, title: openSummaryPageString, color: "inherit" }}
         />
-        <IconButton
+        <TooltipIconButton
+          title={labelCopy}
+          color="inherit"
           className={classes.menuButton}
           aria-label={copyEmbedCodeString}
           onClick={(event) => {
@@ -283,12 +278,12 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
           }}
         >
           <CodeIcon />
-        </IconButton>
+        </TooltipIconButton>
         <TooltipIconButton
-          title={openInNewTabString}
+          title={labelOpenInNewTab}
           color="inherit"
           className={classes.menuButton}
-          aria-label={labelOpenInNewWindow}
+          aria-label={labelOpenInNewTab}
           onClick={handleOpenInNewWindow}
         >
           <OpenInNewIcon />
@@ -298,13 +293,15 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
           // with most lightboxes which typically support clicking anywhere outside the content to
           // trigger a close.
         }
-        <IconButton
+        <TooltipIconButton
+          title={labelClose}
+          color="inherit"
           className={classes.menuButton}
           aria-label={labelClose}
           onClick={handleCloseLightbox}
         >
           <CloseIcon />
-        </IconButton>
+        </TooltipIconButton>
       </Toolbar>
       <Grid container alignItems="center">
         <Grid item xs={1}>

--- a/react-front-end/tsrc/components/Lightbox.tsx
+++ b/react-front-end/tsrc/components/Lightbox.tsx
@@ -46,6 +46,19 @@ import LightboxMessage from "./LightboxMessage";
 import { OEQItemSummaryPageButton } from "./OEQItemSummaryPageButton";
 import { TooltipIconButton } from "./TooltipIconButton";
 
+const {
+  common: {
+    action: { close: labelClose, openInNewTab: labelOpenInNewTab },
+  },
+  lightboxComponent: {
+    viewNext: labelViewNext,
+    viewPrevious: labelViewPrevious,
+    openSummaryPage: labelOpenSummaryPage,
+    unsupportedContent: labelUnsupportedContent,
+  },
+  embedCode: { copy: labelCopyEmbedCode },
+} = languageStrings;
+
 const useStyles = makeStyles((theme: Theme) => ({
   lightboxBackdrop: {
     backgroundColor: "#000000cc",
@@ -121,22 +134,6 @@ export interface LightboxProps {
     version: number;
   };
 }
-
-const {
-  viewNext: viewNextString,
-  viewPrevious: viewPreviousString,
-  openSummaryPage: openSummaryPageString,
-} = languageStrings.lightboxComponent;
-
-const { copy: labelCopy } = languageStrings.embedCode;
-
-const { close: labelClose, openInNewTab: labelOpenInNewTab } =
-  languageStrings.common.action;
-
-const { unsupportedContent: labelUnsupportedContent } =
-  languageStrings.lightboxComponent;
-
-const { copy: copyEmbedCodeString } = languageStrings.embedCode;
 
 const domParser = new DOMParser();
 
@@ -265,13 +262,13 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
           {title}
         </Typography>
         <OEQItemSummaryPageButton
-          {...{ item, title: openSummaryPageString, color: "inherit" }}
+          {...{ item, title: labelOpenSummaryPage, color: "inherit" }}
         />
         <TooltipIconButton
-          title={labelCopy}
+          title={labelCopyEmbedCode}
           color="inherit"
           className={classes.menuButton}
-          aria-label={copyEmbedCodeString}
+          aria-label={labelCopyEmbedCode}
           onClick={(event) => {
             event.stopPropagation();
             setOpenEmbedCodeDialog(true);
@@ -307,7 +304,7 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
         <Grid item xs={1}>
           {onPrevious && (
             <TooltipIconButton
-              title={viewPreviousString}
+              title={labelViewPrevious}
               onClick={(e) => {
                 e.stopPropagation();
                 handleNav(onPrevious);
@@ -326,7 +323,7 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
           <Grid item>
             {onNext && (
               <TooltipIconButton
-                title={viewNextString}
+                title={labelViewNext}
                 onClick={(e) => {
                   e.stopPropagation();
                   handleNav(onNext);

--- a/react-front-end/tsrc/components/Lightbox.tsx
+++ b/react-front-end/tsrc/components/Lightbox.tsx
@@ -135,6 +135,8 @@ const {
   openSummaryPage: openSummaryPageString,
 } = languageStrings.lightboxComponent;
 
+const { openInNewTab: openInNewTabString } = languageStrings.common.action;
+
 const { close: labelClose, openInNewWindow: labelOpenInNewWindow } =
   languageStrings.common.action;
 
@@ -282,13 +284,15 @@ const Lightbox = ({ open, onClose, config, item }: LightboxProps) => {
         >
           <CodeIcon />
         </IconButton>
-        <IconButton
+        <TooltipIconButton
+          title={openInNewTabString}
+          color="inherit"
           className={classes.menuButton}
           aria-label={labelOpenInNewWindow}
           onClick={handleOpenInNewWindow}
         >
           <OpenInNewIcon />
-        </IconButton>
+        </TooltipIconButton>
         {
           // This following close button is really just added as a security blanket. A common thing
           // with most lightboxes which typically support clicking anywhere outside the content to

--- a/react-front-end/tsrc/util/langstrings.ts
+++ b/react-front-end/tsrc/util/langstrings.ts
@@ -166,6 +166,7 @@ export const languageStrings = {
       no: "No",
       ok: "OK",
       openInNewWindow: "Open in new window",
+      openInNewTab: "Open in new tab",
       refresh: "Refresh",
       reject: "Reject",
       register: "Register",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Add help text for Open in new tab button in Lightbox.
Add help text for Close button in Lightbox.
Add help text for Copy buttton in Lightbox.

I use TooltipButton instead of IconButton, but we lost the background animation for Open in new tab icon.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

https://user-images.githubusercontent.com/92769668/144938832-1e456ec9-87bd-4255-be95-9a46213e4f96.mp4

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
