### PR TITLE
feat: With visibility scripting, clear values of any hidden fields

### DIFF
--- a/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
+++ b/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
@@ -42,6 +42,7 @@ export const Simple: Story<AdvancedSearchPanelProps> = (args) => (
 );
 Simple.args = {
   wizardControls: controls,
+  values: new Map(),
 };
 
 export const NoRequiredFields: Story<AdvancedSearchPanelProps> = (args) => (
@@ -51,4 +52,5 @@ NoRequiredFields.args = {
   wizardControls: controls.map((c) =>
     OEQ.WizardControl.isWizardBasicControl(c) ? { ...c, mandatory: false } : c
   ),
+  values: new Map(),
 };

--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -43,8 +43,8 @@ const countBy =
     pipe(as, NEA.groupBy(by), R.map(A.size));
 
 describe("render()", () => {
-  const logOnChange = (update: FieldValue): void =>
-    console.debug("onChange called", update);
+  const logOnChange = (updates: FieldValue[]): void =>
+    console.debug("onChange called", updates);
 
   const noFieldValues = new Map();
 
@@ -245,4 +245,39 @@ describe("render()", () => {
       expect(visibleControls).toHaveLength(controlsVisible);
     }
   );
+
+  it("calls onChange to clear the value for any hidden control", () => {
+    const testNode = "/item/hidden";
+    const testTarget: ControlTarget = {
+      schemaNode: [testNode],
+      type: "editbox",
+      isValueTokenised: true,
+    };
+    const testValues: FieldValueMap = M.singleton(testTarget, ["test value"]);
+    const mockOnChange = jest.fn();
+
+    render(
+      [
+        {
+          ...mockWizardControlFactory({
+            controlType: "editbox",
+            mandatory: false,
+            schemaNodes: [{ target: testNode, attribute: "" }],
+            options: [],
+            defaultValues: [],
+          }),
+          visibilityScript: "return false;", // i.e. always hidden - no need to get tricky
+        },
+      ],
+      testValues,
+      mockOnChange,
+      buildVisibilityScriptContext(testValues, guestUser)
+    );
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    // Note value being cleared via `[]`
+    expect(mockOnChange).toHaveBeenCalledWith([
+      { target: testTarget, value: [] },
+    ]);
+  });
 });

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -111,16 +111,21 @@ export const AdvancedSearchPanel = ({
   );
 
   const onChangeHandler = useCallback(
-    ({ target, value }: WizardHelper.FieldValue): void => {
+    (updates: WizardHelper.FieldValue[]): void => {
       console.debug("AdvancedSearchPanel : onChangeHandler called.", {
         currentValues,
-        update: {
-          target,
-          value,
-        },
+        updates,
       });
-      setCurrentValues(
-        pipe(currentValues, WizardHelper.fieldValueMapInsert(target, value))
+      pipe(
+        updates,
+        A.reduce(
+          currentValues,
+          (
+            valueMap: WizardHelper.FieldValueMap,
+            { target, value }: WizardHelper.FieldValue
+          ) => pipe(valueMap, WizardHelper.fieldValueMapInsert(target, value))
+        ),
+        setCurrentValues
       );
     },
     [currentValues, setCurrentValues]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

To match Legacy UI workings, when a field is hidden due to visibility scripting, then it's value should be cleared. This change adds that.

Also includes minor fix to AdvancedSearchPanel.stories... Not sure how long that's been broken....

https://user-images.githubusercontent.com/43919233/144963888-4c22cfb2-9ede-4154-b67d-ed526e948118.mp4


<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
