### PR TITLE
fix: additional whitespace in user selector

### DIFF
--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -130,7 +130,7 @@ export const AdvancedSearchPanel = ({
             currentValues,
             onChangeHandler
           ).map((e) => (
-            <Grid key={e.props.id} item>
+            <Grid key={e.props.id} item container direction="column">
               {e}
             </Grid>
           ))}

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -130,7 +130,7 @@ export const AdvancedSearchPanel = ({
             currentValues,
             onChangeHandler
           ).map((e) => (
-            <Grid key={e.props.id} item container direction="column">
+            <Grid key={e.props.id} container direction="column">
               {e}
             </Grid>
           ))}

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -130,7 +130,8 @@ export const AdvancedSearchPanel = ({
             currentValues,
             onChangeHandler
           ).map((e) => (
-            <Grid key={e.props.id} container direction="column">
+            // width is a tricky way to fix additional whitespace issue caused by user selector
+            <Grid key={e.props.id} item style={{ width: "100%" }}>
               {e}
             </Grid>
           ))}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Fix additional whitespace in user selector by adding two classes to the root div for wizards in AdvSearchPanel.

Solution found in [here](https://stackoverflow.com/questions/51445959/unexpected-empty-space-using-flexbox).
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

https://user-images.githubusercontent.com/92769668/144966006-e633327d-04bf-4014-88e9-c61d14f91900.mp4

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
