### PR TITLE
feat(frontend): add error handling for wizard controls

### DIFF
--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -69,6 +69,15 @@ import { WizardSimpleTermSelector } from "./WizardSimpleTermSelector";
 import { WizardUnsupported } from "./WizardUnsupported";
 import { WizardUserSelector } from "./WizardUserSelector";
 
+export const WizardErrorContext = React.createContext<{
+  /**
+   * Function to handle errors thrown from wizard components.
+   */
+  handleError: (error: Error) => void;
+}>({
+  handleError: () => {},
+});
+
 /**
  * Provide basic props a Wizard control component needs.
  */

--- a/react-front-end/tsrc/components/wizard/WizardSimpleTermSelector.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardSimpleTermSelector.tsx
@@ -34,15 +34,15 @@ import { not } from "fp-ts/Predicate";
 import * as RA from "fp-ts/ReadonlyArray";
 import * as RSET from "fp-ts/ReadonlySet";
 import * as S from "fp-ts/string";
-import * as TE from "fp-ts/TaskEither";
 import * as T from "fp-ts/Task";
+import * as TE from "fp-ts/TaskEither";
 import * as React from "react";
-import { useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { searchTaxonomyTerms } from "../../modules/TaxonomyModule";
 import { languageStrings } from "../../util/langstrings";
 import { OrdAsIs } from "../../util/Ord";
 import { TooltipIconButton } from "../TooltipIconButton";
-import { WizardControlBasicProps } from "./WizardHelper";
+import { WizardControlBasicProps, WizardErrorContext } from "./WizardHelper";
 import { WizardLabel } from "./WizardLabel";
 
 export interface WizardSimpleTermSelectorProps extends WizardControlBasicProps {
@@ -110,6 +110,8 @@ export const WizardSimpleTermSelector = ({
 
   const [loading, setLoading] = useState<boolean>(false);
 
+  const { handleError } = useContext(WizardErrorContext);
+
   const searchTerms = useMemo(
     () =>
       debounce(async (query: string) => {
@@ -136,12 +138,10 @@ export const WizardSimpleTermSelector = ({
 
         pipe(
           await taskChain(),
-          E.fold((e) => {
-            throw new Error(e);
-          }, setOptions)
+          E.fold(flow(E.toError, handleError), setOptions)
         );
       }, 500),
-    [selectionRestriction, selectedTaxonomy, termProvider]
+    [handleError, selectedTaxonomy, selectionRestriction, termProvider]
   );
 
   const removeSelectedTerm = (term: string) =>

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -33,7 +33,10 @@ import * as TE from "fp-ts/TaskEither";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { TooltipIconButton } from "../../components/TooltipIconButton";
 import * as WizardHelper from "../../components/wizard/WizardHelper";
-import { buildVisibilityScriptContext } from "../../components/wizard/WizardHelper";
+import {
+  buildVisibilityScriptContext,
+  WizardErrorContext,
+} from "../../components/wizard/WizardHelper";
 import { getCurrentUserDetails, guestUser } from "../../modules/UserModule";
 import { languageStrings } from "../../util/langstrings";
 import { SearchPageRenderErrorContext } from "../SearchPage";
@@ -152,16 +155,18 @@ export const AdvancedSearchPanel = ({
           direction="column"
           spacing={2}
         >
-          {WizardHelper.render(
-            wizardControls,
-            currentValues,
-            onChangeHandler,
-            buildVisibilityScriptContext(currentValues, currentUser)
-          ).map((e) => (
-            <Grid key={e.props.id} item>
-              {e}
-            </Grid>
-          ))}
+          <WizardErrorContext.Provider value={{ handleError }}>
+            {WizardHelper.render(
+              wizardControls,
+              currentValues,
+              onChangeHandler,
+              buildVisibilityScriptContext(currentValues, currentUser)
+            ).map((e) => (
+              <Grid key={e.props.id} item>
+                {e}
+              </Grid>
+            ))}
+          </WizardErrorContext.Provider>
           {hasRequiredFields && (
             <Grid item>
               <Typography variant="caption" color="textSecondary">


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Some Wizard Controls are a bit smarter than others (say, with async
calls) and as a result are prone to have errors. Therefore, we need a
standard way for them to report their errors.

For this, I've created a React Context that sits in WizardHelper so that
 any wizard rendered controls can be wrapped in that context and can
 rely on it be present. Currently, this is only in the Advanced Search
 Panel, but in the future it would be in the components for contribution
  wizards.

Tests: Covered mostly be existing tests, plus manual testing to ensure when network connectivity was broken that the standard search page error toast was displayed.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
