### PR TITLE
Feature/adv search page in selection session

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootAdvancedSearchSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/section/RootAdvancedSearchSection.java
@@ -73,8 +73,6 @@ public class RootAdvancedSearchSection extends RootSearchSection {
 
   @Override
   public boolean useNewSearch() {
-    // Because we haven't built any new UI for Advanced search, return false
-    // to keep using old UI.
-    return false;
+    return true;
   }
 }

--- a/react-front-end/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
@@ -235,6 +235,7 @@ describe("buildSelectionSessionAdvancedSearchLink", () => {
     updateMockGetRenderData(basicRenderData);
     updateMockGetBaseUrl();
   });
+
   const advSearchId = "72558c1d-8788-4515-86c8-b24a28cc451e";
 
   it("builds a link for accessing an Advanced search", () => {

--- a/react-front-end/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/LegacySelectionSessionModule.test.ts
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 import { getSearchResult } from "../../../__mocks__/SearchResult.mock";
-import type { RenderData } from "../../../tsrc/AppConfig";
+import type { RenderData, SelectionSessionInfo } from "../../../tsrc/AppConfig";
 import {
   buildPostDataForSelectOrAdd,
   buildPostDataForStructured,
+  buildSelectionSessionAdvancedSearchLink,
   buildSelectionSessionItemSummaryLink,
+  buildSelectionSessionSearchPageLink,
   isSelectionSessionOpen,
   isSelectSummaryButtonDisabled,
   SelectionSessionPostData,
@@ -29,6 +31,7 @@ import { languageStrings } from "../../../tsrc/util/langstrings";
 import { defaultBaseUrl, updateMockGetBaseUrl } from "../BaseUrlHelper";
 import {
   basicRenderData,
+  basicSelectionSessionInfo,
   renderDataForSelectOrAdd,
   selectSummaryButtonDisabled,
   updateMockGetRenderData,
@@ -223,6 +226,57 @@ describe("isSelectSummaryButtonDisabled", () => {
     ) => {
       updateMockGetRenderData(renderData);
       expect(isSelectSummaryButtonDisabled()).toBe(isButtonDisabled);
+    }
+  );
+});
+
+describe("buildSelectionSessionAdvancedSearchLink", () => {
+  beforeEach(() => {
+    updateMockGetRenderData(basicRenderData);
+    updateMockGetBaseUrl();
+  });
+  const advSearchId = "72558c1d-8788-4515-86c8-b24a28cc451e";
+
+  it("builds a link for accessing an Advanced search", () => {
+    const link = buildSelectionSessionAdvancedSearchLink(advSearchId);
+    expect(link).toBe(
+      "http://localhost:8080/vanilla/advanced/searching.do?in=P72558c1d-8788-4515-86c8-b24a28cc451e&editquery=true&_sl.stateId=1"
+    );
+  });
+
+  it("supports including external MIME types in the link", () => {
+    const link = buildSelectionSessionAdvancedSearchLink(advSearchId, [
+      "image/gif",
+    ]);
+    expect(link).toBe(
+      "http://localhost:8080/vanilla/advanced/searching.do?in=P72558c1d-8788-4515-86c8-b24a28cc451e&editquery=true&_sl.stateId=1&_int.mimeTypes=image%2Fgif"
+    );
+  });
+});
+
+describe("buildSelectionSessionSearchPageLink", () => {
+  it.each<[string, SelectionSessionInfo, string]>([
+    ["structured", basicSelectionSessionInfo, "access/course"],
+    [
+      "selectoradd",
+      { ...basicSelectionSessionInfo, layout: "search" },
+      "selectoradd",
+    ],
+    [
+      "skinny",
+      { ...basicSelectionSessionInfo, layout: "skinnysearch" },
+      "access/skinny",
+    ],
+  ])(
+    "builds a link for accessing search page in %s layout",
+    (layout: string, selectionSessionInfo: SelectionSessionInfo, path) => {
+      updateMockGetRenderData({ ...basicRenderData, selectionSessionInfo });
+      updateMockGetBaseUrl();
+      const link = buildSelectionSessionSearchPageLink(["image/gif"]);
+
+      expect(link).toBe(
+        `http://localhost:8080/vanilla/${path}/searching.do?_sl.stateId=1&_int.mimeTypes=image%2Fgif`
+      );
     }
   );
 });

--- a/react-front-end/tsrc/mainui/App.tsx
+++ b/react-front-end/tsrc/mainui/App.tsx
@@ -28,6 +28,7 @@ import { ReactNode, useCallback } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { getRouterBaseName } from "../AppConfig";
 import MessageInfo from "../components/MessageInfo";
+import { getAdvancedSearchIdFromLocation } from "../modules/AdvancedSearchModule";
 import { getOeqTheme } from "../modules/ThemeModule";
 import { startHeartbeat } from "../util/heartbeat";
 import { simpleMatch } from "../util/match";
@@ -150,7 +151,12 @@ const App = ({ entryPage }: AppProps): JSX.Element => {
         },
         searchPage: () => (
           <NewPage classPrefix="oeq-nsp">
-            <SearchPage updateTemplate={nop} />
+            <SearchPage
+              updateTemplate={nop}
+              advancedSearchId={getAdvancedSearchIdFromLocation(
+                window.location
+              )}
+            />
           </NewPage>
         ),
         settingsPage: () => (

--- a/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
@@ -19,7 +19,7 @@ import Axios from "axios";
 import * as A from "fp-ts/Array";
 import * as IO from "fp-ts/IO";
 import * as E from "fp-ts/Either";
-import { flow, identity, pipe } from "fp-ts/function";
+import { flow, pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
 import {
   API_BASE_URL,
@@ -275,7 +275,7 @@ export const buildSelectionSessionRemoteSearchLink = (uuid: string): string =>
   buildSelectionSessionLink(routes.RemoteSearch.to(uuid));
 
 /**
- * Build a Selection Session specific Advanced search Link. The link will contains a list of MIME types if provided by LMS.
+ * Build a Selection Session specific Advanced search Link. The link will contain a list of MIME types if provided by LMS.
  * Recommended to first call `isSelectionSessionOpen()` before use.
  *
  * @param uuid The UUID of an Advanced search
@@ -293,7 +293,7 @@ export const buildSelectionSessionAdvancedSearchLink = (
 
 /**
  * Build a Selection Session specific Search page link. The three Selection Session layouts are supported.
- * The link will contains a list of MIME types if provided by LMS.
+ * The link will contain a list of MIME types if provided by LMS.
  * Recommended to first call `isSelectionSessionOpen()` before use.
  *
  * @param externalMimeTypes A list of MIME types provided by LMS.
@@ -311,8 +311,7 @@ export const buildSelectionSessionSearchPageLink = (
       _: () => {
         throw new Error("Unknown Selection Session layout");
       },
-    }),
-    identity
+    })
   );
 
   return buildSelectionSessionLink(

--- a/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
@@ -194,7 +194,7 @@ export const isSelectSummaryButtonDisabled = (): boolean => {
  * Validate the selectionSessionInfo included in renderData.
  * And return selectionSessionInfo if the checking is passed, or throw a type error.
  */
-const getSelectionSessionInfo = (): SelectionSessionInfo => {
+export const getSelectionSessionInfo = (): SelectionSessionInfo => {
   const selectionSessionInfo = getRenderData()?.selectionSessionInfo;
   if (isSelectionSessionInfo(selectionSessionInfo)) {
     return selectionSessionInfo;

--- a/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
@@ -18,7 +18,7 @@
 import Axios from "axios";
 import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
-import { flow, pipe } from "fp-ts/function";
+import { flow, identity, pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
 import {
   API_BASE_URL,
@@ -230,7 +230,8 @@ const submitSelection = <T>(
 
 const buildSelectionSessionLink = (
   routerPath: string,
-  includeLayout = false
+  includeLayout = false,
+  externalMimeTypes: string[] = []
 ) => {
   const { stateId, integId, layout } = getSelectionSessionInfo();
   const url = new URL(routerPath.substr(1), getBaseUrl()); // Drop routerPath's first '/'.
@@ -241,6 +242,11 @@ const buildSelectionSessionLink = (
   }
   if (includeLayout) {
     url.searchParams.append("a", layout);
+  }
+  if (A.isNonEmpty(externalMimeTypes)) {
+    externalMimeTypes.forEach((m) =>
+      url.searchParams.append("_int.mimeTypes", m)
+    );
   }
   return url.toString();
 };
@@ -265,12 +271,52 @@ export const buildSelectionSessionRemoteSearchLink = (uuid: string): string =>
   buildSelectionSessionLink(routes.RemoteSearch.to(uuid));
 
 /**
- * Build a Selection Session specific Advanced search Link. Recommended to first call `isSelectionSessionOpen()`
- * before use.
+ * Build a Selection Session specific Advanced search Link. The link will contains a list of MIME types if provided by LMS.
+ * Recommended to first call `isSelectionSessionOpen()` before use.
+ *
  * @param uuid The UUID of an Advanced search
+ * @param externalMimeTypes A list of MIME types provided by LMS.
  */
-export const buildSelectionSessionAdvancedSearchLink = (uuid: string): string =>
-  buildSelectionSessionLink(routes.OldAdvancedSearch.to(uuid));
+export const buildSelectionSessionAdvancedSearchLink = (
+  uuid: string,
+  externalMimeTypes?: string[]
+): string =>
+  buildSelectionSessionLink(
+    routes.OldAdvancedSearch.to(uuid),
+    false,
+    externalMimeTypes
+  );
+
+/**
+ * Build a Selection Session specific Search page link. The three Selection Session layouts are supported.
+ * The link will contains a list of MIME types if provided by LMS.
+ * Recommended to first call `isSelectionSessionOpen()` before use.
+ *
+ * @param externalMimeTypes A list of MIME types provided by LMS.
+ */
+export const buildSelectionSessionSearchPageLink = (
+  externalMimeTypes?: string[]
+) => {
+  const { layout } = getSelectionSessionInfo();
+  const legacySelectionSessionPath = pipe(
+    layout,
+    simpleMatch<string>({
+      coursesearch: () => "access/course",
+      search: () => "selectoradd",
+      skinnysearch: () => "access/skinny",
+      _: () => {
+        throw new Error("Unknown Selection Session layout");
+      },
+    }),
+    identity
+  );
+
+  return buildSelectionSessionLink(
+    `/${legacySelectionSessionPath}/searching.do`,
+    false,
+    externalMimeTypes
+  );
+};
 
 /**
  * Update the content of DIV "selection-summary". This function is primarily for

--- a/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
+++ b/react-front-end/tsrc/modules/LegacySelectionSessionModule.ts
@@ -17,6 +17,7 @@
  */
 import Axios from "axios";
 import * as A from "fp-ts/Array";
+import * as IO from "fp-ts/IO";
 import * as E from "fp-ts/Either";
 import { flow, identity, pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
@@ -243,11 +244,14 @@ const buildSelectionSessionLink = (
   if (includeLayout) {
     url.searchParams.append("a", layout);
   }
-  if (A.isNonEmpty(externalMimeTypes)) {
-    externalMimeTypes.forEach((m) =>
-      url.searchParams.append("_int.mimeTypes", m)
-    );
-  }
+
+  pipe(
+    externalMimeTypes,
+    A.traverse(IO.Applicative)(
+      (mimeType) => () => url.searchParams.append("_int.mimeTypes", mimeType)
+    )
+  )();
+
   return url.toString();
 };
 

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -184,18 +184,22 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     { mode: "normal" }
   );
 
+  // Function to navigate Search page or Advanced search page to another page. If in Selection Session,
+  // call the provided path builder to generate a Selection Session specific path.
+  const navigateTo = (
+    normalPath: string,
+    selectionSessionPathBuilder: () => string
+  ) => {
+    isSelectionSessionOpen()
+      ? window.open(selectionSessionPathBuilder(), "_self")
+      : history.push(normalPath);
+  };
+
   const exitAdvancedSearchMode = () => {
     searchPageModeDispatch({ type: "useNormal" });
-    if (isSelectionSessionOpen()) {
-      window.open(
-        buildSelectionSessionSearchPageLink(
-          searchPageOptions.externalMimeTypes
-        ),
-        "_self"
-      );
-    } else {
-      history.push(NEW_SEARCH_PATH);
-    }
+    navigateTo(NEW_SEARCH_PATH, () =>
+      buildSelectionSessionSearchPageLink(searchPageOptions.externalMimeTypes)
+    );
   };
 
   const defaultSearchPageHistory: SearchPageHistoryState = {
@@ -541,15 +545,12 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   ) => {
     if (selection) {
       const { uuid } = selection;
-      isSelectionSessionOpen()
-        ? window.open(
-            buildSelectionSessionAdvancedSearchLink(
-              uuid,
-              searchPageOptions.externalMimeTypes
-            ),
-            "_self"
-          )
-        : history.push(routes.NewAdvancedSearch.to(uuid));
+      navigateTo(routes.NewAdvancedSearch.to(uuid), () =>
+        buildSelectionSessionAdvancedSearchLink(
+          uuid,
+          searchPageOptions.externalMimeTypes
+        )
+      );
     } else {
       exitAdvancedSearchMode();
     }

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -117,6 +117,7 @@ import {
   generateSearchPageOptionsFromQueryString,
   getPartialSearchOptions,
   getRawModeFromStorage,
+  openSearchPageInSelectionSession,
   SearchPageOptions,
   writeRawModeToStorage,
 } from "./SearchPageHelper";
@@ -185,7 +186,11 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
 
   const exitAdvancedSearchMode = () => {
     searchPageModeDispatch({ type: "useNormal" });
-    history.push(NEW_SEARCH_PATH);
+    if (isSelectionSessionOpen()) {
+      openSearchPageInSelectionSession();
+    } else {
+      history.push(NEW_SEARCH_PATH);
+    }
   };
 
   const defaultSearchPageHistory: SearchPageHistoryState = {

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -61,6 +61,7 @@ import {
 import {
   buildSelectionSessionAdvancedSearchLink,
   buildSelectionSessionRemoteSearchLink,
+  buildSelectionSessionSearchPageLink,
   isSelectionSessionInStructured,
   isSelectionSessionOpen,
   prepareDraggable,
@@ -117,7 +118,6 @@ import {
   generateSearchPageOptionsFromQueryString,
   getPartialSearchOptions,
   getRawModeFromStorage,
-  openSearchPageInSelectionSession,
   SearchPageOptions,
   writeRawModeToStorage,
 } from "./SearchPageHelper";
@@ -187,7 +187,12 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
   const exitAdvancedSearchMode = () => {
     searchPageModeDispatch({ type: "useNormal" });
     if (isSelectionSessionOpen()) {
-      openSearchPageInSelectionSession();
+      window.open(
+        buildSelectionSessionSearchPageLink(
+          searchPageOptions.externalMimeTypes
+        ),
+        "_self"
+      );
     } else {
       history.push(NEW_SEARCH_PATH);
     }
@@ -537,7 +542,13 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
     if (selection) {
       const { uuid } = selection;
       isSelectionSessionOpen()
-        ? window.open(buildSelectionSessionAdvancedSearchLink(uuid), "_self")
+        ? window.open(
+            buildSelectionSessionAdvancedSearchLink(
+              uuid,
+              searchPageOptions.externalMimeTypes
+            ),
+            "_self"
+          )
         : history.push(routes.NewAdvancedSearch.to(uuid));
     } else {
       exitAdvancedSearchMode();

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -332,6 +332,8 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
               dateRangeQuickModeEnabled: false,
               sortOrder: options.sortOrder ?? searchSettings.defaultSearchSort,
               advancedSearchCriteria: initialAdvancedSearchCriteria,
+              collections:
+                advancedSearchDefinition?.collections ?? options.collections,
             })),
             O.getOrElse<SearchPageOptions>(() => ({
               ...searchPageOptions,

--- a/react-front-end/tsrc/search/SearchPageHelper.ts
+++ b/react-front-end/tsrc/search/SearchPageHelper.ts
@@ -18,7 +18,7 @@
 import * as OEQ from "@openequella/rest-api-client";
 import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
-import { identity, pipe } from "fp-ts/function";
+import { pipe } from "fp-ts/function";
 import * as O from "fp-ts/Option";
 import { History, Location } from "history";
 import { pick } from "lodash";
@@ -37,7 +37,6 @@ import {
   Union,
   Unknown,
 } from "runtypes";
-import { getBaseUrl } from "../AppConfig";
 import type { FieldValueMap } from "../components/wizard/WizardHelper";
 import {
   RuntypesControlTarget,
@@ -55,7 +54,6 @@ import {
 } from "../modules/CollectionsModule";
 import {
   buildSelectionSessionItemSummaryLink,
-  getSelectionSessionInfo,
   isSelectionSessionOpen,
 } from "../modules/LegacySelectionSessionModule";
 import {
@@ -481,28 +479,3 @@ export const buildOpenSummaryPageHandler = (
       })
     )
   );
-
-export const openSearchPageInSelectionSession = () => {
-  const { stateId, integId, layout } = getSelectionSessionInfo();
-  const layoutType = pipe(
-    layout,
-    simpleMatch<string>({
-      coursesearch: () => "access/course",
-      search: () => "selectoradd",
-      skinnysearch: () => "access/skinny",
-      _: () => {
-        throw new Error("Unknown Selection Session layout");
-      },
-    }),
-    identity
-  );
-
-  const url = new URL(`${layoutType}/searching.do`, getBaseUrl());
-  url.searchParams.append("_sl.stateId", stateId);
-
-  if (integId) {
-    url.searchParams.append("_int.id", integId);
-  }
-
-  window.open(url.toString(), "_self");
-};


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for displaying the new Advanced search page in Selection Session.

There is one line change on server. But on client, the major changes are
1. Update how to build a link to access an Advanced search in Selection Session;
2. Update how to exit Advanced search mode in Selection Session;
3. How to support external MIME types.

I have also tested scripting and Wizard controls in Selection Session and they all work nicely.

https://user-images.githubusercontent.com/47203811/145311985-5208a3e0-05d9-4177-afe5-7b7e161d93d1.mp4


