### PR TITLE
fix: display attachment actions only in editable mode

### DIFF
--- a/react-front-end/tsrc/fileuploader/InlineFileUploader.tsx
+++ b/react-front-end/tsrc/fileuploader/InlineFileUploader.tsx
@@ -295,8 +295,20 @@ export const InlineFileUploader = ({
    * Build three text buttons for UploadedFile or one icon button for UploadingFile.
    */
   const buildActions = (file: UploadedFile | UploadingFile): UploadAction[] => {
-    if (isUploadedFile(file)) {
-      if (!editable) return [];
+    const uploadComplete = isUploadedFile(file);
+
+    if (!uploadComplete) {
+      return [
+        {
+          onClick: () => onCancel(file.localId),
+          text: strings.cancel,
+          icon: <CancelIcon />,
+        },
+      ];
+    } else if (!editable) {
+      // No further actions available
+      return [];
+    } else {
       const basicAction = [
         {
           onClick: () => onDelete(file),
@@ -304,7 +316,7 @@ export const InlineFileUploader = ({
         },
       ];
       const { id, editable: fileEditable } = file.fileEntry;
-      return fileEditable
+      const actions = fileEditable
         ? [
             {
               onClick: () => onEdit(id),
@@ -317,14 +329,8 @@ export const InlineFileUploader = ({
             ...basicAction,
           ]
         : basicAction;
+      return actions;
     }
-    return [
-      {
-        onClick: () => onCancel(file.localId),
-        text: strings.cancel,
-        icon: <CancelIcon />,
-      },
-    ];
   };
 
   // Build an Icon button for adding resources. In Old UI, this is achieved by legacy CSS styles.

--- a/react-front-end/tsrc/fileuploader/InlineFileUploader.tsx
+++ b/react-front-end/tsrc/fileuploader/InlineFileUploader.tsx
@@ -296,14 +296,15 @@ export const InlineFileUploader = ({
    */
   const buildActions = (file: UploadedFile | UploadingFile): UploadAction[] => {
     if (isUploadedFile(file)) {
+      if (!editable) return [];
       const basicAction = [
         {
           onClick: () => onDelete(file),
           text: strings.delete,
         },
       ];
-      const { id, editable } = file.fileEntry;
-      return editable
+      const { id, editable: fileEditable } = file.fileEntry;
+      return fileEditable
         ? [
             {
               onClick: () => onEdit(id),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Now attachment actions only display after the user click the edit button.

So before we were misled by the local variable `editable` and props `editable`. :smile: 
It can actually be done in the front end.

https://user-images.githubusercontent.com/92769668/145497673-7911dbc4-1244-4442-8222-4b21031b670f.mp4

 <!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
