### PR TITLE
chore(frontend): hide Remote Repository option on the Advanced search page

### DIFF
--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -864,7 +864,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
       title: searchStrings.advancedSearchSelector.title,
       component: (
         <AdvancedSearchSelector
-          advancedSearches={advancedSearches}
+          advancedSearches={advancedSearches.sort()}
           onSelectionChange={handleAdvancedSearchChanged}
           value={advancedSearches.find(({ uuid }) => uuid === advancedSearchId)}
         />
@@ -882,7 +882,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           urlGeneratorForMuiLink={buildSelectionSessionRemoteSearchLink}
         />
       ),
-      disabled: true,
+      disabled: searchPageModeState.mode === "advSearch",
     },
     {
       idSuffix: "DateRangeSelector",

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -882,7 +882,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           urlGeneratorForMuiLink={buildSelectionSessionRemoteSearchLink}
         />
       ),
-      disabled: false,
+      disabled: true,
     },
     {
       idSuffix: "DateRangeSelector",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Hide Remote Repository option on the Advanced search page.

![image](https://user-images.githubusercontent.com/92769668/145516648-05894687-9ddd-4b5a-8fa9-7e9f59ecd902.png)


<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
