### PR TITLE
bugfix: show Wizard control that uses an empty string as visibility scripting

### DIFF
--- a/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
+++ b/react-front-end/__tests__/tsrc/components/wizard/WizardHelper.test.ts
@@ -206,6 +206,7 @@ describe("render()", () => {
       new Map(),
       1,
     ],
+    ["empty string (visible)", ``, new Map(), 2],
   ])(
     "hides controls based on visibility scripts - %s",
     (_, script, values, controlsVisible) => {

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -31,6 +31,7 @@ import * as M from "fp-ts/Map";
 import * as NEA from "fp-ts/NonEmptyArray";
 import * as N from "fp-ts/number";
 import * as O from "fp-ts/Option";
+import { not } from "fp-ts/Predicate";
 import * as RA from "fp-ts/ReadonlyArray";
 import * as RSET from "fp-ts/ReadonlySet";
 import { Refinement } from "fp-ts/Refinement";
@@ -630,7 +631,10 @@ export const render = (
   const isVisible: (_: OEQ.WizardControl.WizardControl) => boolean = flow(
     O.fromPredicate(OEQ.WizardControl.isWizardBasicControl),
     O.chain<OEQ.WizardControl.WizardBasicControl, string>(
-      ({ visibilityScript }) => O.fromNullable(visibilityScript)
+      flow(
+        O.fromNullableK(({ visibilityScript }) => visibilityScript),
+        O.filter(not(S.isEmpty))
+      )
     ),
     O.chain((script) =>
       pipe(


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Do not execute the visibility script is it's just an empty string. As a result, the Wizard control is visible.