### PR TITLE
feat: show Advanced search name at the top of the Advanced search panel

### DIFF
--- a/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
+++ b/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
@@ -41,7 +41,7 @@ export const Simple: Story<AdvancedSearchPanelProps> = (args) => (
   <AdvancedSearchPanel {...args} />
 );
 Simple.args = {
-  name: "Simple Advanced search",
+  title: "Simple Advanced search",
   wizardControls: controls,
   values: new Map(),
 };

--- a/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
+++ b/react-front-end/__stories__/search/AdvancedSearchPanel.stories.tsx
@@ -41,6 +41,7 @@ export const Simple: Story<AdvancedSearchPanelProps> = (args) => (
   <AdvancedSearchPanel {...args} />
 );
 Simple.args = {
+  name: "Simple Advanced search",
   wizardControls: controls,
   values: new Map(),
 };

--- a/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/AdvancedSearch.test.tsx
@@ -51,8 +51,10 @@ jest.setTimeout(20000);
 
 const {
   showAdvancedSearchFilter: filterButtonLabel,
-  AdvancedSearchPanel: { title: panelTitle },
+  AdvancedSearchPanel: { title: defaultPanelTitle },
 } = languageStrings.searchpage;
+
+const panelTitle = getAdvancedSearchDefinition.name ?? defaultPanelTitle;
 
 const {
   mockCollections,

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -1068,6 +1068,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
               searchPageModeState.isAdvSearchPanelOpen && (
                 <Grid item xs={12}>
                   <AdvancedSearchPanel
+                    name={searchPageModeState.definition.name}
                     wizardControls={searchPageModeState.definition.controls}
                     values={searchPageModeState.queryValues}
                     onSubmit={handleSubmitAdvancedSearch}

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -1068,7 +1068,7 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
               searchPageModeState.isAdvSearchPanelOpen && (
                 <Grid item xs={12}>
                   <AdvancedSearchPanel
-                    name={searchPageModeState.definition.name}
+                    title={searchPageModeState.definition.name}
                     wizardControls={searchPageModeState.definition.controls}
                     values={searchPageModeState.queryValues}
                     onSubmit={handleSubmitAdvancedSearch}

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -43,6 +43,10 @@ import { SearchPageRenderErrorContext } from "../SearchPage";
 
 export interface AdvancedSearchPanelProps {
   /**
+   * Name of the Advanced search.
+   */
+  name?: string;
+  /**
    * A list of Wizard controls.
    */
   wizardControls: OEQ.WizardControl.WizardControl[];
@@ -75,6 +79,7 @@ export const AdvancedSearchPanel = ({
   onClose,
   onSubmit,
   onClear,
+  name,
 }: AdvancedSearchPanelProps) => {
   const { handleError } = useContext(SearchPageRenderErrorContext);
   const [currentValues, setCurrentValues] =
@@ -138,7 +143,7 @@ export const AdvancedSearchPanel = ({
   return (
     <Card id={idPrefix}>
       <CardHeader
-        title={languageStrings.searchpage.AdvancedSearchPanel.title}
+        title={name ?? languageStrings.searchpage.AdvancedSearchPanel.title}
         action={
           <TooltipIconButton
             title={languageStrings.common.action.close}

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -43,7 +43,7 @@ import { SearchPageRenderErrorContext } from "../SearchPage";
 
 export interface AdvancedSearchPanelProps {
   /**
-   * Name of the Advanced search.
+   * Title of the Advanced search panel. Defaults to language string `languageStrings.searchpage.AdvancedSearchPanel.title`.
    */
   title?: string;
   /**

--- a/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
+++ b/react-front-end/tsrc/search/components/AdvancedSearchPanel.tsx
@@ -45,7 +45,7 @@ export interface AdvancedSearchPanelProps {
   /**
    * Name of the Advanced search.
    */
-  name?: string;
+  title?: string;
   /**
    * A list of Wizard controls.
    */
@@ -79,7 +79,7 @@ export const AdvancedSearchPanel = ({
   onClose,
   onSubmit,
   onClear,
-  name,
+  title,
 }: AdvancedSearchPanelProps) => {
   const { handleError } = useContext(SearchPageRenderErrorContext);
   const [currentValues, setCurrentValues] =
@@ -143,7 +143,7 @@ export const AdvancedSearchPanel = ({
   return (
     <Card id={idPrefix}>
       <CardHeader
-        title={name ?? languageStrings.searchpage.AdvancedSearchPanel.title}
+        title={title ?? languageStrings.searchpage.AdvancedSearchPanel.title}
         action={
           <TooltipIconButton
             title={languageStrings.common.action.close}


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Show the name of an Advanced search at the top of the Advanced search panel.

![image](https://user-images.githubusercontent.com/47203811/145733896-171bbd5a-807a-4106-868c-638a7c4203ce.png)
