### PR TITLE
chore(deps): stop tika parsers transitive log4j dep

### DIFF
--- a/Source/Server/conversion/build.sbt
+++ b/Source/Server/conversion/build.sbt
@@ -4,7 +4,8 @@ libraryDependencies ++= Seq(
   "org.slf4j"       % "slf4j-api"                     % "1.7.32",
   "org.slf4j"       % "slf4j-simple"                  % "1.7.32",
   "org.apache.tika" % "tika-core"                     % tikaVersion,
-  "org.apache.tika" % "tika-parsers-standard-package" % tikaVersion
+  "org.apache.tika" % "tika-parsers-standard-package" % tikaVersion excludeAll ExclusionRule(
+    organization = "org.apache.logging.log4j")
 )
 
 excludeDependencies += "commons-logging" % "commons-logging"

--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -1,4 +1,5 @@
 import Path.rebase
+
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -179,26 +180,27 @@ libraryDependencies ++= Seq(
     ExclusionRule(organization = "antlr",
                   name = "antlr")
   ),
-  "org.apache.struts"           % "struts-extras"                 % "1.3.10",
-  "org.apache.struts"           % "struts-taglib"                 % "1.3.10",
-  "org.apache.tika"             % "tika-core"                     % tikaVersion,
-  "org.apache.tika"             % "tika-parsers-standard-package" % tikaVersion,
-  "org.apache.tomcat"           % "tomcat-annotations-api"        % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-api"                    % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-catalina"               % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-catalina-ha"            % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-coyote"                 % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-jsp-api"                % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-juli"                   % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-servlet-api"            % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-tribes"                 % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-util"                   % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-util-scan"              % TomcatVersion,
-  "org.apache.tomcat"           % "tomcat-ssi"                    % TomcatVersion,
-  "org.apache.ws.commons.axiom" % "axiom-api"                     % "1.3.0",
-  "org.apache.ws.commons.axiom" % "axiom-impl"                    % "1.3.0",
-  "org.apache.ws.security"      % "wss4j"                         % "1.6.19",
-  "org.apache.zookeeper"        % "zookeeper"                     % "3.4.6" excludeAll (
+  "org.apache.struts" % "struts-extras"                 % "1.3.10",
+  "org.apache.struts" % "struts-taglib"                 % "1.3.10",
+  "org.apache.tika"   % "tika-core"                     % tikaVersion,
+  "org.apache.tika"   % "tika-parsers-standard-package" % tikaVersion excludeAll ExclusionRule(
+    organization = "org.apache.logging.log4j"),
+  "org.apache.tomcat"           % "tomcat-annotations-api" % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-api"             % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-catalina"        % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-catalina-ha"     % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-coyote"          % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-jsp-api"         % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-juli"            % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-servlet-api"     % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-tribes"          % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-util"            % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-util-scan"       % TomcatVersion,
+  "org.apache.tomcat"           % "tomcat-ssi"             % TomcatVersion,
+  "org.apache.ws.commons.axiom" % "axiom-api"              % "1.3.0",
+  "org.apache.ws.commons.axiom" % "axiom-impl"             % "1.3.0",
+  "org.apache.ws.security"      % "wss4j"                  % "1.6.19",
+  "org.apache.zookeeper"        % "zookeeper"              % "3.4.6" excludeAll (
     ExclusionRule(organization = "org.slf4j",
                   name = "slf4j-log4j12")
   ),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

When we upgraded to Tika 2 (#3296) it turns out that the microsoft parser in
standard parsers brings in log4j including an SLF4J binding. This causes
some of our logging to then fail, as it uses SLF4J and picks up the
Log4J2 binding where we only configure Log4J 1.2.x.

This was only new in the version we're currently working on and have not
yet released - 2021.2.

I tested this manually to ensure that Microsoft Office files (tested with docx and doc) are still nicely indexed with searches for words in the content returning the items and highlighting the search result was in the attachments. This means that tika is still successfully extracting text from Microsoft files.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
