### PR TITLE
feat: support using `xml.getAll` in visibility scripts

### DIFF
--- a/react-front-end/__tests__/tsrc/modules/ScriptingModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/ScriptingModule.test.ts
@@ -45,6 +45,8 @@ describe("buildVisibilityScript", () => {
         xpath === testData.path && value === testData.value,
       get: (xpath: string): string =>
         xpath === testData.path ? testData.value : "unknown xpath",
+      getAll: (xpath: string): ReadonlyArray<string> =>
+        xpath === testData.path ? [testData.value] : [],
     },
   };
 
@@ -54,6 +56,7 @@ var bRet = false; // 'var bRet' is used to be similar to the UI generated script
 const results = [
     xml.contains('${testData.path}', '${testData.value}'),
     xml.get('${testData.path}') == '${testData.value}',
+    xml.getAll('${testData.path}').includes('${testData.value}'),
     user.hasRole('${testData.uuid}')
 ];
 if (results.every(v => v === true)) {

--- a/react-front-end/tsrc/components/wizard/WizardHelper.tsx
+++ b/react-front-end/tsrc/components/wizard/WizardHelper.tsx
@@ -507,6 +507,12 @@ const buildXmlScriptObject = (values: PathValueMap): XmlScriptType =>
           O.chain(RA.head),
           O.getOrElse(() => S.empty) // as per legacy code
         ),
+      getAll: (node): ReadonlyArray<string> =>
+        pipe(
+          m,
+          M.lookup(S.Eq)(node),
+          O.getOrElse<ReadonlyArray<string>>(() => RA.empty)
+        ),
     })
   );
 

--- a/react-front-end/tsrc/modules/ScriptingModule.ts
+++ b/react-front-end/tsrc/modules/ScriptingModule.ts
@@ -45,6 +45,13 @@ export interface XmlScriptType {
    * @return The value from the XML document
    */
   get: (xpath: string) => string;
+  /**
+   * Returns all node text values for a given XPath.
+   *
+   * @param xpath The XPath to the node(s)
+   * @return An array of all the text values of the matching nodes
+   */
+  getAll: (xpath: string) => ReadonlyArray<string>;
 }
 
 /**


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This PR adds the support for using  xml.getAll in visibility scripts.

https://user-images.githubusercontent.com/47203811/145932937-d7a380ff-8eac-457f-b5fe-e4192de9d5c8.mp4


