### PR TITLE
bugfix: ensure double clicking the Save button don't lose attachments

### DIFF
--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -17,6 +17,7 @@
  */
 import { CircularProgress, Grid } from "@material-ui/core";
 import Axios from "axios";
+import { isEqual } from "lodash";
 import * as React from "react";
 import { useContext } from "react";
 import { v4 } from "uuid";
@@ -104,6 +105,21 @@ export interface LegacyContentProps extends BaseOEQRouteComponentProps {
   children?: never;
 }
 
+interface LegacyContentSubmission {
+  /**
+   * Indicate whether there is a request submitted to `LegacyContentApi` already but not completed yet.
+   */
+  submitting: boolean;
+  /**
+   * Where to send the form data.
+   */
+  action?: string;
+  /**
+   * Payload of the submission.
+   */
+  payload?: StateData;
+}
+
 export type SubmitResponse =
   | ExternalRedirect
   | LegacyContentResponse
@@ -146,8 +162,9 @@ export const LegacyContent = React.memo(function LegacyContent({
 }: LegacyContentProps) {
   const [content, setContent] = React.useState<PageContent>();
   const [updatingContent, setUpdatingContent] = React.useState<boolean>(true);
-  // Indicate whether there is a request submitted to `LegacyContentApi` already but not completed yet.
-  const submittingForm = React.useRef(false);
+  const submittingForm = React.useRef<LegacyContentSubmission>({
+    submitting: false,
+  });
   const { appErrorHandler } = useContext(AppRenderErrorContext);
 
   const baseUrl = document.getElementsByTagName("base")[0].href;
@@ -228,12 +245,21 @@ export const LegacyContent = React.memo(function LegacyContent({
     callback?: (response: SubmitResponse) => void
   ) {
     if (formAction) {
-      if (submittingForm.current) {
+      const { submitting, action, payload } = submittingForm.current;
+      if (
+        submitting &&
+        formAction === action &&
+        isEqual(submitValues, payload)
+      ) {
         console.error(`ignore redundant submission to ${formAction}`);
         return;
       }
 
-      submittingForm.current = true;
+      submittingForm.current = {
+        submitting: true,
+        action: formAction,
+        payload: submitValues,
+      };
     }
 
     submitRequest(toRelativeUrl(formAction || pathname), submitValues)
@@ -265,7 +291,7 @@ export const LegacyContent = React.memo(function LegacyContent({
       })
       .finally(() => {
         if (formAction) {
-          submittingForm.current = false;
+          submittingForm.current = { submitting: false };
         }
       });
   }

--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -227,11 +227,14 @@ export const LegacyContent = React.memo(function LegacyContent({
     submitValues: StateData,
     callback?: (response: SubmitResponse) => void
   ) {
-    if (submittingForm.current) {
-      console.error(`ignore redundant submission to ${formAction}`);
-      return;
+    if (formAction) {
+      if (submittingForm.current) {
+        console.error(`ignore redundant submission to ${formAction}`);
+        return;
+      }
+
+      submittingForm.current = true;
     }
-    submittingForm.current = true;
 
     submitRequest(toRelativeUrl(formAction || pathname), submitValues)
       .then((content) => {
@@ -260,7 +263,11 @@ export const LegacyContent = React.memo(function LegacyContent({
             : generateFromError(error);
         handleError(fullScreen, errorResponse);
       })
-      .finally(() => (submittingForm.current = false));
+      .finally(() => {
+        if (formAction) {
+          submittingForm.current = false;
+        }
+      });
   }
 
   function stdSubmit(validate: boolean) {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

When editing an Item, repeatedly submitting a Legacy Content request in a very short period can result in attachments missing or the whole UI broken. Actually, where this bug can happen is not limited to Contribution. For example, double clicking the `Edit this version` button in Resource Summary page can break the UI as well.

To fix this, I added a new type definition in `LegacyContent.tsx` and used `useRef` to create an object which stores the details of the request in progress. And then I can stop the redundant submissions by comparing the details with that of the new request.


https://user-images.githubusercontent.com/47203811/147991371-ffe23149-a2ef-432e-b721-98dececea707.mp4



