### PR TITLE
fix(frontend): persist old UI after going into a Settings page that uses Material UI

### DIFF
--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -143,12 +143,19 @@ export const LegacyContent = React.memo(function LegacyContent({
   redirect,
   setPreventNavigation,
   updateTemplate,
+  isReloadNeeded,
 }: LegacyContentProps) {
   const [content, setContent] = React.useState<PageContent>();
   const [updatingContent, setUpdatingContent] = React.useState<boolean>(true);
   const { appErrorHandler } = useContext(AppRenderErrorContext);
 
   const baseUrl = document.getElementsByTagName("base")[0].href;
+
+  React.useEffect(() => {
+    if (isReloadNeeded) {
+      window.location.reload();
+    }
+  }, [isReloadNeeded]);
 
   const redirected = (href: string, external: boolean) => {
     if (external) {

--- a/react-front-end/tsrc/settings/SettingsPage.tsx
+++ b/react-front-end/tsrc/settings/SettingsPage.tsx
@@ -33,6 +33,7 @@ import * as OEQ from "@openequella/rest-api-client";
 import * as React from "react";
 import { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { getBaseUrl } from "../AppConfig";
 import { AppRenderErrorContext } from "../mainui/App";
 import { templateDefaults, TemplateUpdateProps } from "../mainui/Template";
 import { fetchSettings } from "../modules/GeneralSettingsModule";
@@ -78,7 +79,7 @@ const SettingsPage = ({
 
   React.useEffect(() => {
     if (isReloadNeeded) {
-      window.location.reload();
+      window.location.href = getBaseUrl() + "access/settings.do";
     }
   }, [isReloadNeeded]);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist
Reload legacy content as needed

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Reload legacy content as needed to persist old UI.
Change func reload to open in SettingsPage to handle go back operation.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

https://user-images.githubusercontent.com/92769668/148157452-c33f0ae0-462b-43a6-9db9-6b3f1294288c.mp4

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
