### PR TITLE
chore(deps): remove unused tomcat:jsp-api

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -251,7 +251,6 @@ libraryDependencies ++= Seq(
 //    ),
   "stax"                      % "stax-api"          % "1.0.1",
   "taglibs"                   % "standard"          % "1.1.2",
-  "tomcat"                    % "jsp-api"           % "5.5.23",
   "com.github.equella.legacy" % "qtiworks-jqtiplus" % "1.0-beta3" excludeAll (
     ExclusionRule(organization = "org.slf4j"),
     ExclusionRule(organization = "ch.qos.logback"),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This appears to be unused (based on testing by complete rebuild after
removal, and manual UI usage); most likely as there was also the
dependency for the newer [org.apache.tomcat:tomcat-jsp-api](https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-jsp-api). This newer
one was kept - and is in sync with all the other Tomcat deps due to a
variable.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
