### PR TITLE
chore(deps): remove references to asm

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -138,7 +138,6 @@ libraryDependencies ++= Seq(
     ExclusionRule(organization = "javax.xml.bind"),
     ExclusionRule(organization = "javax.xml.soap"),
     ExclusionRule(organization = "xml-resolver"),
-    ExclusionRule(organization = "asm"),
     ExclusionRule(organization = "org.springframework"),
     ExclusionRule(organization = "aopalliance"),
     ExclusionRule(organization = "org.jvnet"),
@@ -228,10 +227,7 @@ libraryDependencies ++= Seq(
   "javax.json.bind"                      % "javax.json.bind-api"          % "1.0",
   "org.jsoup"                            % "jsoup"                        % jsoupVersion,
   xstreamDep,
-  "org.opensaml" % "xmltooling" % "1.3.1" excludeAll (
-    ExclusionRule(organization = "org.slf4j")
-  ),
-  "org.ow2.asm" % "asm" % "5.2",
+  "org.opensaml" % "xmltooling" % "1.3.1" excludeAll ExclusionRule(organization = "org.slf4j"),
   postgresDep,
   "org.scannotation"    % "scannotation"           % "1.0.3",
   "org.slf4j"           % "jcl-over-slf4j"         % "1.7.32",
@@ -281,7 +277,6 @@ dependencyOverrides += "javax.mail" % "mail" % "1.4.7"
 
 excludeDependencies ++= Seq(
   "com.google.guava"             % "guava-jdk5",
-  "asm"                          % "asm",
   "javax.servlet"                % "servlet-api",
   "org.mortbay.jetty"            % "servlet-api",
   "antlr"                        % "antlr",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] the [contributor license agreement][] is signed
- [ ] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Not sure why this was explicitly included other than possibly when the
migration was done from the 'lib' directory to accommodate what is now a
transitive dependency.

Also, explicitly include a version meant the transitives had to be
excluded where as now that can be simplified and left to its own
devices.

Tested manually locally with full rebuild and then manual mini smoke test.

Resolves #3329 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
