### PR TITLE
chore(deps): remove unused apache poi-ooxml

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -162,7 +162,6 @@ libraryDependencies ++= Seq(
   "org.apache.lucene"         % "lucene-analyzers" % "3.6.2",
   "org.apache.lucene"         % "lucene-core"      % "3.6.2",
   "org.apache.lucene"         % "lucene-queries"   % "3.6.2",
-  "org.apache.poi"            % "poi-ooxml"        % "3.17",
   "org.apache.rampart"        % "rampart-core"     % "1.6.3" excludeAll (
     ExclusionRule(organization = "org.apache.xalan"),
     ExclusionRule(organization = "org.apache.xerces")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

I'm guessing this was added from when dependencies where just managed in a `lib` directory. As the Tika parsers from Microsoft office documents do have a transitive dependency - so we can just leave it to that.

Here is the output from `whatDependsOn` after I removed it:

```
sbt:Equella> whatDependsOn org.apache.poi poi-ooxml
[info] org.apache.poi:poi-ooxml:4.1.2
[info]   +-org.apache.tika:tika-parser-microsoft-module:2.2.1
[info]     +-org.apache.tika:tika-parsers-standard-package:2.2.1
[info]       +-com.github.equella:conversion_2.12:702b5b5601dfdd347a0e6948ce92a075a0de0a9d [S]
[info]       
```

Resolves #3326

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
