### PR TITLE
fix: hide menu bar for error page in IMS viewer

### DIFF
--- a/react-front-end/tsrc/api/errors.ts
+++ b/react-front-end/tsrc/api/errors.ts
@@ -24,19 +24,6 @@ export interface ErrorResponse {
   error: string;
   error_description?: string;
   code?: number;
-  hideNav?: boolean;
-}
-
-/**
- * temp.hn and temp.hb are two possible params contains in the request and response
- * and are used in old UI to hide navigation (menu bar) and banner.
- * In new UI, for normal legacy content we have a template props `fullscreenMode`
- * received from server to hide menu bar, but not the error page.
- * Thus, it is used to set `fullscreenMode` for error page.
- */
-interface AxiosResponseConfigData {
-  "temp.hn"?: [string];
-  "temp.hb"?: [string];
 }
 
 export const generateNewErrorID = (
@@ -103,17 +90,12 @@ export function fromAxiosResponse(
           return [response.statusText, ""];
       }
     })();
-    const configData: AxiosResponseConfigData = JSON.parse(
-      response.config.data
-    );
+
     return {
       id: v4(),
       error,
       error_description,
       code: response.status,
-      hideNav: configData["temp.hn"]
-        ? configData["temp.hn"][0] === "true"
-        : undefined,
     };
   }
 }

--- a/react-front-end/tsrc/api/errors.ts
+++ b/react-front-end/tsrc/api/errors.ts
@@ -24,6 +24,7 @@ export interface ErrorResponse {
   error: string;
   error_description?: string;
   code?: number;
+  hideNav?: boolean;
 }
 
 export const generateNewErrorID = (
@@ -85,16 +86,18 @@ export function fromAxiosResponse(
     const [error, error_description] = (function () {
       switch (response.status) {
         case 404:
-          return ["Not Found", ""];
+          return ["Not Found", response.request.responseURL];
         default:
           return [response.statusText, ""];
       }
     })();
+    const data = JSON.parse(response.config.data);
     return {
       id: v4(),
       error,
       error_description,
       code: response.status,
+      hideNav: data["temp.hn"] ? data["temp.hn"][0] === "true" : undefined,
     };
   }
 }

--- a/react-front-end/tsrc/api/errors.ts
+++ b/react-front-end/tsrc/api/errors.ts
@@ -27,6 +27,18 @@ export interface ErrorResponse {
   hideNav?: boolean;
 }
 
+/**
+ * temp.hn and temp.hb are two possible params contains in the request and response
+ * and are used in old UI to hide navigation (menu bar) and banner.
+ * In new UI, for normal legacy content we have a template props `fullscreenMode`
+ * received from server to hide menu bar, but not the error page.
+ * Thus, it is used to set `fullscreenMode` for error page.
+ */
+interface AxiosResponseConfigData {
+  "temp.hn"?: [string];
+  "temp.hb"?: [string];
+}
+
 export const generateNewErrorID = (
   error: string,
   code?: number,
@@ -91,13 +103,17 @@ export function fromAxiosResponse(
           return [response.statusText, ""];
       }
     })();
-    const data = JSON.parse(response.config.data);
+    const configData: AxiosResponseConfigData = JSON.parse(
+      response.config.data
+    );
     return {
       id: v4(),
       error,
       error_description,
       code: response.status,
-      hideNav: data["temp.hn"] ? data["temp.hn"][0] === "true" : undefined,
+      hideNav: configData["temp.hn"]
+        ? configData["temp.hn"][0] === "true"
+        : undefined,
     };
   }
 }

--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -17,7 +17,7 @@
  */
 import { CircularProgress, Grid } from "@material-ui/core";
 import Axios from "axios";
-import { constFalse, pipe } from "fp-ts/function";
+import { pipe } from "fp-ts/function";
 import { isEqual } from "lodash";
 import * as O from "fp-ts/Option";
 import * as React from "react";
@@ -31,7 +31,11 @@ import {
 import { LEGACY_CSS_URL } from "../AppConfig";
 import { AppRenderErrorContext } from "../mainui/App";
 import { BaseOEQRouteComponentProps } from "../mainui/routes";
-import { templateDefaults, templatePropsForLegacy } from "../mainui/Template";
+import {
+  FullscreenMode,
+  templateDefaults,
+  templatePropsForLegacy,
+} from "../mainui/Template";
 import { deleteRawModeFromStorage } from "../search/SearchPageHelper";
 import { LegacyContentRenderer } from "./LegacyContentRenderer";
 import { getEqPageForm, legacyFormId } from "./LegacyForm";
@@ -253,19 +257,20 @@ export const LegacyContent = React.memo(function LegacyContent({
    * received from server to hide menu bar, but not the error page.
    * Thus, it is used to set `fullscreenMode` for error page.
    */
-  function preUpdateFullscreenMode(submitValues: StateData) {
+  const preUpdateFullscreenMode = (submitValues: StateData) => {
     pipe(
       O.fromNullable(submitValues["temp.hn"]),
-      O.map(([firstValue]) => firstValue === "true"),
-      O.getOrElse(constFalse),
-      (isFullscreenMode) => {
+      O.chain<string[], FullscreenMode>(([firstValue]) =>
+        firstValue === "true" ? O.some("YES") : O.none
+      ),
+      O.map((value) =>
         updateTemplate((tp) => ({
           ...tp,
-          fullscreenMode: isFullscreenMode ? "YES" : tp.fullscreenMode,
-        }));
-      }
+          fullscreenMode: value,
+        }))
+      )
     );
-  }
+  };
 
   function submitCurrentForm(
     fullScreen: boolean,

--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -17,7 +17,9 @@
  */
 import { CircularProgress, Grid } from "@material-ui/core";
 import Axios from "axios";
+import { constFalse, pipe } from "fp-ts/function";
 import { isEqual } from "lodash";
+import * as O from "fp-ts/Option";
 import * as React from "react";
 import { useContext } from "react";
 import { v4 } from "uuid";
@@ -252,14 +254,17 @@ export const LegacyContent = React.memo(function LegacyContent({
    * Thus, it is used to set `fullscreenMode` for error page.
    */
   function preUpdateFullscreenMode(submitValues: StateData) {
-    const isFullscreenMode = submitValues["temp.hn"]
-      ? submitValues["temp.hn"][0] === "true"
-      : false;
-
-    updateTemplate((tp) => ({
-      ...tp,
-      fullscreenMode: isFullscreenMode ? "YES" : tp.fullscreenMode,
-    }));
+    pipe(
+      O.fromNullable(submitValues["temp.hn"]),
+      O.map(([firstValue]) => firstValue === "true"),
+      O.getOrElse(constFalse),
+      (isFullscreenMode) => {
+        updateTemplate((tp) => ({
+          ...tp,
+          fullscreenMode: isFullscreenMode ? "YES" : tp.fullscreenMode,
+        }));
+      }
+    );
   }
 
   function submitCurrentForm(

--- a/react-front-end/tsrc/legacycontent/LegacyContent.tsx
+++ b/react-front-end/tsrc/legacycontent/LegacyContent.tsx
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 import { CircularProgress, Grid } from "@material-ui/core";
-import Axios from "axios";
+import Axios, { AxiosResponse } from "axios";
+import { pipe } from "fp-ts/function";
 import { isEqual } from "lodash";
 import * as React from "react";
+import * as O from "fp-ts/Option";
 import { useContext } from "react";
 import { v4 } from "uuid";
 import {
@@ -118,6 +120,18 @@ interface LegacyContentSubmission {
    * Payload of the submission.
    */
   payload?: StateData;
+}
+
+/**
+ * temp.hn and temp.hb are two possible params contains in the request and response
+ * and are used in old UI to hide navigation (menu bar) and banner.
+ * In new UI, for normal legacy content we have a template props `fullscreenMode`
+ * received from server to hide menu bar, but not the error page.
+ * Thus, it is used to set `fullscreenMode` for error page.
+ */
+interface AxiosResponseConfigData {
+  "temp.hn"?: [string];
+  "temp.hb"?: [string];
 }
 
 export type SubmitResponse =
@@ -290,11 +304,28 @@ export const LegacyContent = React.memo(function LegacyContent({
         }
       })
       .catch((error) => {
-        const errorResponse: ErrorResponse =
-          error.response !== undefined
-            ? fromAxiosResponse(error.response)
-            : generateFromError(error);
-        handleError(fullScreen, errorResponse);
+        pipe(
+          O.fromNullable(error.response),
+          O.map((e: AxiosResponse) => {
+            const configData: AxiosResponseConfigData = JSON.parse(
+              e.config.data
+            );
+
+            const isFullscreenMode = configData["temp.hn"]
+              ? configData["temp.hn"][0] === "true"
+              : false;
+
+            updateTemplate((tp) => ({
+              ...tp,
+              fullscreenMode: isFullscreenMode ? "YES" : undefined,
+            }));
+            return fromAxiosResponse(e);
+          }),
+          O.getOrElseW<ErrorResponse>(() => generateFromError(error)),
+          (e) => {
+            handleError(fullScreen, e);
+          }
+        );
       })
       .finally(() => {
         if (formAction) {

--- a/react-front-end/tsrc/mainui/ErrorPage.tsx
+++ b/react-front-end/tsrc/mainui/ErrorPage.tsx
@@ -24,6 +24,8 @@ const useStyles = makeStyles((t) => ({
     display: "flex",
     justifyContent: "center",
     marginTop: t.spacing(8),
+    marginLeft: t.spacing(3),
+    marginRight: t.spacing(3),
   },
 }));
 

--- a/react-front-end/tsrc/mainui/ErrorPage.tsx
+++ b/react-front-end/tsrc/mainui/ErrorPage.tsx
@@ -24,8 +24,8 @@ const useStyles = makeStyles((t) => ({
     display: "flex",
     justifyContent: "center",
     marginTop: t.spacing(8),
-    marginLeft: t.spacing(3),
-    marginRight: t.spacing(3),
+    marginLeft: t.spacing(2),
+    marginRight: t.spacing(2),
   },
 }));
 

--- a/react-front-end/tsrc/mainui/IndexPage.tsx
+++ b/react-front-end/tsrc/mainui/IndexPage.tsx
@@ -153,10 +153,6 @@ export default function IndexPage() {
 
   const errorCallback = React.useCallback((err: ErrorResponse) => {
     errorShowing.current = true;
-    setTemplateProps((p) => ({
-      ...p,
-      fullscreenMode: err.hideNav ? "YES" : undefined,
-    }));
     setFullPageError(err);
   }, []);
 

--- a/react-front-end/tsrc/mainui/IndexPage.tsx
+++ b/react-front-end/tsrc/mainui/IndexPage.tsx
@@ -153,7 +153,10 @@ export default function IndexPage() {
 
   const errorCallback = React.useCallback((err: ErrorResponse) => {
     errorShowing.current = true;
-    setTemplateProps((p) => ({ ...p, fullscreenMode: undefined }));
+    setTemplateProps((p) => ({
+      ...p,
+      fullscreenMode: err.hideNav ? "YES" : undefined,
+    }));
     setFullPageError(err);
   }, []);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This is a draft PR to address #2873

There are two cases in old UI if there is a missing file:

https://user-images.githubusercontent.com/92769668/149067406-a5ddd62c-233c-4531-ae5d-4dbfee38e529.mp4

An index in the catalogue points to a missing file:
![image](https://user-images.githubusercontent.com/92769668/149067111-3c2943ad-3d60-4ea4-ac5c-098e25551c2d.png)

An internal link in IMS viewer points to a missing file:
![image](https://user-images.githubusercontent.com/92769668/149067280-ad70e166-12fb-4c5f-87e9-1984ac37b42b.png)

But in New UI both cases will display the menu:
![image](https://user-images.githubusercontent.com/92769668/149068436-673a3735-b097-4bd7-8190-d37b2e18244c.png)

In old UI it actually uses param `temp.hn=true` to hide the menu (`RenderTemplate.java:394`).
And 404 page will directly return after the request `IntroToDBS_summary.html?temp.hn=true&temp.hb=true`.

But in new UI, `IntroToDBS_summary.html?temp.hn=true&temp.hb=true` will only return 404 code with some useless HTML content, and trigger a new request to the `LeagcyContent content/submit API`. 

If the URL points to a normal Legacy content, the server will find corresponding content from old UI (`LeagcyContentApi.scala:347`) and generate a `fullscreenMode` variable and pass it to React component (`LeagcyContentApi.scala:576`, `LeagcyContent.tsx:272`).

But if the URL is points to a missing file, the legacy content API will direct return a 404 response (`LeagcyContentApi.scala:346`).

And this 404 response will trigger a catch statement (`LegacyContent.tsx:292`) and finally execute a props method passed from `IndexPage.tsx:154`
![image](https://user-images.githubusercontent.com/92769668/149068067-0147dd3d-5677-4b2b-beb8-0246bd7c2c13.png)
![image](https://user-images.githubusercontent.com/92769668/149070009-8a8b886e-ba33-418b-a062-253679458080.png)

So, currently, I just change the code in the frontend to make new UI has the same behaviour as old UI.

The solution idea is quite simple: if the error response contains the params 'temp.hn=true' let `fullscreenMode` props equal to "YES" otherwise keep undefined.

Here is the screenshot:
![image](https://user-images.githubusercontent.com/92769668/149072370-af6cc844-0670-4c69-9023-8cba6882bc1d.png)

The next step is to hide the menu for the internal link. 
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
