### PR TITLE
build(docker): Upgrade base image to openjdk 8u312-jre

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk@sha256:0e25c8428a56e32861fe996b528a107933155c98fb2a9998a4a4e9423aad734d as baseequella
+FROM openjdk:8u312-jre as baseequella
 
 # Install needed tools to install and run openEQUELLA, clean up the apt cache afterwards.
 
@@ -10,14 +10,18 @@ RUN useradd -ms /bin/bash equella \
   && apt-get install -y --no-install-recommends \
     curl \
     imagemagick \
-    libav-tools \
+    ffmpeg \
     unzip \
+  # Setup ffmpeg to act like libav-tools
+  && ln -s /usr/bin/ffmpeg /usr/bin/avconv \
+  && ln -s /usr/bin/ffplay /usr/bin/avplay \
+  && ln -s /usr/bin/ffprobe /usr/bin/avprobe \
   && rm -rf /var/lib/apt/lists/*
 
 # Install openEQUELLA
 FROM baseequella as installer
 
-ARG OEQ_INSTALL_FILE=equella-installer-2019.2.0.zip
+ARG OEQ_INSTALL_FILE=installer.zip
 
 COPY ["$OEQ_INSTALL_FILE","defaults.xml", "./"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,15 @@
 
 ## Setup
 
-Install Docker. For example, if you are on Ubuntu, follow the instructions [here|https://docs.docker.com/install/linux/docker-ce/ubuntu/].
+Before you can build the docker image there are a few pre-requisites:
+
+1. You (obviously) need docker installed; and
+2. You need an openEQUELLA installer zip for the version you wish to use.
+
+### Install Docker
+
+For example, if you are on Ubuntu, follow the instructions
+[here|https://docs.docker.com/install/linux/docker-ce/ubuntu/].
 
 Consider enabling the ability to run docker commands without sudo:
 
@@ -16,21 +24,48 @@ Check your version of Docker (The install and build images have been tested with
 docker --version
 ```
 
+### Obtain an installer zip
+
+There are three main ways to get an installer zip:
+
+1. Download for the [releases page](https://github.com/openequella/openEQUELLA/releases) on GitHub;
+2. Build one from source (i.e. using `./sbt installerZip` from the root directory; or
+3. Follow the instructions further down to do it with docker.
+
+Once that is complete, copy the resultant installer zip so that it is along side the `Dockerfile`
+and give it a simple name like `installer.zip`.
+
 ## Default Dockerfile
 
-Starting with an installer zip (output from `Dockerfile-build`), it installs openEQUELLA and is ready to run the application. When the container starts, it keys off of configurable properties such as DB host/name/username/password, admin url, etc.
+Starting with an installer zip, it installs openEQUELLA and is ready to run the application. When
+the container starts, it keys off of configurable properties such as DB host/name/username/password,
+admin url, etc.
 
-Meant for automated builds of openEQUELLA, but can be used as a quickstart to use openEQUELLA (not vetted for production use yet).
+This can be used as a quickstart to use openEQUELLA (not vetted for production use yet). And you'll
+see there are also docker compose files showing how you can use it to spin up an openEQUELLA
+cluster.
 
-Note - the zip and the root directory in the zip are not always the same, hence the different env variables.
+To build the image:
 
 ```sh
-$ cd docker
-$ docker build -t apereo/oeq-install-VER . --build-arg OEQ_INSTALL_FILE=equella-installer-VER.zip --build-arg OEQ_INSTALL_ZIP_ROOT_DIR=equella-installer-VER
-$ docker run -t --name oeq -e EQ_HTTP_PORT=8080 -e EQ_ADMIN_URL=http://172.17.0.2:8080/admin/ -e EQ_HIBERNATE_CONNECTION_URL=jdbc:postgresql://your-db-host-here:5432/eqdocker -e EQ_HIBERNATE_CONNECTION_USERNAME=equellauser -e EQ_HIBERNATE_CONNECTION_PASSWORD="your-db-pw-here" oeq-install-VER
+$ docker build -t openequella/openequella:<version> . --build-arg OEQ_INSTALL_FILE=installer.zip
 ```
 
-To access the terminal of the container:
+Then to run the image:
+
+```sh
+$ docker run -t --name oeq \
+    -e EQ_HTTP_PORT=8080 \
+    -e EQ_ADMIN_URL=http://172.17.0.2:8080/admin/ \
+    -e EQ_HIBERNATE_CONNECTION_URL=jdbc:postgresql://your-db-host-here:5432/eqdocker \
+    -e EQ_HIBERNATE_CONNECTION_USERNAME=equellauser \
+    -e EQ_HIBERNATE_CONNECTION_PASSWORD="your-db-pw-here" \
+    openequella/openequella:<version>
+```
+
+NOTE: In the above `:<version>` can be omitted and docker will automatically use the `latest` tag.
+
+To access the terminal of the running container:
 
 ```sh
 docker exec -it oeq /bin/bash
@@ -38,7 +73,10 @@ docker exec -it oeq /bin/bash
 
 ## docker-build
 
-Pulls the latest Equella repo, sets up the environment, and copies over the helper scripts to build and save the openEQUELLA installer and upgrader. While there is an Oracle JDK version of the docker build file, you need to ensure you're within the bounds of the Oracle JDK licensing terms and conditions. All examples will use the openJDK technology so as to avoid the licensing issues.
+Pulls the latest openEQUELLA repo, sets up the environment, and copies over the helper scripts to
+build and save the openEQUELLA installer and upgrader. While there is an Oracle JDK version of the
+docker build file, you need to ensure you're within the bounds of the Oracle JDK licensing terms and
+conditions. All examples will use the openJDK technology so as to avoid the licensing issues.
 
 ```sh
 $ cd docker/docker-build

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        - OEQ_INSTALL_FILE=equella-installer.zip
+        - OEQ_INSTALL_FILE=installer.zip
     networks:
       - oeq-cluster
     links:

--- a/docker/learningedge-log4j.properties
+++ b/docker/learningedge-log4j.properties
@@ -35,3 +35,21 @@ log4j.appender.TOMCAT.ImmediateFlush=true
 log4j.appender.TOMCAT.Append=true
 log4j.appender.TOMCAT.layout=com.tle.core.equella.runner.HTMLLayout3
 log4j.appender.TOMCAT.layout.title=Tomcat Logs
+
+# Criteria deprecation warning suppression
+log4j.appender.FILE.filter.1=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.FILE.filter.1.StringToMatch=HHH90000022
+log4j.appender.FILE.filter.1.AcceptOnMatch=false
+# -- And for CONSOLE
+log4j.appender.CONSOLE.filter.1=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.CONSOLE.filter.1.StringToMatch=HHH90000022
+log4j.appender.CONSOLE.filter.1.AcceptOnMatch=false
+
+# Generator warning suppression
+log4j.appender.FILE.filter.2=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.FILE.filter.2.StringToMatch=HHH90000014
+log4j.appender.FILE.filter.2.AcceptOnMatch=false
+# -- And for CONSOLE
+log4j.appender.CONSOLE.filter.2=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.CONSOLE.filter.2.StringToMatch=HHH90000014
+log4j.appender.CONSOLE.filter.2.AcceptOnMatch=false


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Main task here was to try and get us to an up to date and known base image - we pinned it a few years back to avoid an issue, but since then have been unsure how to accept renovate pull requests to update. To update the image we also needed to address the deprecation and removal of libav-tools from debian based distros (and this base image is debian).

While doing that I also reviewed and revised some of the docker and simplified the expected filename for the installer.

Undertook manual smoke testing locally, and looks to still function the same (including video previews to ensure I'd done the symbolic links correctly for ffmpeg -> libav).

(I did have an issue getting the Zookeeper part of the docker-compose working even before the upgrade - so at some point we need to loop back around and validate that is still happy.)

This will resolve #2974 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
