### PR TITLE
bugfix: ensure Custom Attachment uses the correct latest version

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/service/AttachmentService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/service/AttachmentService.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.tle.web.api.search.service
+package com.tle.core.item.service
 
 import com.tle.beans.item.attachments.{CustomAttachment, FileAttachment}
 import com.tle.beans.item.{ItemId, ItemIdKey, ItemKey}
@@ -32,7 +32,7 @@ import com.tle.web.controls.resource.ResourceAttachmentBean
 /**
   * Service layer that deals with Attachment related business logic.
   */
-object AttachmentResourceService {
+object AttachmentService {
 
   /**
     * Extract the mimetype for AbstractExtendableBean.
@@ -58,19 +58,6 @@ object AttachmentResourceService {
       case fileAttachment: FileAttachmentBean => Option(fileAttachment.getFilename)
       case _                                  => None
     }
-
-  /**
-    * Use the `description` from the `Attachment` behind the `AttachmentBean` as this provides
-    * the value more commonly seen in the LegacyUI. And specifically uses any tweaks done for
-    * Custom Attachments - such as with Kaltura where the Kaltura Media `title` is pushed into
-    * the `description` rather than using the optional (and multi-line) Kaltura Media `description`.
-    *
-    * @param itemKey the details of the item the attachment belongs to
-    * @param attachmentUuid the UUID of the attachment
-    * @return the description for the attachment if available
-    */
-  def getAttachmentDescription(itemKey: ItemKey, attachmentUuid: String): Option[String] =
-    Option(LegacyGuice.itemService.getAttachmentForUuid(itemKey, attachmentUuid).getDescription)
 
   /**
     * Determines if attachment contains a generated thumbnail in filestore

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.search
 
 import com.tle.web.api.item.interfaces.beans.AttachmentBean

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
@@ -1,0 +1,55 @@
+package com.tle.web.api.search
+
+import com.tle.web.api.item.interfaces.beans.AttachmentBean
+import com.tle.web.api.search.SearchHelper.getLinksFromBean
+import com.tle.web.api.search.service.AttachmentResourceService.getLatestVersionForCustomAttachment
+import com.tle.web.controls.resource.ResourceAttachmentBean
+import com.tle.web.controls.youtube.YoutubeAttachmentBean
+import java.util.Optional
+import scala.collection.JavaConverters._
+
+/**
+  * Object to provide helper functions for building a SearchResultAttachment.
+  */
+object AttachmentHelper {
+
+  /**
+    * Build the links maps for an attachment, which can also include external links (or IDs) for
+    * custom attachments.
+    *
+    * @param attachment to build the links map for
+    * @return a map containing the standard links (view, thumbnail), plus optionally external links
+    *         if suitable for the attachment type.
+    */
+  def buildAttachmentLinks(attachment: AttachmentBean): java.util.Map[String, String] = {
+    val addExternalId = (links: Map[String, String], externalId: Optional[String]) =>
+      if (externalId.isPresent) links ++ Map("externalId" -> externalId.get) else links
+
+    val links = getLinksFromBean(attachment).asScala.toMap
+    (attachment match {
+      case youtube: YoutubeAttachmentBean => addExternalId(links, youtube.getExternalId)
+      case kaltura if attachment.getRawAttachmentType == "custom/kaltura" =>
+        addExternalId(links, kaltura.getExternalId)
+      case _ => links
+    }).asJava
+  }
+
+  /**
+    * When an AttachmentBean is converted to SearchResultAttachment, it may require some extra sanitising
+    * to complete the conversion. The sanitising work includes tasks listed below.
+    *
+    * 1. Help ResourceAttachmentBean check the version of its linked resource.
+    *
+    * @param att An AttachmentBean to be sanitised.
+    */
+  def sanitiseAttachmentBean(att: AttachmentBean): AttachmentBean = {
+    att match {
+      case bean: ResourceAttachmentBean =>
+        val latestVersion =
+          getLatestVersionForCustomAttachment(bean.getItemVersion, bean.getItemUuid)
+        bean.setItemVersion(latestVersion)
+      case _ =>
+    }
+    att
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
@@ -18,9 +18,11 @@
 
 package com.tle.web.api.search
 
+import com.tle.beans.item.ItemKey
+import com.tle.legacy.LegacyGuice
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
 import com.tle.web.api.search.SearchHelper.getLinksFromBean
-import com.tle.web.api.search.service.AttachmentResourceService.getLatestVersionForCustomAttachment
+import com.tle.core.item.service.AttachmentService.getLatestVersionForCustomAttachment
 import com.tle.web.controls.resource.ResourceAttachmentBean
 import com.tle.web.controls.youtube.YoutubeAttachmentBean
 import java.util.Optional
@@ -70,4 +72,17 @@ object AttachmentHelper {
     }
     att
   }
+
+  /**
+    * Use the `description` from the `Attachment` behind the `AttachmentBean` as this provides
+    * the value more commonly seen in the LegacyUI. And specifically uses any tweaks done for
+    * Custom Attachments - such as with Kaltura where the Kaltura Media `title` is pushed into
+    * the `description` rather than using the optional (and multi-line) Kaltura Media `description`.
+    *
+    * @param itemKey the details of the item the attachment belongs to
+    * @param attachmentUuid the UUID of the attachment
+    * @return the description for the attachment if available
+    */
+  def getAttachmentDescription(itemKey: ItemKey, attachmentUuid: String): Option[String] =
+    Option(LegacyGuice.itemService.getAttachmentForUuid(itemKey, attachmentUuid).getDescription)
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -35,13 +35,16 @@ import com.tle.core.services.item.{FreetextResult, FreetextSearchResults}
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.interfaces.beans.AbstractExtendableBean
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
-import com.tle.web.api.search.AttachmentHelper.{buildAttachmentLinks, sanitiseAttachmentBean}
+import com.tle.web.api.search.AttachmentHelper.{
+  buildAttachmentLinks,
+  getAttachmentDescription,
+  sanitiseAttachmentBean
+}
 import com.tle.web.api.search.model.AdditionalSearchParameters.buildAdvancedSearchCriteria
 import cats.Semigroup
 import cats.implicits._
 import com.tle.web.api.search.model._
-import com.tle.web.api.search.service.AttachmentResourceService.{
-  getAttachmentDescription,
+import com.tle.core.item.service.AttachmentService.{
   getFilePathForAttachment,
   getMimetypeForAttachment,
   recurseBrokenAttachmentCheck,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/service/AttachmentResourceService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/service/AttachmentResourceService.scala
@@ -1,0 +1,134 @@
+package com.tle.web.api.search.service
+
+import com.tle.beans.item.attachments.{CustomAttachment, FileAttachment}
+import com.tle.beans.item.{ItemId, ItemIdKey, ItemKey}
+import com.tle.legacy.LegacyGuice
+import com.tle.web.api.interfaces.beans.AbstractExtendableBean
+import com.tle.web.api.item.equella.interfaces.beans.{
+  AbstractFileAttachmentBean,
+  FileAttachmentBean
+}
+import com.tle.web.api.item.interfaces.beans.AttachmentBean
+import com.tle.web.controls.resource.ResourceAttachmentBean
+
+/**
+  * Service layer that deals with Attachment related business logic.
+  */
+object AttachmentResourceService {
+
+  /**
+    * Extract the mimetype for AbstractExtendableBean.
+    */
+  def getMimetypeForAttachment[T <: AbstractExtendableBean](bean: T): Option[String] =
+    bean match {
+      case file: AbstractFileAttachmentBean =>
+        Some(LegacyGuice.mimeTypeService.getMimeTypeForFilename(file.getFilename))
+      case resourceAttachmentBean: ResourceAttachmentBean =>
+        Some(
+          LegacyGuice.mimeTypeService.getMimeTypeForResourceAttachmentBean(resourceAttachmentBean))
+      case _ => None
+    }
+
+  /**
+    * If the attachment is a file, then return the path for that attachment.
+    *
+    * @param attachment a potential file attachment
+    * @return the path of the provided file attachment
+    */
+  def getFilePathForAttachment(attachment: AttachmentBean): Option[String] =
+    attachment match {
+      case fileAttachment: FileAttachmentBean => Option(fileAttachment.getFilename)
+      case _                                  => None
+    }
+
+  /**
+    * Use the `description` from the `Attachment` behind the `AttachmentBean` as this provides
+    * the value more commonly seen in the LegacyUI. And specifically uses any tweaks done for
+    * Custom Attachments - such as with Kaltura where the Kaltura Media `title` is pushed into
+    * the `description` rather than using the optional (and multi-line) Kaltura Media `description`.
+    *
+    * @param itemKey the details of the item the attachment belongs to
+    * @param attachmentUuid the UUID of the attachment
+    * @return the description for the attachment if available
+    */
+  def getAttachmentDescription(itemKey: ItemKey, attachmentUuid: String): Option[String] =
+    Option(LegacyGuice.itemService.getAttachmentForUuid(itemKey, attachmentUuid).getDescription)
+
+  /**
+    * Determines if attachment contains a generated thumbnail in filestore
+    */
+  def thumbExists(itemKey: ItemIdKey, attachBean: AttachmentBean): Option[Boolean] = {
+    attachBean match {
+      case fileBean: FileAttachmentBean =>
+        val item = LegacyGuice.viewableItemFactory.createNewViewableItem(itemKey)
+        Option(fileBean.getThumbnail).map {
+          LegacyGuice.fileSystemService.fileExists(item.getFileHandle, _)
+        }
+      case _ => None
+    }
+  }
+
+  /**
+    * Find out the latest version of the Item which a Custom Attachment points to.
+    *
+    * @param version Version of a linked Item. It is either 0 or 1 where 0 means using the latest version
+    *                and 1 means always using version 1.
+    * @param uuid UUID of the linked Item.
+    */
+  def getLatestVersionForCustomAttachment(version: Int, uuid: String): Int = {
+    version match {
+      // If version of is 0, find the real latest version of this Item.
+      case 0           => LegacyGuice.itemService.getLatestVersion(uuid)
+      case realVersion => realVersion
+    }
+  }
+
+  /**
+    * Determines if a given customAttachment is invalid. Required as these attachments can be recursive.
+    * @param customAttachment The attachment to check.
+    * @return If true, this attachment is broken.
+    */
+  def isCustomAttachmentBroken(customAttachment: CustomAttachment): Boolean = {
+    val uuid    = customAttachment.getData("uuid").asInstanceOf[String]
+    val version = customAttachment.getData("version").asInstanceOf[Int]
+
+    val key = new ItemId(uuid, getLatestVersionForCustomAttachment(version, uuid))
+
+    if (customAttachment.getType != "resource") {
+      return false;
+    }
+    customAttachment.getData("type") match {
+      case "a" =>
+        // Recurse into child attachment
+        recurseBrokenAttachmentCheck(key, customAttachment.getUrl)
+      case "p" =>
+        // Get the child item. If it doesn't exist, this is a dead attachment
+        Option(LegacyGuice.itemService.getUnsecureIfExists(key)).isEmpty
+      case _ => false
+    }
+  }
+
+  /**
+    * Determines if a given attachment is invalid.
+    * If it is a resource selector attachment, this gets handled by
+    * [[isCustomAttachmentBroken(customAttachment: CustomAttachment)]]
+    * which links back in here to recurse through customAttachments to find the root.
+    *
+    * @param itemKey the details of the item the attachment belongs to
+    * @param attachmentUuid the UUID of the attachment
+    * @return True if broken, false if intact.
+    */
+  def recurseBrokenAttachmentCheck(itemKey: ItemKey, attachmentUuid: String): Boolean = {
+    Option(LegacyGuice.itemService.getNullableAttachmentForUuid(itemKey, attachmentUuid)) match {
+      case Some(fileAttachment: FileAttachment) =>
+        //check if file is present in the filestore
+        val item =
+          LegacyGuice.viewableItemFactory.createNewViewableItem(fileAttachment.getItem.getItemId)
+        !LegacyGuice.fileSystemService.fileExists(item.getFileHandle, fileAttachment.getFilename)
+      case Some(customAttachment: CustomAttachment) =>
+        isCustomAttachmentBroken(customAttachment)
+      case None    => true
+      case Some(_) => false
+    }
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/service/AttachmentResourceService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/service/AttachmentResourceService.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.api.search.service
 
 import com.tle.beans.item.attachments.{CustomAttachment, FileAttachment}


### PR DESCRIPTION
#3769 

##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

We have added a fix (#3563)for the bug caused by a custom attachment which points to the latest version of another resource. 

However, that fix only works when the linked resource is an Item. When the resource is an Attachment, the issue can still happen such as when checking the MIME type of the linked attachment. (#3769)

So this PR adds some improvements to make sure whenever a linked resource is used in search2 API, the genuine latest version is used. 

During implementation, I realised that `SearchHelper` has been getting bigger and bigger. So I move some functions to the Scala version `AttachmentResourceService` and some to `AttachmentHelper`.