### PR TITLE
build(gha): upgrade GHA CI to postgres 10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,7 +199,7 @@ jobs:
     strategy:
       matrix:
         newui: [true, false]
-        pgsql-image: [latest, 9.6]
+        pgsql-image: [latest, 10]
         exclude:
           - newui: false
             pgsql-image: latest


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Now that 9.6 is no longer supported, version 10 is the oldest supported
version (until November this year - see
https://www.postgresql.org/support/versioning/ for more info).

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
