### PR TITLE
fix(api): ensure batchUpdate return correct id in response

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/FacetedSearch/FacetedSearchClassificationResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/FacetedSearch/FacetedSearchClassificationResource.scala
@@ -136,7 +136,9 @@ class FacetedSearchClassificationResource {
             newClassification.setDateModified(new Date())
             newClassification.setInstitution(CurrentInstitution.get)
             service.add(newClassification)
-            ApiBatchOperationResponse(id, 200, s"A new classification has been created.")
+            ApiBatchOperationResponse(newClassification.getId,
+                                      200,
+                                      s"A new classification has been created.")
           } else {
             Option(service.getById(id)) match {
               case Some(oldClassification) =>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
FacetedSearchClassification will generate its own id for creating operations.
Therefore the change is to make sure the response id is correct. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
