### PR TITLE
Feature/consolidate logging layer

### DIFF
--- a/Dev/learningedge-config/build.sbt
+++ b/Dev/learningedge-config/build.sbt
@@ -13,7 +13,7 @@ prepareDevConfig := {
     installerConfig / "hikari.properties"
   ).pair(rebase(installerConfig, baseDir))
   val fromDefaults = Seq(
-    "learningedge-log4j.properties",
+    "learningedge-log4j.yaml",
     "optional-config.properties",
     "hibernate.properties"
   ).map(f => (defaultsDir / s"$f.default", baseDir / f))

--- a/Dev/learningedge-config/defaults/learningedge-log4j.yaml.default
+++ b/Dev/learningedge-config/defaults/learningedge-log4j.yaml.default
@@ -1,0 +1,22 @@
+Configuration:
+  status: debug
+
+  appenders:
+    Console:
+      name: CONSOLE
+      target: SYSTEM_OUT
+      Filters:
+        ThresholdFilter:
+          level: debug
+        RegexFilter:
+          regex: ".*(HHH90000022|HHH90000014).*"
+          onMatch: "DENY"
+          onMismatch: "NEUTRAL"
+      PatternLayout:
+        Pattern: "%d{ABSOLUTE} %-5p [%c{1}] %m%n"
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        - ref: CONSOLE

--- a/Source/Tools/UpgradeInstallation/build.sbt
+++ b/Source/Tools/UpgradeInstallation/build.sbt
@@ -5,13 +5,15 @@ libraryDependencies ++= Seq(
   "org.slf4j"        % "jcl-over-slf4j" % "1.7.33",
   log4j,
   log4jSlf4jImpl,
+  "org.typelevel"            %% "cats-core"       % "2.7.0",
   xstreamDep,
   "commons-configuration" % "commons-configuration" % "1.10",
   "commons-io"            % "commons-io"            % "2.11.0",
   "commons-lang"          % "commons-lang"          % "2.6",
   // Need these two jackson deps to allow processing log4j yaml config files.
   "com.fasterxml.jackson.core"       % "jackson-databind"        % jacksonVersion,
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion,
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala"   % jacksonVersion
 )
 
 excludeDependencies ++= Seq(
@@ -19,7 +21,7 @@ excludeDependencies ++= Seq(
 )
 
 (assembly / mainClass) := Some("com.tle.upgrade.UpgradeMain")
-(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
+(assembly / assemblyOption) := (assembly / assemblyOption).value.withIncludeScala(true)
 
 (assembly / assemblyMergeStrategy) := {
   case PathList("org", "xmlpull", "v1", _*) => MergeStrategy.first

--- a/Source/Tools/UpgradeInstallation/build.sbt
+++ b/Source/Tools/UpgradeInstallation/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"        % "jcl-over-slf4j" % "1.7.33",
   log4j,
   log4jSlf4jImpl,
-  "org.typelevel"            %% "cats-core"       % "2.7.0",
+  "org.typelevel" %% "cats-core" % "2.7.0",
   xstreamDep,
   "commons-configuration" % "commons-configuration" % "1.10",
   "commons-io"            % "commons-io"            % "2.11.0",

--- a/Source/Tools/UpgradeInstallation/plugin-jpf.xml
+++ b/Source/Tools/UpgradeInstallation/plugin-jpf.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE plugin PUBLIC "-//JPF//Java Plug-in Manifest 1.0" "http://jpf.sourceforge.net/plugin_1_0.dtd">
-<plugin version="1" id="TLE Installation Upgrade">
+<plugin version="1" id="UpgradeInstallation">
 	<requires>
 		<import plugin-id="com.tle.platform.equella" />
 		<import plugin-id="com.tle.platform.common" />

--- a/Source/Tools/UpgradeInstallation/resources/com/tle/upgrade/upgraders/learningedge-log4j.yaml
+++ b/Source/Tools/UpgradeInstallation/resources/com/tle/upgrade/upgraders/learningedge-log4j.yaml
@@ -1,0 +1,101 @@
+# This file configures the logging features of TLE.  Please go through each
+# of the following lines, and replace with the appropriate values.
+
+# Logs location.  You should always use forward slashes for the path
+# even on a Microsoft Windows box. Files names end up like this...
+#
+#   Example 1: c:/tle/logs/resource-centre/application.html
+#
+#     Logs To: c:/tle/logs/resource-centre/2006-05-23/application.html
+#              c:/tle/logs/resource-centre/2006-05-23/application.1.html
+#              c:/tle/logs/resource-centre/2006-05-23/application.2.html
+#              .....
+#
+
+Configuration:
+  status: warn
+
+  appenders:
+    RollingFile:
+      - name: FILE
+        fileName: "${install.path}/logs/resource-centre/application.html"
+        filePattern: "${install.path}/logs/resource-centre/%d{yyyy-MM-dd}/application-%i.html"
+        immediateFlush: true
+        append: true
+        Filters:
+          ThresholdFilter:
+            level: DEBUG
+          RegexFilter:
+            # Filter out Hibernate Criteria deprecation warning and Generator warning.
+            regex: ".*(HHH90000022|HHH90000014).*"
+            onMatch: "DENY"
+            onMismatch: "NEUTRAL"
+        HTMLLayout:
+          title: TLE Resource Centre
+          datePattern: ISO8601
+          locationInfo: true
+        Policies:
+          TimeBasedTriggeringPolicy:
+            interval: 1
+            modulate: true
+          SizeBasedTriggeringPolicy:
+            size: 10 MB
+        DefaultRollOverStrategy:
+          max: 20
+
+      - name: REPORT
+        fileName: "${install.path}/logs/reporting/log.html"
+        filePattern: "${install.path}/logs/reporting/%d{yyyy-MM-dd}/log-%i.html"
+        immediateFlush: true
+        append: true
+        Filters:
+          ThresholdFilter:
+            level: DEBUG
+        HTMLLayout:
+          title: EQUELLA Reporting Logs
+          datePattern: ISO8601
+          locationInfo: true
+        Policies:
+          TimeBasedTriggeringPolicy:
+            interval: 1
+            modulate: true
+          SizeBasedTriggeringPolicy:
+            size: 10 MB
+        DefaultRollOverStrategy:
+          max: 20
+
+      - name: TOMCAT
+        fileName: "${install.path}/logs/tomcat/tomcat.html"
+        filePattern: "${install.path}/logs/tomcat/%d{yyyy-MM-dd}/tomcat-%i.html"
+        immediateFlush: true
+        append: true
+        Filters:
+          ThresholdFilter:
+            level: DEBUG
+        HTMLLayout:
+          title: Tomcat Logs
+          datePattern: ISO8601
+          locationInfo: true
+        Policies:
+          TimeBasedTriggeringPolicy:
+            interval: 1
+            modulate: true
+          SizeBasedTriggeringPolicy:
+            size: 10 MB
+        DefaultRollOverStrategy:
+          max: 20
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: FILE
+    Logger:
+      - name: org.eclipse.birt
+        level: INFO
+        AppenderRef:
+          ref: REPORT
+      - name: TomcatLog
+        level: INFO
+        AppenderRef:
+          ref: TOMCAT

--- a/Source/Tools/UpgradeInstallation/resources/com/tle/upgrade/upgraders/log4j.yaml
+++ b/Source/Tools/UpgradeInstallation/resources/com/tle/upgrade/upgraders/log4j.yaml
@@ -1,0 +1,53 @@
+Configuration:
+  status: warn
+
+  properties:
+    property:
+      - name: filePath
+        value: "../logs/equella-manager"
+      - name: fileName
+        value: "${filePath}/services.html"
+      - name: filePattern
+        value: "${filePath}/%d{yyyy-MM-dd}/services-%i.html"
+
+  appenders:
+    Console:
+      name: STDOUT
+      target: SYSTEM_OUT
+      Filters:
+        ThresholdFilter:
+          level: info
+      PatternLayout:
+        Pattern: "%d{ABSOLUTE} %-5p [%c{1}] %m%n"
+
+    RollingFile:
+      name: ROLLING_FILE
+      fileName: "${fileName}"
+      filePattern: "${filePattern}"
+      immediateFlush: true
+      append: true
+      Filters:
+        ThresholdFilter:
+          level: info
+      HTMLLayout:
+        title: TLE Service Manager
+        datePattern: ISO8601
+        locationInfo: true
+      Policies:
+        TimeBasedTriggeringPolicy:
+          interval: 1
+          modulate: true
+        SizeBasedTriggeringPolicy:
+          size: 10 MB
+      DefaultRollOverStrategy:
+        max: 20
+
+  Loggers:
+    Root:
+      level: debug
+      AppenderRef:
+        - ref: STDOUT
+        - ref: ROLLING_FILE
+    Logger:
+      name: com.tle.common.util.ExecUtils
+      level: warn

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Appender.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Appender.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders.log4j2
 
 import cats.implicits._

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Appender.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Appender.scala
@@ -1,0 +1,157 @@
+package com.tle.upgrade.upgraders.log4j2
+
+import cats.implicits._
+import cats.data.{Validated, ValidatedNec}
+import com.fasterxml.jackson.annotation.{JsonAnyGetter, JsonIgnoreProperties}
+import com.tle.upgrade.upgraders.log4j2.Appender.getLayoutMap
+import com.tle.upgrade.upgraders.log4j2.Filter.getFilters
+import com.tle.upgrade.upgraders.log4j2.Layout.getLayout
+import com.tle.upgrade.upgraders.log4j2.PropertyHelper.{
+  readBooleanProperty,
+  readIntProperty,
+  readProperty
+}
+
+import java.util.Properties
+import scala.collection.JavaConverters._
+
+case class RollOverStrategy(max: Int = 20)
+
+sealed trait RollingPolicy
+case class TimeBasedTriggeringPolicy(interval: Int = 1, modulate: Boolean = true)
+    extends RollingPolicy
+case class SizeBasedTriggeringPolicy(size: String = "10 MB") extends RollingPolicy
+
+@JsonIgnoreProperties(Array("layout"))
+sealed trait Appender {
+  def layout: Layout
+  @JsonAnyGetter
+  def getLayout: java.util.Map[String, Layout] = getLayoutMap(layout)
+}
+
+case class Console(name: String,
+                   target: String,
+                   layout: Layout,
+                   Filters: Option[Map[String, Seq[Filter]]])
+    extends Appender
+
+case class RollingFile(name: String,
+                       fileName: String,
+                       filePattern: String,
+                       immediateFlush: Boolean,
+                       append: Boolean,
+                       layout: Layout,
+                       Filters: Option[Map[String, Seq[Filter]]],
+                       Policies: Map[String, RollingPolicy],
+                       DefaultRollOverStrategy: RollOverStrategy)
+    extends Appender
+
+object Appender {
+  val appenderPrefix = "log4j.appender."
+
+  def getLayoutMap(layout: Layout): java.util.Map[String, Layout] =
+    Map(layout.getClass.getSimpleName -> layout).asJava
+
+  def appenderName(key: String): String = key.replace(appenderPrefix, "")
+
+  def buildConsole(key: String, props: Properties): ValidatedNec[String, Console] = {
+    def target =
+      readProperty(s"${key}.Target", props)
+      // If target is "system.out", use "system_out" instead.
+        .filter(_.toLowerCase != "system.out")
+        .getOrElse("SYSTEM_OUT")
+
+    (getLayout(s"${key}.layout", props), getFilters(key, props))
+      .mapN((layout, filters) => Console(appenderName(key), target, layout, filters))
+  }
+
+  def buildRollingFile(key: String, props: Properties): ValidatedNec[String, RollingFile] = {
+    def fileName =
+      readProperty(s"${key}.File", props)
+        .toValidNec(s"Must specify a file name for ${key}")
+
+    def immediateFlush =
+      readBooleanProperty(s"${key}.ImmediateFlush", props).getOrElse(true)
+
+    def append =
+      readBooleanProperty(s"${key}.Append", props).getOrElse(true)
+
+    def maxFileSize =
+      readProperty(s"${key}.MaxFileSize", props)
+        .getOrElse("10MB")
+
+    def maxBackupIndex =
+      readIntProperty(s"${key}.MaxBackupIndex", props)
+        .getOrElse(10)
+
+    def filePattern(fileName: String) = {
+      // Regex matching a file name and an optional directory.
+      // Examples:
+      // 1. test.log
+      // 2. ../test.log
+      // 3. dir/test.log
+      // 4. dir1/dir2/.../dir10/test.log
+      val Regex = """(.*/)?(.*)\.(.*)$""".r
+
+      // Log4J default date pattern.
+      val defaultPattern = "%d{yyyy-MM-dd}"
+
+      fileName match {
+        case Regex(dir, filename, ext) =>
+          s"${Option(dir).getOrElse("")}${defaultPattern}/${filename}-%i.${ext}"
+        case name => s"${defaultPattern}/${name}-%i"
+      }
+    }
+
+    (fileName, getLayout(s"${key}.layout", props), getFilters(key, props)).mapN(
+      (filename, layout, filters) => {
+        RollingFile(
+          name = appenderName(key),
+          fileName = filename,
+          filePattern = filePattern(filename),
+          immediateFlush = immediateFlush,
+          append = append,
+          layout = layout,
+          Filters = filters,
+          DefaultRollOverStrategy = RollOverStrategy(maxBackupIndex),
+          Policies = Map("TimeBasedTriggeringPolicy" -> TimeBasedTriggeringPolicy(),
+                         "SizeBasedTriggeringPolicy" -> SizeBasedTriggeringPolicy(maxFileSize))
+        )
+      }
+    )
+  }
+
+  // Build one Appender based on the property value.
+  def buildAppender(key: String, props: Properties): ValidatedNec[String, Appender] = {
+    readProperty(key, props)
+      .map {
+        case "org.apache.log4j.ConsoleAppender" => buildConsole(key, props)
+        case "com.tle.core.equella.runner.DailySizeRollingAppender" |
+            "com.dytech.common.log4j.DailySizeRollingAppender" |
+            "org.apache.log4j.RollingFileAppender" =>
+          buildRollingFile(key, props)
+        case unsupported => Validated.invalidNec(s"Unsupported Appender ${unsupported}")
+      }
+      .getOrElse(Validated.invalidNec(s"Must specify an Appender for $key"))
+  }
+
+  // Build a list of Appenders by extracting all the Appender definition keys and creating
+  // an Appender for each key.
+  // The format of a valid appender definition key must be "log4j.appender.XXX" where
+  // "XXX" is the appender name.
+  def buildAppenders(props: Properties): ValidatedNec[String, Map[String, Seq[Appender]]] = {
+    // Group a list of Appenders by their class name.
+    def groupAppenders(appenders: List[Appender]): Map[String, Seq[Appender]] =
+      appenders.groupBy(_.getClass.getSimpleName)
+
+    props
+      .stringPropertyNames()
+      .asScala
+      .filter(_.startsWith(appenderPrefix))
+      .filter(_.split("\\.").length == 3)
+      .map(buildAppender(_, props))
+      .toList
+      .sequence
+      .map(groupAppenders)
+  }
+}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
@@ -79,12 +79,12 @@ object Filter {
 
       props.getProperty(key) match {
         case "org.apache.log4j.varia.StringMatchFilter" =>
-          (stringToMatch, acceptOnMatch).mapN {
-            case (regex, onMatch) =>
+          (stringToMatch, acceptOnMatch).mapN(
+            (regex, onMatch) =>
               RegexFilter(regex = regex,
                           onMatch = filterResult(onMatch),
                           onMismatch = filterResult(!onMatch))
-          }
+          )
         case unsupported => Validated.invalidNec(s"Unsupported filter $unsupported")
       }
     }
@@ -113,17 +113,16 @@ object Filter {
     */
   def getFilters(appender: String,
                  props: Properties): ValidatedNec[String, Option[Map[String, Seq[Filter]]]] = {
-    (getRegexFilters(appender, props), getThresholdFilter(appender, props)).mapN {
-      case (regexFilters, thresholdFilter) =>
-        // Group filters by their types.
-        def group(filters: Seq[Filter]) = {
-          filters.groupBy(_.getClass.getSimpleName)
-        }
+    // Group filters by their types.
+    def group(filters: Seq[Filter]) = {
+      filters.groupBy(_.getClass.getSimpleName)
+    }
 
+    (getRegexFilters(appender, props), getThresholdFilter(appender, props)).mapN(
+      (regexFilters, thresholdFilter) =>
         (regexFilters ++ thresholdFilter.map(Seq(_)))
           .reduceOption(_ ++ _)
           .map(group)
-
-    }
+    )
   }
 }

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders.log4j2
 
 import java.util.Properties

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
@@ -1,0 +1,86 @@
+package com.tle.upgrade.upgraders.log4j2
+
+import java.util.Properties
+import cats.implicits._
+import cats.data.{Validated, ValidatedNec}
+import com.tle.upgrade.upgraders.log4j2.PropertyHelper.{readBooleanProperty, readProperty}
+import org.apache.logging.log4j.spi.StandardLevel
+import scala.collection.JavaConverters._
+import org.apache.logging.log4j.core.Filter.Result
+
+sealed trait Filter
+
+case class ThresholdFilter(level: String) extends Filter
+
+case class RegexFilter(regex: String, onMatch: String, onMismatch: String) extends Filter
+
+object Filter {
+  def getThresholdFilter(appender: String,
+                         props: Properties): ValidatedNec[String, Option[ThresholdFilter]] = {
+    def buildFilter(level: String) =
+      Either
+        .cond(StandardLevel.values().map(s => s.toString).contains(level),
+              ThresholdFilter(level),
+              "Unknown Threshold filter level")
+        .toValidatedNec
+
+    readProperty(s"${appender}.Threshold", props)
+      .traverse(buildFilter)
+  }
+
+  def getRegexFilters(appender: String,
+                      props: Properties): ValidatedNec[String, Option[Seq[RegexFilter]]] = {
+
+    def buildFilter(key: String, props: Properties): ValidatedNec[String, RegexFilter] = {
+      def filterResult(value: Boolean) =
+        if (value) Result.NEUTRAL.toString else Result.DENY.toString
+
+      def acceptOnMatch =
+        readBooleanProperty(s"${key}.AcceptOnMatch", props)
+          .toValidNec(s"Failed to find the value of AcceptOnMatch for ${key}")
+
+      def stringToMatch =
+        readProperty(s"${key}.StringToMatch", props)
+          .map(regex => s".*${regex}.*")
+          .toValidNec(s"Failed to find the value of StringToMatch for ${key}")
+
+      props.getProperty(key) match {
+        case "org.apache.log4j.varia.StringMatchFilter" =>
+          (stringToMatch, acceptOnMatch).mapN {
+            case (regex, onMatch) =>
+              RegexFilter(regex = regex,
+                          onMatch = filterResult(onMatch),
+                          onMismatch = filterResult(!onMatch))
+          }
+        case unsupported => Validated.invalidNec(s"Unsupported filter ${unsupported}")
+      }
+    }
+    // Regex for the format of an Appender filter definition.
+    // For example: log4j.appender.FILE.filter.1
+    val filterKeyRegex = s"^${appender}\\.filter\\.\\d{1}$$"
+
+    props
+      .stringPropertyNames()
+      .asScala
+      .filter(_.matches(filterKeyRegex))
+      .map(buildFilter(_, props))
+      .toList
+      .sequence
+      .map(Option(_).filter(_.nonEmpty))
+  }
+
+  def getFilters(appender: String,
+                 props: Properties): ValidatedNec[String, Option[Map[String, Seq[Filter]]]] = {
+    (getRegexFilters(appender, props), getThresholdFilter(appender, props)).mapN {
+      case (regexFilters, thresholdFilter) =>
+        // Currently, we support RegexFilter and ThresholdFilter.
+        // So convert a list of Filter to a Map where key is either "RegexFilter" or "ThresholdFilter"
+        // and value is a list of RegexFilter or ThresholdFilter.
+        def groupFilter(filters: Seq[RegexFilter],
+                        filter: ThresholdFilter): Map[String, Seq[Filter]] =
+          Map("RegexFilter" -> filters, "ThresholdFilter" -> Seq(filter))
+
+        regexFilters.map2(thresholdFilter)(groupFilter)
+    }
+  }
+}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Filter.scala
@@ -73,14 +73,15 @@ object Filter {
                  props: Properties): ValidatedNec[String, Option[Map[String, Seq[Filter]]]] = {
     (getRegexFilters(appender, props), getThresholdFilter(appender, props)).mapN {
       case (regexFilters, thresholdFilter) =>
-        // Currently, we support RegexFilter and ThresholdFilter.
-        // So convert a list of Filter to a Map where key is either "RegexFilter" or "ThresholdFilter"
-        // and value is a list of RegexFilter or ThresholdFilter.
-        def groupFilter(filters: Seq[RegexFilter],
-                        filter: ThresholdFilter): Map[String, Seq[Filter]] =
-          Map("RegexFilter" -> filters, "ThresholdFilter" -> Seq(filter))
+        // Group filters by their types.
+        def group(filters: Seq[Filter]) = {
+          filters.groupBy(_.getClass.getSimpleName)
+        }
 
-        regexFilters.map2(thresholdFilter)(groupFilter)
+        (regexFilters ++ thresholdFilter.map(Seq(_)))
+          .reduceOption(_ ++ _)
+          .map(group)
+
     }
   }
 }

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Layout.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Layout.scala
@@ -1,0 +1,38 @@
+package com.tle.upgrade.upgraders.log4j2
+
+import cats.data.ValidatedNec
+import cats.implicits._
+import com.tle.upgrade.upgraders.log4j2.PropertyHelper.{readBooleanProperty, readProperty}
+
+import java.util.Properties
+
+sealed trait Layout
+case class PatternLayout(Pattern: String) extends Layout
+case class HTMLLayout(title: Option[String],
+                      datePattern: Option[String] = None,
+                      locationInfo: Option[Boolean])
+    extends Layout
+
+object Layout {
+  def getLayout(layoutKey: String, props: Properties): ValidatedNec[String, Layout] = {
+    readProperty(layoutKey, props)
+      .map {
+        case "org.apache.log4j.PatternLayout" =>
+          readProperty(s"${layoutKey}.ConversionPattern", props)
+            .map(PatternLayout)
+            .toRight(s"Failed to find layout pattern for ${layoutKey}")
+
+        case "org.apache.log4j.HTMLLayout" | "com.dytech.common.log4j.HTMLLayout2" |
+            "com.tle.core.equella.runner.HTMLLayout3" =>
+          val title = readProperty(s"${layoutKey}.title", props)
+          val locationInfo =
+            readBooleanProperty(s"${layoutKey}.LocationInfo", props)
+          val datePattern = readProperty(s"${layoutKey}.datePattern", props)
+          Right(HTMLLayout(title, datePattern, locationInfo))
+
+        case unsupported => Left(s"Unsupported layout $unsupported")
+      }
+      .getOrElse(Left(s"Failed to find layout for $layoutKey"))
+      .toValidatedNec
+  }
+}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Layout.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Layout.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders.log4j2
 
 import cats.data.ValidatedNec

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Logger.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Logger.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders.log4j2
 
 import cats.data.{Validated, ValidatedNec}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Logger.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Logger.scala
@@ -18,7 +18,7 @@
 
 package com.tle.upgrade.upgraders.log4j2
 
-import cats.data.{Validated, ValidatedNec}
+import cats.data.ValidatedNec
 import cats.implicits._
 import com.tle.upgrade.upgraders.log4j2.PropertyHelper.readProperty
 
@@ -35,20 +35,33 @@ case class NormalLogger(name: String,
 case class LoggerConfig(Root: RootLogger, Logger: List[NormalLogger])
 
 object Logger {
-  private def buildRootLogger(props: Properties): ValidatedNec[String, RootLogger] = {
+
+  /**
+    * Build the Root Logger.
+    *
+    * @param props Property file which provides details of the Root Logger.
+    * @return A RootLogger or a list of errors captured the build.
+    */
+  def buildRootLogger(props: Properties): ValidatedNec[String, RootLogger] = {
     readProperty("log4j.rootLogger", props)
       .map(_.split(","))
       .map {
         case Array(level, firstAppender, others @ _*) =>
           val refs = (others :+ firstAppender).map(_.trim).map(AppenderReference)
-          Right((RootLogger(level, refs)))
+          Right(RootLogger(level, refs))
         case _ => Left("Failed to find Appenders for Root logger")
       }
       .getOrElse(Left("Missing Root logger"))
       .toValidatedNec
   }
 
-  private def buildNormalLogger(props: Properties): ValidatedNec[String, List[NormalLogger]] = {
+  /**
+    * Build a list of normal Loggers.
+    *
+    * @param props Property file which provides details of all the normal Loggers.
+    * @return A list of NormalLogger or a list of errors captured the build.
+    */
+  def buildNormalLogger(props: Properties): ValidatedNec[String, List[NormalLogger]] = {
     val loggerPrefix = "log4j.logger."
 
     def build(key: String) = {
@@ -62,7 +75,7 @@ object Logger {
                          AppenderRef = Option((others :+ firstAppender).map(AppenderReference))))
         // A normal logger can have a level without an Appender.
         case Array(level) => Right(NormalLogger(name = name, level = level))
-        case _            => Left(s"Missing logger level for ${name}")
+        case _            => Left(s"Missing logger level for $name")
       }
     }
 
@@ -75,6 +88,12 @@ object Logger {
       .traverse(_.toValidatedNec)
   }
 
+  /**
+    * Build a Root Logger and a list of Normal Loggers.
+    *
+    * @param props Property file which provides details of all the normal Loggers.
+    * @return LoggerConfig including a Root Logger and a list of Normal Loggers.
+    */
   def buildLoggerConfig(props: Properties): ValidatedNec[String, LoggerConfig] =
     (buildRootLogger(props), buildNormalLogger(props))
       .mapN(LoggerConfig)

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Logger.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/Logger.scala
@@ -1,0 +1,63 @@
+package com.tle.upgrade.upgraders.log4j2
+
+import cats.data.{Validated, ValidatedNec}
+import cats.implicits._
+import com.tle.upgrade.upgraders.log4j2.PropertyHelper.readProperty
+
+import java.util.Properties
+import scala.collection.JavaConverters._
+
+case class AppenderReference(ref: String)
+
+case class RootLogger(level: String, AppenderRef: Seq[AppenderReference])
+case class NormalLogger(name: String,
+                        level: String,
+                        AppenderRef: Option[Seq[AppenderReference]] = None)
+
+case class LoggerConfig(Root: RootLogger, Logger: List[NormalLogger])
+
+object Logger {
+  private def buildRootLogger(props: Properties): ValidatedNec[String, RootLogger] = {
+    readProperty("log4j.rootLogger", props)
+      .map(_.split(","))
+      .map {
+        case Array(level, firstAppender, others @ _*) =>
+          val refs = (others :+ firstAppender).map(_.trim).map(AppenderReference)
+          Right((RootLogger(level, refs)))
+        case _ => Left("Failed to find Appenders for Root logger")
+      }
+      .getOrElse(Left("Missing Root logger"))
+      .toValidatedNec
+  }
+
+  private def buildNormalLogger(props: Properties): ValidatedNec[String, List[NormalLogger]] = {
+    val loggerPrefix = "log4j.logger."
+
+    def build(key: String) = {
+      val name = key.replace(loggerPrefix, "")
+
+      props.getProperty(key).split(",").map(_.trim) match {
+        case Array(level, firstAppender, others @ _*) =>
+          Right(
+            NormalLogger(name = name,
+                         level = level,
+                         AppenderRef = Option((others :+ firstAppender).map(AppenderReference))))
+        // A normal logger can have a level without an Appender.
+        case Array(level) => Right(NormalLogger(name = name, level = level))
+        case _            => Left(s"Missing logger level for ${name}")
+      }
+    }
+
+    props
+      .stringPropertyNames()
+      .asScala
+      .filter(_.startsWith(loggerPrefix))
+      .map(build)
+      .toList
+      .traverse(_.toValidatedNec)
+  }
+
+  def buildLoggerConfig(props: Properties): ValidatedNec[String, LoggerConfig] =
+    (buildRootLogger(props), buildNormalLogger(props))
+      .mapN(LoggerConfig)
+}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/PropertyHelper.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/PropertyHelper.scala
@@ -28,7 +28,7 @@ object PropertyHelper {
     *
     * @param key Key of a property.
     * @param props The property configuration to be read.
-    * @return An Option of String.
+    * @return None if the key is not found in the provided properties, otherwise the value as a String.
     */
   def readProperty(key: String, props: Properties): Option[String] =
     Option(props.getProperty(key))
@@ -39,31 +39,27 @@ object PropertyHelper {
     *
     * @param key Key of a property.
     * @param props The property configuration to be read.
-    * @return An Option of Boolean.
+    * @return None if the key is not found in the provided properties or the key can't be parsed to a Boolean,
+    *         otherwise the value as a Boolean.
     */
   def readBooleanProperty(key: String, props: Properties): Option[Boolean] =
-    readProperty(key, props).map(s =>
+    readProperty(key, props).flatMap(s =>
       Try {
         s.toBoolean
-      } match {
-        case Success(value) => value
-        case Failure(_)     => false
-    })
+      }.toOption)
 
   /**
     * Get an Int value from the property configurations by the supplied key.
     *
     * @param key Key of a property.
     * @param props The property configuration to be read.
-    * @return An Option of Int.
+    * @return None if the key is not found in the provided properties or the key can't be parsed to a Int,
+    *         otherwise the value as a Int.
     */
   def readIntProperty(key: String, props: Properties): Option[Int] =
     readProperty(key, props)
-      .map(s =>
+      .flatMap(s =>
         Try {
           s.toInt
-        } match {
-          case Success(value) => value
-          case Failure(_)     => 0
-      })
+        }.toOption)
 }

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/PropertyHelper.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/PropertyHelper.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders.log4j2
 
 import java.util.Properties

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/PropertyHelper.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/PropertyHelper.scala
@@ -1,0 +1,51 @@
+package com.tle.upgrade.upgraders.log4j2
+
+import java.util.Properties
+import scala.util.{Failure, Success, Try}
+
+object PropertyHelper {
+
+  /**
+    * Get a String value from the property configurations by the supplied key.
+    *
+    * @param key Key of a property.
+    * @param props The property configuration to be read.
+    * @return An Option of String.
+    */
+  def readProperty(key: String, props: Properties): Option[String] =
+    Option(props.getProperty(key))
+      .filter(_.nonEmpty)
+
+  /**
+    * Get a boolean value from the property configurations by the supplied key.
+    *
+    * @param key Key of a property.
+    * @param props The property configuration to be read.
+    * @return An Option of Boolean.
+    */
+  def readBooleanProperty(key: String, props: Properties): Option[Boolean] =
+    readProperty(key, props).map(s =>
+      Try {
+        s.toBoolean
+      } match {
+        case Success(value) => value
+        case Failure(_)     => false
+    })
+
+  /**
+    * Get an Int value from the property configurations by the supplied key.
+    *
+    * @param key Key of a property.
+    * @param props The property configuration to be read.
+    * @return An Option of Int.
+    */
+  def readIntProperty(key: String, props: Properties): Option[Int] =
+    readProperty(key, props)
+      .map(s =>
+        Try {
+          s.toInt
+        } match {
+          case Success(value) => value
+          case Failure(_)     => 0
+      })
+}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
@@ -1,0 +1,67 @@
+package com.tle.upgrade.upgraders.log4j2
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.implicits._
+import com.dytech.edge.common.Constants
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.tle.common.util.EquellaConfig
+import com.tle.upgrade.{PropertyFileModifier, UpgradeResult}
+import com.tle.upgrade.upgraders.AbstractUpgrader
+import com.tle.upgrade.upgraders.log4j2.Appender.buildAppenders
+import com.tle.upgrade.upgraders.log4j2.Logger.buildLoggerConfig
+
+import java.io.File
+import java.util.Properties
+
+/**
+  * Data structure for the Log4j2 configuration in YAML format.
+  *
+  * @param status Log4j internal logging level.
+  * @param appenders A map where key is an Appender type and value is a list of the Appender configuration.
+  * @param Loggers The logger configuration including root logger and normal loggers.
+  */
+case class Configuration(
+    status: String,
+    appenders: Map[String, Seq[Appender]],
+    Loggers: LoggerConfig
+)
+
+class UpdateLog4JConfigFile extends AbstractUpgrader {
+  val mapper = new ObjectMapper(new YAMLFactory())
+    .registerModule(DefaultScalaModule)
+    .setSerializationInclusion(Include.NON_ABSENT)
+    .configure(SerializationFeature.WRAP_ROOT_VALUE, true)
+
+  override def getId: String = "UpdateLog4JConfigFile"
+
+  override def isBackwardsCompatible: Boolean = false
+
+  override def upgrade(result: UpgradeResult, installDir: File): Unit = {
+    def buildYamlFile(file: File): Unit = {
+      val props = loadProperties(file)
+      (buildAppenders(props), buildLoggerConfig(props)).mapN(Configuration("warn", _, _)) match {
+        case Invalid(e) => result.info(e.mkString_("\n"))
+        case Valid(config) =>
+          result.info("Successfully convert Log4J configuration!")
+          mapper.writeValue(new File(file.getParent, file.getName.replace(".properties", ".yaml")),
+                            config);
+      }
+    }
+
+    List(
+      new File(installDir, Constants.LEARNINGEDGE_CONFIG_FOLDER + "/learningedge-log4j.properties"),
+      new File(installDir, Constants.MANAGER_FOLDER + "/log4j.properties"),
+      new File(installDir, Constants.MANAGER_FOLDER + "/upgrader-log4j.properties")
+    ).foreach(buildYamlFile)
+  }
+}
+
+object main extends App {
+  val f = new File("/home/penghai/Edalex/forks/2021",
+                   Constants.MANAGER_FOLDER + "/upgrader-log4j.properties")
+  println("name: " + f.getName)
+  println("name: " + f.getParent)
+}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
@@ -92,7 +92,7 @@ class UpdateLog4JConfigFile extends AbstractUpgrader {
             s"Failed to update Log4J configuration for file ${propertyFile.getName} due to \n ${e
               .mkString_("\n")}")
         case Valid(config) =>
-          mapper.writeValue(new File(propertyFile.getParent, yamlFileName(propertyFile)), config);
+          mapper.writeValue(new File(propertyFile.getParent, yamlFileName(propertyFile)), config)
           result.info(s"Successfully update Log4J configuration for file ${propertyFile.getName}")
       }
     }

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders.log4j2
 
 import cats.data.Validated.{Invalid, Valid}

--- a/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
+++ b/Source/Tools/UpgradeInstallation/scalasrc/com/tle/upgrade/upgraders/log4j2/UpdateLog4JConfigFile.scala
@@ -29,7 +29,6 @@ import com.tle.upgrade.UpgradeResult
 import com.tle.upgrade.upgraders.AbstractUpgrader
 import com.tle.upgrade.upgraders.log4j2.Appender.buildAppenders
 import com.tle.upgrade.upgraders.log4j2.Logger.buildLoggerConfig
-
 import java.io.File
 import java.nio.file.{Files, Paths, StandardCopyOption}
 
@@ -46,6 +45,20 @@ case class Configuration(
     Loggers: LoggerConfig
 )
 
+/**
+  * This migration is intended to update Log4J configuration files to use the new syntax and YAML format.
+  *
+  * Files to be updated:
+  * 1. 'learningedge-log4j.properties' under folder `learningedge-config`;
+  * 2. 'log4j.properties' under folder `manager`;
+  * 3. 'upgrader-log4j.properties' under folder `manager`.
+  *
+  * The result of this migration is to have three YAML files in above folders alongside the original
+  * configuration files.
+  *
+  * All the errors captured during the update will be printed out and the default configurations files
+  * will be copied and pasted to above folders.
+  */
 class UpdateLog4JConfigFile extends AbstractUpgrader {
   val mapper = new ObjectMapper(new YAMLFactory())
     .registerModule(DefaultScalaModule)

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
@@ -65,6 +65,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -76,6 +77,14 @@ import org.apache.commons.logging.LogFactory;
 
 @SuppressWarnings("nls")
 public class UpgradeMain {
+  static {
+    URL log4jConfigFile =
+        ClassLoader.getSystemResource("com/tle/upgrade/upgraders/upgrader-log4j.yaml");
+    if (log4jConfigFile != null) {
+      System.getProperties().setProperty("log4j2.configurationFile", log4jConfigFile.toString());
+    }
+  }
+
   private static final Log LOGGER = LogFactory.getLog(UpgradeMain.class);
 
   private static String commit = "476-g5014b34";

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
@@ -55,6 +55,7 @@ import com.tle.upgrade.upgraders.UpgradeToTomcat6_0_26;
 import com.tle.upgrade.upgraders.UpgradeToTomcat6_0_32;
 import com.tle.upgrade.upgraders.UpgradeToTomcat6_0_35;
 import com.tle.upgrade.upgraders.UpgradeToTomcat7_0_37;
+import com.tle.upgrade.upgraders.log4j2.UpdateLog4JConfigFile;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -115,7 +116,8 @@ public class UpgradeMain {
         new AddLDAPPoolingOptions(),
         new AddLibAvConfig(),
         new AddFreetextAnalyzerConfig(),
-        new AddPostHib5UpgradeConfig()
+        new AddPostHib5UpgradeConfig(),
+        new UpdateLog4JConfigFile()
       };
 
   public static void main(String[] args) throws Throwable {

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
@@ -46,6 +46,7 @@ import com.tle.upgrade.upgraders.RemoveQuartzPropertiesFile;
 import com.tle.upgrade.upgraders.RenameBehindProxyConfig;
 import com.tle.upgrade.upgraders.UpdateClusterConfig;
 import com.tle.upgrade.upgraders.UpdateHibernateProperties;
+import com.tle.upgrade.upgraders.UpdateLog4jConfigForTomcatLog;
 import com.tle.upgrade.upgraders.UpdateManagerJar;
 import com.tle.upgrade.upgraders.UpdateServiceWrapper;
 import com.tle.upgrade.upgraders.UpdateToApacheCommonsDaemon;
@@ -88,6 +89,7 @@ public class UpgradeMain {
 
   public static Upgrader[] upgraders =
       new Upgrader[] {
+        new UpdateLog4jConfigForTomcatLog(),
         new UpdateHibernateProperties(),
         new UpdateManagerJar(),
         new UpdateServiceWrapper(),

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/UpdateLog4jConfigForTomcatLog.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/UpdateLog4jConfigForTomcatLog.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.upgrade.upgraders;
+
+import com.tle.upgrade.UpgradeResult;
+import java.io.File;
+
+@SuppressWarnings("nls")
+@Deprecated
+public class UpdateLog4jConfigForTomcatLog extends AbstractUpgrader {
+  @Override
+  public String getId() {
+    return "Log4jTomcatConfig";
+  }
+
+  @Override
+  public boolean isBackwardsCompatible() {
+    return true;
+  }
+
+  @Override
+  public void upgrade(UpgradeResult result, File tleInstallDir) throws Exception {
+    obsoleteError();
+  }
+}

--- a/Source/Tools/UpgradeManager/src/com/tle/upgrademanager/deploy/DatabaseUpgraderInvoker.java
+++ b/Source/Tools/UpgradeManager/src/com/tle/upgrademanager/deploy/DatabaseUpgraderInvoker.java
@@ -58,7 +58,6 @@ public final class DatabaseUpgraderInvoker {
       final File managerDir = config.getManagerDir();
       List<String> args = Lists.newArrayList();
       args.add(config.getJavaBin().getAbsolutePath());
-      args.add("-Dlog4j2.configurationFile=file:upgrader-log4j.yaml");
       args.add("-classpath");
       args.add(managerDir.getAbsolutePath());
       args.add("-jar");
@@ -66,13 +65,6 @@ public final class DatabaseUpgraderInvoker {
       if (install) {
         args.add("--install");
       }
-
-      /*
-       * StringBuilder command = new StringBuilder(); boolean first =
-       * true; for( String a : args ) { if( !first ) {
-       * command.append(" "); } command.append(a); first = false; }
-       * System.out.println("Executing " + command.toString());
-       */
 
       final ProcessBuilder pbuilder = new ProcessBuilder(args);
       pbuilder.directory(config.getManagerDir());

--- a/project/JPFScanPlugin.scala
+++ b/project/JPFScanPlugin.scala
@@ -134,7 +134,8 @@ object JPFScanPlugin extends AutoPlugin {
     val baseDir = proj.base
     val allManifests = (baseDir / "Source/Plugins" * "*" * "*" / "plugin-jpf.xml").get ++
       (baseDir / "Platform/Plugins" * "*" / "plugin-jpf.xml").get ++
-      (baseDir / "Interface/Plugins" * "*" / "plugin-jpf.xml").get
+      (baseDir / "Interface/Plugins" * "*" / "plugin-jpf.xml").get ++
+      (baseDir / "Source/Tools/UpgradeInstallation/plugin-jpf.xml").get
     val manifestMap = allManifests.map(parseJPF).map(p => (p.id, p)).toMap
 
 //    val adminPlugins = manifestMap.values.filter(_.adminConsole).map(_.id).toSet


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

This is finally the third PR for the Log4J work. What are included in this PR:

1. A new migration to update three Log4J configurations to use the new syntax in YAML format. The files are `leanringedge-log4j.properties` under folder `learningedge-config` and `log4j.properties` and `upgrader-log4j.properties` under folder `manager`. The scala files are housed in `Source/Tools/UpgradeInstallation/scalasrc`.

2. Some dependency updates and JPF plugin updates to support running above migration.
3. Bring back the migration `UpdateLog4jConfigForTomcatLog`  which was dropped in the second PR, but deprecate it. This is due to the `incompatible backwards migration` issue.
4. Update how to set the Log4J configuration when `database-upgrade.jar` is executed. This one could be confusing so please grab me to explain more.