### PR TITLE
chore: update Log4J to v2.17.1 in 'import-export-tool'

### DIFF
--- a/import-export-tool/build.gradle
+++ b/import-export-tool/build.gradle
@@ -33,8 +33,9 @@ allprojects {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'javax.xml', name: 'jaxrpc-api', version: '1.1'
     implementation group: 'javax.xml.soap', name: 'javax.xml.soap-api', version: '1.4.0'
-    implementation group: 'log4j', name: 'log4j', version: '1.2.17'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.35'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j', version: '2.17.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.1'
     implementation group: 'commons-codec', name: 'commons-codec', version: '1.15'
     implementation group: 'commons-discovery', name: 'commons-discovery', version: '0.5'
     implementation group: 'org.apache.axis', name: 'axis', version: '1.4'
@@ -44,7 +45,6 @@ allprojects {
     implementation group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.35'
     implementation fileTree(dir: '../Platform/Plugins/com.tle.platform.common/target/scala-2.12', include: ['*.jar'])
     implementation fileTree(dir: '../Source/Plugins/Platform/com.tle.platform.swing/target/scala-2.12', include: ['*.jar'])
-    testImplementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.35'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

I missed the Log4j in `import-export-tool` as this module was somehow unloaded in my dev env. So open this PR 
to update the Log4j.

After the update, warns from `SLF4J` disappear.
![image](https://user-images.githubusercontent.com/47203811/151479562-e08ba4de-c5ee-47f6-9aa3-325694108e38.png)

