### PR TITLE
fix: don't convert LTI custom parameters to string if no parameters provided 

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/externaltools/service/impl/ExternalToolsServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/externaltools/service/impl/ExternalToolsServiceImpl.java
@@ -326,7 +326,7 @@ public class ExternalToolsServiceImpl
   @Override
   public String customParamListToString(List<NameValue> customParams) {
     StringBuilder value = new StringBuilder("");
-    if (customParams.size() > 0) {
+    if (!Check.isEmpty(customParams)) {
       Iterator<NameValue> iterator = customParams.iterator();
       while (iterator.hasNext()) {
         NameValue param = iterator.next();


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

New Search UI is broken when an Item has an LTI attachment. This is because the LTI custom params are null 
and calling `customParams.size()` results in NPE. 

So we should properly check if the custom params are provided or not by calling `!Check.isEmpty`.