### PR TITLE
refactor: don't filter entities by ACL in `PagedResults`

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/PagedResults.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/entity/PagedResults.scala
@@ -81,9 +81,14 @@ object PagedResults {
     }
 
     def getAvailable: Int = {
-      // It's acceptable to retrieve all because targeted BaseEntities are all small datasets.
-      val entities = getBaseEntities(0, -1)
-      filterByPermission(entities).length
+      // We only return the full number of available entities because filtering entities by ACL is very slow.
+      // Here is an example that would it.
+      // val entities = getBaseEntities(0, -1)
+      // filterByPermission(entities).length
+
+      res.getEntityService
+        .countAll(new EnumerateOptions(q, 0, -1, system, if (includeDisabled) null else false))
+        .toInt
     }
 
     def collectMore(length: Int, initialOffset: Int): (Int, List[PagedEntity[BE]]) = {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Before 2020.2, the value of 'available' in a PagedResult is the full number of available
entities, which is actually not correct because ACL is not taken into account. We fixed
this in 2020.2. However, we found the fix can cause significant performance issue due to
filtering entities by ACL. So we decided to revert the fix and use the full number of
available entities again.