### PR TITLE
fix: add 'UpgradeManager' to jpf scan list

### DIFF
--- a/Installer/plugin-jpf.xml
+++ b/Installer/plugin-jpf.xml
@@ -4,7 +4,7 @@
 		<import plugin-id="com.tle.platform.swing" />
 		<import plugin-id="com.tle.platform.equella" />
 		<import plugin-id="com.tle.platform.common" />
-		<import plugin-id="TLE Upgrade Manager" />
+		<import plugin-id="UpgradeManager" />
 		<import plugin-id="jpf:jpf" />
 		<import plugin-id="org.postgresql:postgresql" />
 		<import plugin-id="com.oracle:ojdbc6" />

--- a/Source/Tools/UpgradeInstallation/plugin-jpf.xml
+++ b/Source/Tools/UpgradeInstallation/plugin-jpf.xml
@@ -7,7 +7,7 @@
 		<import plugin-id="commons-io:commons-io" />
 		<import plugin-id="commons-lang:commons-lang" />
 		<import plugin-id="org.jvnet.hudson:xstream" />
-		<import plugin-id="TLE Upgrade Manager" />
+		<import plugin-id="UpgradeManager" />
 		<import plugin-id="com.google.guava:guava" />
 	</requires>
 	<runtime>

--- a/Source/Tools/UpgradeManager/plugin-jpf.xml
+++ b/Source/Tools/UpgradeManager/plugin-jpf.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE plugin PUBLIC "-//JPF//Java Plug-in Manifest 1.0" "http://jpf.sourceforge.net/plugin_1_0.dtd">
-<plugin version="1" id="TLE Upgrade Manager">
+<plugin version="1" id="UpgradeManager">
 	<requires>
 		<import plugin-id="com.tle.platform.common" />
 		<import plugin-id="com.tle.platform.equella" />

--- a/project/JPFScanPlugin.scala
+++ b/project/JPFScanPlugin.scala
@@ -135,7 +135,8 @@ object JPFScanPlugin extends AutoPlugin {
     val allManifests = (baseDir / "Source/Plugins" * "*" * "*" / "plugin-jpf.xml").get ++
       (baseDir / "Platform/Plugins" * "*" / "plugin-jpf.xml").get ++
       (baseDir / "Interface/Plugins" * "*" / "plugin-jpf.xml").get ++
-      (baseDir / "Source/Tools/UpgradeInstallation/plugin-jpf.xml").get
+      // Also include UpgradeInstallation and UpgradeManager
+      (baseDir / "Source/Tools" * "Upgrade*" / "plugin-jpf.xml").get
     val manifestMap = allManifests.map(parseJPF).map(p => (p.id, p)).toMap
 
 //    val adminPlugins = manifestMap.values.filter(_.adminConsole).map(_.id).toSet


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Previous Log4J update work has caused a sbt error about not being able to to find plugin `TLE Upgrade Manager`. 

This is because the project of `TLE Upgrade Manager` is the dependency of project `UpgradeInstallation`. 

So we just need to add `TLE Upgrade Manager` to the JPF plugin scan list. However, `TLE Upgrade Manager` is not a valid name so I also renamed the plugin to `UpgradeManager`.