### PR TITLE
Upgrade MS SQL Server JDBC Driver

### DIFF
--- a/Installer/data/server/learningedge-config/hibernate.properties.sqlserver
+++ b/Installer/data/server/learningedge-config/hibernate.properties.sqlserver
@@ -1,6 +1,6 @@
 hibernate.connection.driver_class = com.microsoft.sqlserver.jdbc.SQLServerDriver
 hibernate.dialect = com.tle.hibernate.dialect.SQLServerDialect
-hibernate.connection.url = jdbc:sqlserver://${datasource/host}:${datasource/port};databaseName=${datasource/database}
+hibernate.connection.url = jdbc:sqlserver://${datasource/host}:${datasource/port};databaseName=${datasource/database};trustServerCertificate=${datasource/trustservercerts}
 hibernate.connection.username = ${datasource/username}
 hibernate.connection.password = ${datasource/password}
 

--- a/Installer/resources/script/app-script.xml
+++ b/Installer/resources/script/app-script.xml
@@ -83,7 +83,7 @@
 					<description>Select the database type from the list of currently supported databases.</description>
 					<target>datasource/dbtype</target>
 					<items>
-						<item name="MS SQL Server - 2019+" value="sqlserver" default="true"/>
+						<item name="MS SQL Server - 2012+" value="sqlserver" default="true"/>
 						<item name="Oracle - 12c+" value="oracle"/>
 						<item name="PostgreSQL - 9.6+" value="postgresql"/>
 					</items>
@@ -141,6 +141,17 @@
 						<item name="Service name" value="/" />
 					</items>
 				</control>
+        <control class="mssqltrustservercerts">
+          <title>Trust Server Certificates</title>
+          <description>
+            Do you want to trust the SSL certficates used by your DB server - thereby, skipping
+            certificate validation. (Relates to JDBC URL option 'trustServerCertificate'.)
+          </description>
+          <target>datasource/trustservercerts</target>
+          <items>
+            <item name="Enable" value="/" default="false" />
+          </items>
+        </control>
 			</controls>
 			<buttons>
 				<button label="Back" callback="com.dytech.installer.BasicBackCallback" icon="/images/back.gif" align="left"/>

--- a/Installer/src/com/dytech/edge/installer/DatasourceConfig.java
+++ b/Installer/src/com/dytech/edge/installer/DatasourceConfig.java
@@ -109,6 +109,7 @@ public class DatasourceConfig extends ForeignCommand {
 
     return config;
   }
+
   /** Names of the various names under `datasource/` used for configuration. */
   public enum DatasourceNodes {
     HOST("host"),

--- a/Installer/src/com/dytech/edge/installer/application/FinishedCallback.java
+++ b/Installer/src/com/dytech/edge/installer/application/FinishedCallback.java
@@ -18,8 +18,9 @@
 
 package com.dytech.edge.installer.application;
 
+import static com.dytech.edge.installer.DatasourceConfig.updateHostAndPort;
+
 import com.dytech.devlib.PropBagEx;
-import com.dytech.edge.installer.DatabaseCommand;
 import com.dytech.installer.Callback;
 import com.dytech.installer.Wizard;
 import com.tle.common.hash.Hash;
@@ -91,16 +92,7 @@ public class FinishedCallback implements Callback {
 
     installer.finished();
 
-    // This needs to happen AFTER finished() call to make sure host isn't
-    // overridden
-    String dbhost = output.getNode("datasource/host");
-    if (dbhost.indexOf(':') >= 0) {
-      String[] bits = dbhost.split(":");
-      output.setNode("datasource/host", bits[0]);
-      output.setNode("datasource/port", bits[1]);
-    } else {
-      String dbtype = output.getNode("datasource/dbtype");
-      output.setNode("datasource/port", DatabaseCommand.getDefaultPort(dbtype));
-    }
+    // This needs to happen AFTER finished() call to make sure host isn't overridden
+    updateHostAndPort(output);
   }
 }

--- a/Installer/src/com/dytech/installer/WizardPage.java
+++ b/Installer/src/com/dytech/installer/WizardPage.java
@@ -35,6 +35,7 @@ import com.dytech.installer.controls.GShuffleBox;
 import com.dytech.installer.controls.GuiControl;
 import com.dytech.installer.controls.HelpButton;
 import com.dytech.installer.controls.HostEditor;
+import com.dytech.installer.controls.MsSqlTrustServerCertsSelector;
 import com.dytech.installer.controls.OracleIdSelector;
 import com.dytech.installer.gui.JPanelAA;
 import java.awt.FlowLayout;
@@ -68,7 +69,7 @@ public class WizardPage {
     this.pageBag = pageBag;
     this.parent = parent;
 
-    controls = new Vector<GuiControl>();
+    controls = new Vector<>();
   }
 
   public GuiControl controlFactory(PropBagEx controlBag) throws InstallerException {
@@ -104,6 +105,8 @@ public class WizardPage {
       control = new HostEditor(controlBag);
     } else if (cclass.equalsIgnoreCase("oracleidselector")) {
       control = new OracleIdSelector(controlBag, parent);
+    } else if (cclass.equalsIgnoreCase("mssqltrustservercerts")) {
+      control = new MsSqlTrustServerCertsSelector(controlBag, parent);
     } else if (cclass.equalsIgnoreCase("link")) {
       control = new GLink(controlBag);
     } else {

--- a/Installer/src/com/dytech/installer/controls/GuiControl.java
+++ b/Installer/src/com/dytech/installer/controls/GuiControl.java
@@ -32,12 +32,12 @@ import javax.swing.JPanel;
 
 public abstract class GuiControl {
   protected List targets;
-  protected Vector items;
+  protected Vector<Item> items;
   protected String title;
   protected String description;
 
   public GuiControl(PropBagEx controlBag) {
-    items = new Vector();
+    items = new Vector<>();
     targets = new ArrayList();
 
     createControl(controlBag);
@@ -127,6 +127,20 @@ public abstract class GuiControl {
 
       Item item = new Item(name, value, selected);
       items.add(item);
+    }
+  }
+
+  /**
+   * Hides the control by clearing title and description, while also setting all 'items' to
+   * invisible.
+   */
+  protected void hide() {
+    this.title = "";
+    this.description = "";
+    for (Item item : this.items) {
+      if (item != null && item.getButton() != null) {
+        item.getButton().setVisible(false);
+      }
     }
   }
 }

--- a/Installer/src/com/dytech/installer/controls/MsSqlTrustServerCertsSelector.java
+++ b/Installer/src/com/dytech/installer/controls/MsSqlTrustServerCertsSelector.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.dytech.installer.controls;
 
 import com.dytech.devlib.PropBagEx;

--- a/Installer/src/com/dytech/installer/controls/MsSqlTrustServerCertsSelector.java
+++ b/Installer/src/com/dytech/installer/controls/MsSqlTrustServerCertsSelector.java
@@ -1,21 +1,3 @@
-/*
- * Licensed to The Apereo Foundation under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- *
- * The Apereo Foundation licenses this file to you under the Apache License,
- * Version 2.0, (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.dytech.installer.controls;
 
 import com.dytech.devlib.PropBagEx;
@@ -27,17 +9,25 @@ import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
 import javax.swing.JComponent;
 
-public class OracleIdSelector extends GRadioButtonGroup {
+/**
+ * Control to conditionally display for MS SQL server installs to determine whether to trust server
+ * certificates as introduced in mssql-jdbc 10.2.0.
+ *
+ * <p>Based on com.dytech.installer.controls.OracleIdSelector
+ */
+public class MsSqlTrustServerCertsSelector extends GCheckBoxGroup {
   Wizard grandParent;
   PropBagEx defaults;
 
-  public OracleIdSelector(PropBagEx controlBag, Wizard grandParent) throws InstallerException {
+  public MsSqlTrustServerCertsSelector(PropBagEx controlBag, Wizard grandParent)
+      throws InstallerException {
     super(controlBag);
+
     this.grandParent = grandParent;
     this.defaults = grandParent != null ? grandParent.getDefaults() : null;
-    if (items.size() != 2) {
+    if (items.size() != 1) {
       throw new InstallerException(
-          "Expected 2 item definitions for Oracle id selector radio buttons");
+          "Expected 1 item definitions for MS SQL trust server certificates selector.");
     }
 
     update();
@@ -53,7 +43,7 @@ public class OracleIdSelector extends GRadioButtonGroup {
   private void update() {
     PropBagEx stateOfThings = grandParent.getOutputNow();
     String dbtype = stateOfThings.getNode(DatasourceNodes.TYPE.path());
-    boolean relevance = (DatabaseTypes.ORACLE.id().equals(dbtype));
+    boolean relevance = (DatabaseTypes.MSSQL.id().equals(dbtype));
     if (relevance) {
       loadControl(defaults);
     } else {

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -40,7 +40,7 @@ object CommonSettings extends AutoPlugin {
     lazy val platformSwing   = LocalProject("com_tle_platform_swing")
     lazy val platformEquella = LocalProject("com_tle_platform_equella")
     lazy val postgresDep     = "org.postgresql" % "postgresql" % "42.3.1"
-    lazy val sqlServerDep    = "com.microsoft.sqlserver" % "mssql-jdbc" % "6.1.0.jre8"
+    lazy val sqlServerDep    = "com.microsoft.sqlserver" % "mssql-jdbc" % "10.2.0.jre8"
 
     lazy val log4jVersion   = "2.17.1"
     lazy val log4j          = "org.apache.logging.log4j" % "log4j" % log4jVersion


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

oEQ was using a very old version of the MS SQL JDBC Driver which had dependencies on an old version of Jackson (1.9.x) which has recorded security vulnerabilities. So it was high time to upgrade to the latest.

However, it turned out that in the [latest mssql-jdbc](https://github.com/microsoft/mssql-jdbc/releases/tag/v10.2.0) they'd also addressed a [bug where server certificates were not being fully validated](https://github.com/microsoft/mssql-jdbc/pull/1731). By default though, SQL Server installs with a self-signed certificate which will fail this validation.

To support these cases, you can set the new flag `trustServerCertificate` to `true` in JDBC URLs.

In the oEQ installer though we test the JDBC configuration, so if that was not set then the test would fail and you would not be able to complete an installation. In order to address this it made sense to ensure the installer was aware of this flag and the user could set it as required for their environment. Further, that choice could then be captured in their new configuration files (hibernate.properties).

For upgrades though, we will add details to the Feature Guide for sites to address manually depending on their environment and preferences.

(I don't love the way the new checkbox option is implemented. However I followed the existing pattern done for the options which are shown for Oracle installs. It is all a bit upside down though, but to really address it properly would require a larger refactor of the way the UI classes are done - and better yet, would probably be done as a conditional statement within the `app-script.xml`.)

To validate the changes (both for the installer and the new mssql-jdbc driver) I undertook manual testing by doing a full install and then an institution import etc.

Below you can see the update to the page when a user has selected 'SQL Server' as their DB type. Note the new 'Enable' checkbox at the bottom.

![2022-02-11-095231_681x511_scrot](https://user-images.githubusercontent.com/43919233/153510706-a8389906-7411-446b-8767-cc913e985c7e.png)

If you have a server with a self-signed certificate (or with a certificate signed by a CA not in your java trust store) and you don't check 'Enable' you'll see:

![2022-02-11-095320_973x194_scrot](https://user-images.githubusercontent.com/43919233/153510635-e87d98e5-d8be-46a9-8112-39ea841c285c.png)

And if you look at the console you'd see the following stacktrace:

```
java.lang.RuntimeException: Attempted connect at connectionURL (jdbc:sqlserver://localhost:1433;databaseName=equella;trustServerCertificate=false), username (sa), password(Password1), dbtype(sqlserver), database(equella)
	at com.dytech.edge.installer.application.DatabaseConnectCallback.testDatabase(DatabaseConnectCallback.java:164)
	at com.dytech.edge.installer.application.DatabaseConnectCallback$1.construct(DatabaseConnectCallback.java:81)
	at com.dytech.gui.workers.AdvancedSwingWorker$3.run(AdvancedSwingWorker.java:106)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: The driver could not establish a secure connection to SQL Server by using Secure Sockets Layer (SSL) encryption. Error: "PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target". ClientConnectionId:7334069c-f73c-488c-bc49-1fb30aa3d1cd
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.terminate(SQLServerConnection.java:3680)
	at com.microsoft.sqlserver.jdbc.TDSChannel.enableSSL(IOBuffer.java:2113)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectHelper(SQLServerConnection.java:3204)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.login(SQLServerConnection.java:2833)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectInternal(SQLServerConnection.java:2671)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connect(SQLServerConnection.java:1640)
	at com.microsoft.sqlserver.jdbc.SQLServerDriver.connect(SQLServerDriver.java:936)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:247)
	at com.dytech.edge.installer.application.DatabaseConnectCallback.testDatabase(DatabaseConnectCallback.java:161)
	... 3 more
Caused by: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
	at sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:324)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:267)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:262)
	at sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:654)
	at sun.security.ssl.CertificateMessage$T12CertificateConsumer.onCertificate(CertificateMessage.java:473)
	at sun.security.ssl.CertificateMessage$T12CertificateConsumer.consume(CertificateMessage.java:369)
	at sun.security.ssl.SSLHandshake.consume(SSLHandshake.java:377)
	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:444)
	at sun.security.ssl.HandshakeContext.dispatch(HandshakeContext.java:422)
	at sun.security.ssl.TransportContext.dispatch(TransportContext.java:182)
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:152)
	at sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1383)
	at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1291)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:435)
	at com.microsoft.sqlserver.jdbc.TDSChannel.enableSSL(IOBuffer.java:2021)
	... 11 more
Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
	at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:456)
	at sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:323)
	at sun.security.validator.Validator.validate(Validator.java:271)
	at sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:315)
	at sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:234)
	at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:110)
	at com.microsoft.sqlserver.jdbc.TDSChannel$HostNameOverrideX509TrustManager.checkServerTrusted(IOBuffer.java:1702)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkServerTrusted(SSLContextImpl.java:1256)
	at sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:638)
	... 22 more
Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
	at sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:141)
	at sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:126)
	at java.security.cert.CertPathBuilder.build(CertPathBuilder.java:280)
	at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:451)
	... 30 more
```

Resolves #3205 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
