### PR TITLE
chore(deps): partial revert of ansi-regex PR #3814

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
   build_and_check:
     runs-on: ubuntu-latest
     steps:
-      # Using v1 (rather than v2) through-out this workflow due to issue:
-      # https://github.com/actions/checkout/issues/237
       - uses: actions/checkout@v2
 
       - name: NPM Cache
@@ -244,6 +242,8 @@ jobs:
           distribution: adopt
           java-version: 8
 
+      - uses: actions/checkout@v2
+
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
         id: nvm
@@ -252,8 +252,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
-
-      - uses: actions/checkout@v2
 
       - name: Download Artefacts
         uses: actions/download-artifact@v2

--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -2147,6 +2147,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -13486,6 +13495,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Since merging #3814 we've been having GHA build issues. This should address them.

It's unclear how this really got into the lock file in this fashion, however without builds fail in pristine environments (like openjdk
docker containers and GHA) - but still work on CodeBuild for some (ominous) reason.

I did go down the path of installing the ansi-regex package explicitly (no at v6.0.1) and that worked. However, without understanding the tangled web of why this is there, I thought best to simply revert what we needed from #3814 and get things working again.

Also noted (as a red-herring) there is a slight bug in the GHA YAML specification meaning we're not using the version of Node/NPM for the functional tests - just what ever the default is.

(I did test the build of the autotest/IntegTester/ps in a bare openjdk image and all worked. So hopefully the rest now will.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
