### PR TITLE
refactor(search2): optimise number of attachment retrievals

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/service/AttachmentService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/service/AttachmentService.scala
@@ -131,13 +131,13 @@ object AttachmentService {
       LegacyGuice.fileSystemService.fileExists(item.getFileHandle, fa.getFilename)
     }
 
-    Option(LegacyGuice.itemService.getNullableAttachmentForUuid(itemKey, attachmentUuid)) match {
-      case Some(fileAttachment: FileAttachment) =>
-        Some(fileAttachment).filter(fileAttachmentExists)
-      case Some(customAttachment: CustomAttachment) =>
-        Some(customAttachment).filter(ca => !isCustomAttachmentBroken(ca))
-      case Some(attachment) => Some(attachment)
-      case _                => None
+    def customAttachmentExists(ca: CustomAttachment): Boolean = !isCustomAttachmentBroken(ca)
+
+    LegacyGuice.itemService.getNullableAttachmentForUuid(itemKey, attachmentUuid) match {
+      case fa: FileAttachment   => Option(fa).filter(fileAttachmentExists)
+      case ca: CustomAttachment => Option(ca).filter(customAttachmentExists)
+      case a: Attachment        => Option(a)
+      case _                    => None
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/service/AttachmentService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/service/AttachmentService.scala
@@ -18,7 +18,7 @@
 
 package com.tle.core.item.service
 
-import com.tle.beans.item.attachments.{CustomAttachment, FileAttachment}
+import com.tle.beans.item.attachments.{Attachment, CustomAttachment, FileAttachment}
 import com.tle.beans.item.{ItemId, ItemIdKey, ItemKey}
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.interfaces.beans.AbstractExtendableBean
@@ -100,12 +100,12 @@ object AttachmentService {
     val key = new ItemId(uuid, getLatestVersionForCustomAttachment(version, uuid))
 
     if (customAttachment.getType != "resource") {
-      return false;
+      return false
     }
     customAttachment.getData("type") match {
       case "a" =>
         // Recurse into child attachment
-        recurseBrokenAttachmentCheck(key, customAttachment.getUrl)
+        recurseBrokenAttachmentCheck(key, customAttachment.getUrl).isEmpty
       case "p" =>
         // Get the child item. If it doesn't exist, this is a dead attachment
         Option(LegacyGuice.itemService.getUnsecureIfExists(key)).isEmpty
@@ -114,26 +114,30 @@ object AttachmentService {
   }
 
   /**
-    * Determines if a given attachment is invalid.
-    * If it is a resource selector attachment, this gets handled by
-    * [[isCustomAttachmentBroken(customAttachment: CustomAttachment)]]
+    * Determines if a given attachment is invalid. If it is a resource selector attachment, this
+    * gets handled by [[isCustomAttachmentBroken(customAttachment: CustomAttachment)]]
     * which links back in here to recurse through customAttachments to find the root.
     *
     * @param itemKey the details of the item the attachment belongs to
     * @param attachmentUuid the UUID of the attachment
-    * @return True if broken, false if intact.
+    * @return None if the attachment is broken, otherwise the attachment which was found wrapped in
+    *         an Option
     */
-  def recurseBrokenAttachmentCheck(itemKey: ItemKey, attachmentUuid: String): Boolean = {
+  def recurseBrokenAttachmentCheck(itemKey: ItemKey, attachmentUuid: String): Option[Attachment] = {
+    // check if file is present in the file-store
+    def fileAttachmentExists(fa: FileAttachment): Boolean = {
+      val item =
+        LegacyGuice.viewableItemFactory.createNewViewableItem(fa.getItem.getItemId)
+      LegacyGuice.fileSystemService.fileExists(item.getFileHandle, fa.getFilename)
+    }
+
     Option(LegacyGuice.itemService.getNullableAttachmentForUuid(itemKey, attachmentUuid)) match {
       case Some(fileAttachment: FileAttachment) =>
-        //check if file is present in the filestore
-        val item =
-          LegacyGuice.viewableItemFactory.createNewViewableItem(fileAttachment.getItem.getItemId)
-        !LegacyGuice.fileSystemService.fileExists(item.getFileHandle, fileAttachment.getFilename)
+        Some(fileAttachment).filter(fileAttachmentExists)
       case Some(customAttachment: CustomAttachment) =>
-        isCustomAttachmentBroken(customAttachment)
-      case None    => true
-      case Some(_) => false
+        Some(customAttachment).filter(ca => !isCustomAttachmentBroken(ca))
+      case Some(attachment) => Some(attachment)
+      case _                => None
     }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/AttachmentHelper.scala
@@ -72,17 +72,4 @@ object AttachmentHelper {
     }
     att
   }
-
-  /**
-    * Use the `description` from the `Attachment` behind the `AttachmentBean` as this provides
-    * the value more commonly seen in the LegacyUI. And specifically uses any tweaks done for
-    * Custom Attachments - such as with Kaltura where the Kaltura Media `title` is pushed into
-    * the `description` rather than using the optional (and multi-line) Kaltura Media `description`.
-    *
-    * @param itemKey the details of the item the attachment belongs to
-    * @param attachmentUuid the UUID of the attachment
-    * @return the description for the attachment if available
-    */
-  def getAttachmentDescription(itemKey: ItemKey, attachmentUuid: String): Option[String] =
-    Option(LegacyGuice.itemService.getAttachmentForUuid(itemKey, attachmentUuid).getDescription)
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -108,6 +108,7 @@ class SearchResource {
       highlight
     )
   }
+
   @HEAD
   @Path("/export")
   def exportCSV(@BeanParam params: SearchParam): Response = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Profiling revealed a lot of time was spent in search2 requests in `ifNotBroken` due to both uses calling off to retrieve the same
attachment. Significant performance (both speed and DB calls) improvements were possible if instead we re-use the attachment we retrieve when we first check for broken attachment status rather than throwing it away.

Existing tests provide coverage for this, and I also undertook manual testing.

(While doing this, I noticed that for broken attachments the New UI was showing _no_description - just the exclamation mark. This was due to the change to show the Kaltura description. As a result, I rejigged that a little too - and so now broken attachments are more likely to show a description.)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
