### PR TITLE
feat(REST): new includeAttachments param for search2 API

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -268,7 +268,7 @@ object SearchHelper {
       collectionId = bean.getCollection.getUuid,
       commentCount = getItemCommentCount(key),
       starRatings = bean.getRating,
-      attachmentCount = bean.getAttachments.size(),
+      attachmentCount = Option(bean.getAttachments).map(_.size()).getOrElse(0),
       attachments = if (includeAttachments) convertToAttachment(bean.getAttachments, key) else None,
       thumbnail = bean.getThumbnail,
       displayFields = bean.getDisplayFields.asScala.toList,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -250,8 +250,8 @@ object SearchHelper {
     * Convert a SearchItem to an instance of SearchResultItem.
     *
     * @param item Details of an item to convert.
-    *  @param includeAttachments Controls whether to populate the 'attachments' property as that
-    *                            process can be intensive and slow down searches.
+    * @param includeAttachments Controls whether to populate the 'attachments' property as that
+    *                           process can be intensive and slow down searches.
     * @return The result of converting `item` to a `SearchResultItem`.
     */
   def convertToItem(item: SearchItem, includeAttachments: Boolean = true): SearchResultItem = {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -268,7 +268,7 @@ object SearchHelper {
       collectionId = bean.getCollection.getUuid,
       commentCount = getItemCommentCount(key),
       starRatings = bean.getRating,
-      attachmentCount = Option(bean.getAttachments).map(_.size()).getOrElse(0),
+      attachmentCount = Option(bean.getAttachments).map(_.size).getOrElse(0),
       attachments = if (includeAttachments) convertToAttachment(bean.getAttachments, key) else None,
       thumbnail = bean.getThumbnail,
       displayFields = bean.getDisplayFields.asScala.toList,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -248,11 +248,13 @@ object SearchHelper {
 
   /**
     * Convert a SearchItem to an instance of SearchResultItem.
-    * @param item Represents a SearchItem, containing an ItemIdKey, EquellaItemBean, and
-    * Boolean indicating if a search term has been found inside attachment content
-    * @return An instance of SearchResultItem.
+    *
+    * @param item Details of an item to convert.
+    *  @param includeAttachments Controls whether to populate the 'attachments' property as that
+    *                            process can be intensive and slow down searches.
+    * @return The result of converting `item` to a `SearchResultItem`.
     */
-  def convertToItem(item: SearchItem): SearchResultItem = {
+  def convertToItem(item: SearchItem, includeAttachments: Boolean = true): SearchResultItem = {
     val key  = item.idKey
     val bean = item.bean
     SearchResultItem(
@@ -266,7 +268,8 @@ object SearchHelper {
       collectionId = bean.getCollection.getUuid,
       commentCount = getItemCommentCount(key),
       starRatings = bean.getRating,
-      attachments = convertToAttachment(bean.getAttachments, key),
+      attachmentCount = bean.getAttachments.size(),
+      attachments = if (includeAttachments) convertToAttachment(bean.getAttachments, key) else None,
       thumbnail = bean.getThumbnail,
       displayFields = bean.getDisplayFields.asScala.toList,
       displayOptions = Option(bean.getDisplayOptions),

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -104,7 +104,7 @@ class SearchResource {
       searchResults.getOffset,
       searchResults.getCount,
       searchResults.getAvailable,
-      items.map(convertToItem),
+      items.map(i => convertToItem(i, params.includeAttachments)),
       highlight
     )
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchResource.scala
@@ -104,7 +104,7 @@ class SearchResource {
       searchResults.getOffset,
       searchResults.getCount,
       searchResults.getAvailable,
-      items.map(i => convertToItem(i, params.includeAttachments)),
+      items.map(convertToItem(_, params.includeAttachments)),
       highlight
     )
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -58,6 +58,12 @@ class SearchParam {
   var searchAttachments: Boolean = _
 
   @ApiParam(
+    "Whether to search include full attachment details in results. Including attachments incurs extra processing and can slow down response times.")
+  @DefaultValue("true")
+  @QueryParam("includeAttachments")
+  var includeAttachments: Boolean = _
+
+  @ApiParam(
     "An advanced search UUID. If a value is supplied, the collections in the advanced search will be used and the collections parameter will be ignored.")
   @QueryParam("advancedSearch")
   var advancedSearch: String = _

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchParam.scala
@@ -58,7 +58,7 @@ class SearchParam {
   var searchAttachments: Boolean = _
 
   @ApiParam(
-    "Whether to search include full attachment details in results. Including attachments incurs extra processing and can slow down response times.")
+    "Whether to include full attachment details in results. Including attachments incurs extra processing and can slow down response times.")
   @DefaultValue("true")
   @QueryParam("includeAttachments")
   var includeAttachments: Boolean = _

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -34,6 +34,7 @@ import com.tle.web.api.item.equella.interfaces.beans.{DisplayField, DisplayOptio
   * @param collectionId The ID of a collection which the item belongs to.
   * @param commentCount The count of an item's comments.
   * @param starRatings The star ratings of an Item.
+  * @param attachmentCount The total number of attachments for this item.
   * @param attachments A list of Item's attachments.
   * @param thumbnail Item's thumbnail.
   * @param displayFields A list of Item's displayFields.
@@ -55,6 +56,7 @@ case class SearchResultItem(
     collectionId: String,
     commentCount: Option[Integer],
     starRatings: Float,
+    attachmentCount: Int,
     attachments: Option[List[SearchResultAttachment]],
     thumbnail: String,
     displayFields: List[DisplayField],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This adds a new param to the search2 endpoint that allows for attachments to be excluded from the result. Doing so can skip the (sometimes) intensive processing required for attachments and thereby speed up responses.

The intention is to use this in the front-end to exclude attachments on search, but then if a user expands the attachments for an item to use the same endpoint but with a `must` of the item `uuid`. To ensure this can be done and still have the UI display how many attachments an item have there is also a new field in the response called `attachmentCount`.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
