### PR TITLE
Feature/rewrite cloud provider

### DIFF
--- a/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/newentity/Entity.scala
+++ b/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/newentity/Entity.scala
@@ -36,7 +36,7 @@ class EntityID extends Serializable {
     case _              => false
   }
 
-  override def hashCode: Int = Objects.hash(inst_id, uuid)
+  override def hashCode: Int = Objects.hash(inst_id: java.lang.Long, uuid: java.lang.String)
 }
 
 @javax.persistence.Entity

--- a/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/newentity/Entity.scala
+++ b/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/newentity/Entity.scala
@@ -20,7 +20,7 @@ package com.tle.beans.newentity
 
 import com.tle.common.institution.CurrentInstitution
 import com.tle.common.usermanagement.user.CurrentUser
-import java.util.UUID
+import java.util.{Objects, UUID}
 import java.time.Instant
 import javax.persistence.{Column, Embeddable, EmbeddedId, Index, Lob, Table}
 import org.hibernate.annotations.{AttributeAccessor, NamedQuery, Type}
@@ -32,11 +32,11 @@ class EntityID extends Serializable {
   var inst_id: Long = _
 
   override def equals(obj: Any): Boolean = obj match {
-    case that: EntityID => that.uuid == that.uuid && this.inst_id == that.inst_id
+    case that: EntityID => this.uuid == that.uuid && this.inst_id == that.inst_id
     case _              => false
   }
 
-  override def hashCode(): Int = inst_id.hashCode + uuid.hashCode
+  override def hashCode: Int = Objects.hash(inst_id, uuid)
 }
 
 @javax.persistence.Entity

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
@@ -79,7 +79,7 @@ class CloudProviderRegistrationService {
     entity.modified = Instant.now
     entity.name = edits.name
     entity.nameStrings = edits.nameStrings.asJson.noSpaces
-    entity.description = edits.description.getOrElse("")
+    entity.description = edits.description.orNull
     entity.descriptionStrings = edits.descriptionStrings.map(_.asJson.noSpaces).orNull
 
     entity

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
@@ -90,17 +90,16 @@ class CloudProviderRegistrationService {
   }
 
   /**
-    * Check whether a registration token is valid. If yes, invalidate the token.
+    * Check whether a registration token is valid. If yes, return the token.
     * If no, return an EntityValidation indicating the failure.
     *
     * @param regToken The token to be checked.
     */
-  def validToken(regToken: String): ValidatedNec[EntityValidation, Unit] =
-    if (!tokenCache.get(regToken).isPresent)
-      EntityValidation("token", "invalid").invalidNec
+  def validToken(regToken: String): ValidatedNec[EntityValidation, String] =
+    if (tokenCache.get(regToken).isPresent)
+      regToken.validNec
     else {
-      tokenCache.invalidate(regToken)
-      ().validNec
+      EntityValidation("token", "invalid").invalidNec
     }
 
   /**
@@ -158,7 +157,7 @@ class CloudProviderRegistrationService {
     * Update details of a Cloud provider.
     *
     * @param entity Entity representing a Cloud provider instance.
-    * @param registration Cloud provider registration data to be used to update a Cloud provider instance.
+    * @param reg Cloud provider registration data to be used to update a Cloud provider instance.
     * @return ValidatedNec where left is all the errors accumulated during the update and right is
     *         the details of the updated Cloud provider.
     */

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
@@ -1,0 +1,204 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.cloudproviders
+
+import cats.data.ValidatedNec
+import cats.implicits._
+import com.tle.beans.newentity.Entity
+import com.tle.common.i18n.CurrentLocale
+import com.tle.core.guice.Bind
+import com.tle.core.newentity.service.EntityService
+import com.tle.core.replicatedcache.ReplicatedCacheService
+import com.tle.core.validation.{EntityStdEdits, EntityValidation}
+import com.tle.legacy.LegacyGuice
+import com.tle.web.DebugSettings
+import io.circe.parser._
+import io.circe.syntax._
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.collection.JavaConverters._
+
+@Bind
+@Singleton
+class CloudProviderRegistrationService {
+  @Inject var entityService: EntityService = _
+
+  def tokenCache: ReplicatedCacheService.ReplicatedCache[String] =
+    LegacyGuice.replicatedCacheService.getCache[String]("cloudRegTokens", 100, 1, TimeUnit.HOURS)
+  val FieldVendorId    = "vendorId"
+  val RefreshServiceId = "refresh"
+  val typeId           = "cloudprovider"
+  val Logger           = LoggerFactory.getLogger(getClass)
+
+  // Transform an Entity's custom data from String to CloudProviderData.
+  private def extractData(data: String): ValidatedNec[EntityValidation, CloudProviderData] =
+    decode[CloudProviderData](data)
+      .leftMap(err => EntityValidation("data", err.getMessage))
+      .toValidatedNec
+
+  // Build a CloudProviderInstance by Entity and CloudProviderData
+  private def toInstance(entity: Entity, data: CloudProviderData): CloudProviderInstance = {
+    CloudProviderInstance(
+      id = UUID.fromString(entity.id.uuid),
+      name = entity.name,
+      description = Option(entity.description),
+      vendorId = data.vendorId,
+      baseUrl = data.baseUrl,
+      iconUrl = data.iconUrl,
+      providerAuth = data.providerAuth,
+      oeqAuth = data.oeqAuth,
+      serviceUrls = data.serviceUrls,
+      viewers = data.viewers
+    )
+  }
+
+  // Save an Entity with provided values, and return the CloudProviderInstance representing
+  // this Entity.
+  private def save(entity: Entity,
+                   values: (EntityStdEdits, CloudProviderData)): CloudProviderInstance = {
+    val (edits, data) = values
+    entity.data = data.asJson.noSpaces
+    entity.modified = Instant.now
+    entity.name = edits.name
+    entity.nameStrings = edits.nameStrings.asJson.noSpaces
+    entity.description = edits.description.getOrElse("")
+    entity.descriptionStrings = edits.descriptionStrings.map(_.asJson.noSpaces).orNull
+    entityService.createOrUpdate(entity)
+
+    toInstance(entity, data)
+  }
+
+  /**
+    * Check whether a registration token is valid. If yes, invalidate the token.
+    * If no, return an EntityValidation indicating the failure.
+    *
+    * @param regToken The token to be checked.
+    */
+  def validToken(regToken: String): ValidatedNec[EntityValidation, Unit] =
+    if (!tokenCache.get(regToken).isPresent)
+      EntityValidation("token", "invalid").invalidNec
+    else {
+      tokenCache.invalidate(regToken)
+      ().validNec
+    }
+
+  /**
+    * Create a new token for Cloud provider registration.
+    */
+  def createRegistrationToken: String = {
+    val newToken = UUID.randomUUID().toString
+    tokenCache.put(newToken, newToken)
+    newToken
+  }
+
+  /**
+    * Check whether a registration is valid. For example, check if the vendor ID is blank.
+    *
+    * @param reg A Cloud provider registration to be validated.
+    * @return ValidatedNec where left is all the accumulated validation errors and right is
+    *         the validated standard registration data.
+    */
+  def validateRegistrationFields(
+      reg: CloudProviderRegistration): ValidatedNec[EntityValidation, EntityStdEdits] = {
+    EntityValidation.nonBlankString(FieldVendorId, reg.vendorId) *>
+      EntityValidation.standardValidation(
+        EntityStdEdits(name = reg.name, description = reg.description),
+        CurrentLocale.getLocale)
+  }
+
+  /**
+    * Register a Cloud provider with provided token and registration information.
+    *
+    * @param regToken Token created for a specific registration.
+    * @param registration Cloud provider registration data to be used to create a Cloud provider instance.
+    * @return ValidatedNec where left is all the errors accumulated during the registration and right is
+    *         the details of the registered Cloud provider.
+    */
+  def register(regToken: String, registration: CloudProviderRegistration)
+    : ValidatedNec[EntityValidation, CloudProviderInstance] =
+    (validToken(regToken), validateRegistrationFields(registration))
+      .mapN(
+        (_, fields) =>
+          save(
+            Entity.blankEntity(typeId),
+            (fields,
+             CloudProviderData(
+               baseUrl = registration.baseUrl,
+               iconUrl = registration.iconUrl,
+               vendorId = registration.vendorId,
+               providerAuth = registration.providerAuth,
+               oeqAuth = CloudOAuthCredentials.random(),
+               serviceUrls = registration.serviceUrls,
+               viewers = registration.viewers
+             ))
+        ))
+
+  /**
+    * Update details of a Cloud provider.
+    *
+    * @param entity Entity representing a Cloud provider instance.
+    * @param registration Cloud provider registration data to be used to update a Cloud provider instance.
+    * @return ValidatedNec where left is all the errors accumulated during the update and right is
+    *         the details of the updated Cloud provider.
+    */
+  def editRegistered(
+      entity: Entity,
+      reg: CloudProviderRegistration): ValidatedNec[EntityValidation, CloudProviderInstance] =
+    (extractData(entity.data), validateRegistrationFields(reg))
+      .mapN((data, fields) => {
+        val validatedData = CloudProviderData(
+          baseUrl = reg.baseUrl,
+          iconUrl = reg.iconUrl,
+          vendorId = reg.vendorId,
+          providerAuth = reg.providerAuth,
+          oeqAuth = data.oeqAuth,
+          serviceUrls = reg.serviceUrls,
+          viewers = reg.viewers
+        )
+        save(entity, (fields, validatedData))
+      })
+
+  /**
+    * Get all the registered Cloud providers.
+    *
+    * @return ValidatedNec where left is errors accumulated during the retrieval and right is a list
+    *         of Cloud provider details.
+    */
+  def getAllProviders: ValidatedNec[EntityValidation, List[CloudProviderDetails]] = {
+    entityService
+      .getAllByType(typeId)
+      .asScala
+      .map { entity =>
+        extractData(entity.data).map(data =>
+          CloudProviderDetails(
+            id = UUID.fromString(entity.id.uuid),
+            name = entity.name,
+            description = Option(entity.description),
+            vendorId = data.vendorId,
+            iconUrl = data.iconUrl,
+            canRefresh = DebugSettings.isDevMode && data.serviceUrls.contains(RefreshServiceId)
+        ))
+      }
+      .toList
+      .sequence
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
@@ -82,6 +82,8 @@ class CloudProviderRegistrationService {
     entity.nameStrings = edits.nameStrings.asJson.noSpaces
     entity.description = edits.description.getOrElse("")
     entity.descriptionStrings = edits.descriptionStrings.map(_.asJson.noSpaces).orNull
+
+    // Persist the new Entity
     entityService.createOrUpdate(entity)
 
     toInstance(entity, data)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderRegistrationService.scala
@@ -174,7 +174,7 @@ class CloudProviderRegistrationService {
           serviceUrls = reg.serviceUrls,
           viewers = reg.viewers
         )
-        val entity = applyValues(entity, fields, validatedData)
+        applyValues(entity, fields, validatedData)
 
         entityService.createOrUpdate(entity)
         toInstance(entity, validatedData)

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/newentity/service/EntityService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/newentity/service/EntityService.scala
@@ -25,7 +25,7 @@ import java.time.Instant
 trait EntityService {
 
   /**
-    * Get an Entity by UUID.
+    * Get an Entity by UUID limited to those in the current institution.
     *
     * @param uuid UUID of the Entity.
     */
@@ -39,7 +39,7 @@ trait EntityService {
   def getAllByInstitution(institution: Institution): java.util.List[Entity]
 
   /**
-    * Get a list of Entity by Entity type.
+    * Get a list of Entity by Entity type limited to those in the current institution.
     * @param typeId The type representing an Entity (e.g. cloudprovider)
     */
   def getAllByType(typeId: String): java.util.List[Entity]

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/newentity/service/EntityService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/newentity/service/EntityService.scala
@@ -20,17 +20,29 @@ package com.tle.core.newentity.service
 
 import com.tle.beans.Institution
 import com.tle.beans.newentity.Entity
-
 import java.time.Instant
 
 trait EntityService {
+
+  /**
+    * Get an Entity by UUID.
+    *
+    * @param uuid UUID of the Entity.
+    */
+  def getByUuid(uuid: String): Entity
 
   /**
     * Get all the Entity of an Institution.
     *
     * @param institution The Institution from where to get the list of Entity.
     */
-  def getAllEntity(institution: Institution): java.util.List[Entity]
+  def getAllByInstitution(institution: Institution): java.util.List[Entity]
+
+  /**
+    * Get a list of Entity by Entity type.
+    * @param typeId The type representing an Entity (e.g. cloudprovider)
+    */
+  def getAllByType(typeId: String): java.util.List[Entity]
 
   /**
     * Create a new Entity or update an existing entity.
@@ -60,6 +72,22 @@ trait EntityService {
                      owner: String,
                      data: String,
                      institution: Institution): Unit
+
+  /**
+    * Create a new Entity or update an existing entity.
+    *
+    *
+    *
+    * @param entity The Entity to be created or updated.
+    */
+  def createOrUpdate(entity: Entity): Unit
+
+  /**
+    * Delete an Entity.
+    *
+    * @param entity The Entity to be delted.
+    */
+  def delete(entity: Entity): Unit
 
   /**
     * Delete all the Entity of an Institution.

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/newentity/service/EntityServiceImpl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/newentity/service/EntityServiceImpl.scala
@@ -20,10 +20,13 @@ package com.tle.core.newentity.service
 
 import com.tle.beans.Institution
 import com.tle.beans.newentity.{Entity, EntityID}
+import com.tle.common.institution.CurrentInstitution
 import com.tle.core.guice.Bind
 import com.tle.core.newentity.dao.EntityDao
+import org.springframework.transaction.annotation.Transactional
 import javax.inject.Singleton
 import java.time.Instant
+import java.util
 import javax.inject.Inject
 
 @Bind(classOf[EntityService])
@@ -31,9 +34,17 @@ import javax.inject.Inject
 class EntityServiceImpl extends EntityService {
   @Inject var entityDao: EntityDao = _
 
-  override def getAllEntity(institution: Institution): java.util.List[Entity] =
-    entityDao.getAll(institution)
+  override def getByUuid(uuid: String): Entity =
+    entityDao.findById(EntityID(uuid, CurrentInstitution.get().getDatabaseId))
 
+  override def getAllByInstitution(institution: Institution): java.util.List[Entity] =
+    entityDao.getAllByInstitution(institution)
+
+  override def getAllByType(typeId: String): util.List[Entity] = {
+    entityDao.getAllByType(typeId)
+  }
+
+  @Transactional
   override def createOrUpdate(uuid: String,
                               typeId: String,
                               name: String,
@@ -60,8 +71,19 @@ class EntityServiceImpl extends EntityService {
     entity.owner = owner
     entity.typeid = typeId
     entity.data = data
+    createOrUpdate(entity)
+  }
+
+  @Transactional
+  override def createOrUpdate(entity: Entity): Unit = {
     entityDao.saveOrUpdate(entity)
   }
 
+  @Transactional
+  override def delete(entity: Entity): Unit = {
+    entityDao.delete(entity)
+  }
+
+  @Transactional
   override def deleteAllEntity(institution: Institution): Unit = entityDao.deleteAll(institution)
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/cloudprovider/CloudProviderApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/cloudprovider/CloudProviderApi.scala
@@ -18,22 +18,26 @@
 
 package com.tle.web.api.cloudprovider
 
-import java.util.UUID
+import cats.data.NonEmptyChain
 import cats.syntax.functor._
+import com.tle.common.institution.CurrentInstitution
 import com.tle.core.cloudproviders._
-import com.tle.core.db._
+import com.tle.core.validation.EntityValidation
 import com.tle.legacy.LegacyGuice
+import com.tle.web.api.ApiErrorResponse.{badRequest, resourceNotFound}
 import com.tle.web.api.settings.SettingsApiHelper.ensureEditSystem
 import com.tle.web.api.{ApiHelper, EntityPaging}
 import com.tle.web.settings.SettingsList
 import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.parsing.UrlParser
 import io.swagger.annotations.{Api, ApiOperation}
+
 import javax.ws.rs._
 import javax.ws.rs.core._
 import org.jboss.resteasy.annotations.cache.NoCache
 
 import scala.util.Success
+import java.util.UUID
 
 case class CloudProviderForward(url: String)
 @NoCache
@@ -44,27 +48,31 @@ class CloudProviderApi {
 
   import CloudProviderApi._
 
+  val registrationService = LegacyGuice.cloudProviderRegistrationService
+  val entityService       = LegacyGuice.entityService
+
+  private def collectErrors(validations: NonEmptyChain[EntityValidation]): List[String] =
+    validations.toNonEmptyList.toList.map(_.toString)
+
   @POST
   @Path("register")
   @ApiOperation(value = "Register a cloud provider",
                 response = classOf[CloudProviderRegistrationResponse])
   def register(@QueryParam(TokenParam) @DefaultValue("") regtoken: String,
                registration: CloudProviderRegistration): Response = {
-    ApiHelper.runAndBuild {
-      for {
-        ctx               <- getContext
-        validatedInstance <- CloudProviderDB.register(regtoken, registration)
-      } yield {
-        val forwardUrl = UriBuilder
-          .fromUri(ctx.inst.getUrlAsUri)
-          .path(SettingsList.CloudProviderListPage)
-          .build()
-          .toString
-        ApiHelper.validationOrEntity(validatedInstance.map { inst =>
-          CloudProviderRegistrationResponse(inst, forwardUrl)
-        })
-      }
-    }
+    def forwardUrl: String =
+      UriBuilder
+        .fromUri(CurrentInstitution.get.getUrlAsUri)
+        .path(SettingsList.CloudProviderListPage)
+        .build()
+        .toString
+
+    registrationService
+      .register(regtoken, registration)
+      .map(CloudProviderRegistrationResponse(_, forwardUrl))
+      .map(Response.ok(_).build)
+      .leftMap(collectErrors)
+      .valueOr(badRequest(_: _*))
   }
 
   @POST
@@ -80,27 +88,22 @@ class CloudProviderApi {
     checkPermissions()
     UrlParser.parseUrl(providerUrl) match {
       case Success(u: Url) =>
+        def returnUrl: String =
+          ApiHelper
+            .apiUriBuilder()
+            .path(classOf[CloudProviderApi])
+            .path(classOf[CloudProviderApi], "register")
+            .queryParam(TokenParam, registrationService.createRegistrationToken)
+            .build()
+            .toString
+
         ensureEditSystem()
-        RunWithDB.execute {
-          for {
-            token <- CloudProviderDB.createRegistrationToken
-          } yield {
-            val returnUrl = ApiHelper
-              .apiUriBuilder()
-              .path(classOf[CloudProviderApi])
-              .path(classOf[CloudProviderApi], "register")
-              .queryParam(TokenParam, token)
-              .build()
-              .toString
-            CloudProviderForward(
-              u.addParam(RegistrationParam, returnUrl)
-                .addParam(InstUrl, LegacyGuice.urlService.getBaseInstitutionURI.toString)
-                .toString)
-          }
-        }
+        CloudProviderForward(
+          u.addParam(RegistrationParam, returnUrl)
+            .addParam(InstUrl, LegacyGuice.urlService.getBaseInstitutionURI.toString)
+            .toString)
       case _ => throw new BadRequestException("Invalid provider registration url")
     }
-
   }
 
   @PUT
@@ -109,24 +112,24 @@ class CloudProviderApi {
   def editServiceDetails(@PathParam("uuid") uuid: UUID,
                          registration: CloudProviderRegistration): Response = {
     checkPermissions()
-    ApiHelper.runAndBuild {
-      CloudProviderDB
-        .editRegistered(uuid, registration)
-        .map { validatedInstance =>
-          ApiHelper.validationOr(validatedInstance.map { inst =>
-            Response.noContent()
-          })
-        }
-        .getOrElse(Response.status(404))
-    }
+    Option(entityService.getByUuid(uuid.toString))
+      .map(registrationService.editRegistered(_, registration))
+      .map(
+        _.map(_ => Response.noContent.build)
+          .leftMap(collectErrors)
+          .valueOr(badRequest(_: _*)))
+      .getOrElse(resourceNotFound(s"Failed to find Cloud provider matching UUID: $uuid"))
   }
 
   @DELETE
   @Path("provider/{uuid}")
   @ApiOperation(value = "Delete a cloud provider")
-  def deleteRegistration(@PathParam("uuid") uuid: UUID): Response = ApiHelper.runAndBuild {
+  def deleteRegistration(@PathParam("uuid") uuid: UUID): Response = {
     checkPermissions()
-    CloudProviderDB.deleteRegistration(uuid).as(Response.noContent())
+    Option(entityService.getByUuid(uuid.toString))
+      .map(entityService.delete)
+      .map(_ => Response.noContent().build())
+      .getOrElse(resourceNotFound(s"Not Cloud Provider matching UUID: $uuid"))
   }
 
   @POST
@@ -142,11 +145,10 @@ class CloudProviderApi {
   @ApiOperation("List current cloud providers")
   def list(): EntityPaging[CloudProviderDetails] = {
     checkPermissions()
-    RunWithDB.execute {
-      ApiHelper.allEntities {
-        CloudProviderDB.allProviders
-      }
-    }
+    registrationService.getAllProviders
+      .map(EntityPaging.allResults)
+      .leftMap(collectErrors)
+      .valueOr(s => throw new BadRequestException(s.mkString))
   }
 }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/newentity/convert/NewEntityConverter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/newentity/convert/NewEntityConverter.java
@@ -54,7 +54,7 @@ public class NewEntityConverter extends AbstractJsonConverter<Object> {
   public void doExport(
       TemporaryFileHandle staging, Institution institution, ConverterParams callback)
       throws IOException {
-    for (Entity entity : entityService.getAllEntity(institution)) {
+    for (Entity entity : entityService.getAllByInstitution(institution)) {
       String uuid = entity.id().uuid();
       String typeId = entity.typeid();
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/newentity/dao/EntityDao.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/newentity/dao/EntityDao.java
@@ -25,7 +25,9 @@ import com.tle.core.hibernate.dao.GenericDao;
 import java.util.List;
 
 public interface EntityDao extends GenericDao<Entity, EntityID> {
-  List<Entity> getAll(Institution institution);
+  List<Entity> getAllByInstitution(Institution institution);
+
+  List<Entity> getAllByType(String type);
 
   void deleteAll(Institution institution);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/newentity/dao/EntityDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/newentity/dao/EntityDaoImpl.java
@@ -21,6 +21,7 @@ package com.tle.core.newentity.dao;
 import com.tle.beans.Institution;
 import com.tle.beans.newentity.Entity;
 import com.tle.beans.newentity.EntityID;
+import com.tle.common.institution.CurrentInstitution;
 import com.tle.core.guice.Bind;
 import com.tle.core.hibernate.dao.GenericDaoImpl;
 import java.util.List;
@@ -35,13 +36,25 @@ public class EntityDaoImpl extends GenericDaoImpl<Entity, EntityID> implements E
   }
 
   @Override
-  public List<Entity> getAll(Institution institution) {
+  public List<Entity> getAllByInstitution(Institution institution) {
     return getHibernateTemplate()
         .execute(
             session ->
                 session
                     .createQuery("from Entity WHERE id.inst_id = :institutionId")
                     .setParameter("institutionId", institution.getDatabaseId())
+                    .getResultList());
+  }
+
+  @Override
+  public List<Entity> getAllByType(String typeId) {
+    return getHibernateTemplate()
+        .execute(
+            session ->
+                session
+                    .getNamedQuery("getAllByType")
+                    .setParameter("institutionId", CurrentInstitution.get().getDatabaseId())
+                    .setParameter("typeId", typeId)
                     .getResultList());
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -25,6 +25,7 @@ import com.tle.common.scripting.service.ScriptingService;
 import com.tle.core.accessibility.AccessibilityModeService;
 import com.tle.core.activation.service.ActivationService;
 import com.tle.core.auditlog.AuditLogService;
+import com.tle.core.cloudproviders.CloudProviderRegistrationService;
 import com.tle.core.collection.service.ItemDefinitionService;
 import com.tle.core.dynacollection.DynaCollectionService;
 import com.tle.core.encryption.EncryptionService;
@@ -47,6 +48,7 @@ import com.tle.core.item.service.ItemService;
 import com.tle.core.item.standard.service.ItemCommentService;
 import com.tle.core.jackson.ObjectMapperService;
 import com.tle.core.mimetypes.MimeTypeService;
+import com.tle.core.newentity.service.EntityService;
 import com.tle.core.oauth.service.OAuthService;
 import com.tle.core.plugins.PluginTracker;
 import com.tle.core.powersearch.PowerSearchService;
@@ -124,6 +126,8 @@ public class LegacyGuice extends AbstractModule {
 
   @Inject public static CALWebServiceImpl calWebService;
 
+  @Inject public static CloudProviderRegistrationService cloudProviderRegistrationService;
+
   @Inject public static ConfigurationService configService;
 
   @Inject public static ContentRestrictionsPrivilegeTreeProvider contentRestricPrivProvider;
@@ -139,6 +143,8 @@ public class LegacyGuice extends AbstractModule {
   @Inject public static DynaCollectionService dynaCollectionService;
 
   @Inject public static EncryptionService encryptionService;
+
+  @Inject public static EntityService entityService;
 
   @Inject public static EventService eventService;
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

In order to remove the use of simpleDBA in Cloud provider, we firstly need to drop the `CloudProviderDB`. At the beginning, this class name made me think it worked like a DAO, but I was wrong. This one is more like a Service which provided supports like registering a Cloud providers and was mostly used in the Cloud provider REST APIs. So I created a new class named `CloudProviderRegistrationService` which uses the `EntityService` implemented in previous PR.

Major changes:
1. more methods in `EntityService` and `EntityDAO`  and named query in `Entity`.
2. The new implementation in the new Service which required some changes in `EntityValidation` as well.
3. Due to the class `Entity` being a normal class and the types of its fields are either primitive types or String, an extra handling for converting string to `CloudProviderData` is required
4. Use the Service in `CloudProviderApi`.
5. Drop unused methods in `CloudProviderDB`. 

I tried to minimise changes, especially logical changes. But some of the previous implementation did not look quite right to me and did not work seamlessly with the new implementation. So I had to change some logical (but all minor). 

There is only one previous implementation related to cloud provider registration left. It is `refreshCloudProvider`. The main reason is the use of `CloudProviderService.serviceRequest` which obviously has simpleDBA code. Refactoring this one will cause a lot of more changes in different files. So I decided to do this in next PR when I will focus on refactoring `CloudProviderService`.

I have tested initialising a Cloud provider registration, listing all Cloud providers, adding a new one and deleting an existing one via the page. I can't find any UI that allows me to edit a Cloud provider so I tested this in the Swagger API page. 