### PR TITLE
feat(rest-module): add support for includeAttachments param of search2

### DIFF
--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -81,6 +81,11 @@ interface SearchParamsBase {
    */
   dynaCollection?: string;
   /**
+   * Whether to include full attachment details in results. Including attachments incurs extra
+   * processing and can slow down response times.
+   */
+  includeAttachments?: boolean;
+  /**
    * A flag indicating whether to search attachments or not.
    */
   searchAttachments?: boolean;
@@ -302,9 +307,14 @@ interface SearchResultItemBase {
    */
   starRatings: number;
   /**
-   * Item's attachments.
+   * Item's attachments. Will not be present if `includeAttachments` in search params is `false` or
+   * if the item has none.
    */
   attachments?: Attachment[];
+  /**
+   * How many attachments this item has - present regardless of `includeAttachments`.
+   */
+  attachmentCount: number;
   /**
    * Item's thumbnail.
    */

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 import { is } from 'typescript-is';
-import { GET } from '../src/AxiosInstance';
 import * as OEQ from '../src';
+import { GET } from '../src/AxiosInstance';
 import * as TC from './TestConfig';
 
 beforeAll(() => OEQ.Auth.login(TC.API_PATH, TC.USERNAME, TC.PASSWORD));
@@ -114,12 +114,12 @@ describe('Search for items', () => {
   );
 });
 
-describe('Search for attachments', () => {
+describe('Params related to attachments', () => {
   test.each([
-    ['include attachments', true, 4],
-    ['exclude attachments', false, 3],
+    ['within attachments and their metadata', true, 4],
+    ['within item metadata only (exclude searching attachments)', false, 3],
   ])(
-    'should be possible to %s in a search',
+    'should be possible to search %s',
     async (
       _testName: string,
       searchAttachments: boolean,
@@ -133,9 +133,19 @@ describe('Search for attachments', () => {
       expect(searchResult.results).toHaveLength(expectResultCount);
     }
   );
+
+  it('is possible to exclude attachment details from search results', async () => {
+    const searchResults = await doSearch({
+      includeAttachments: false,
+      mimeTypes: ['application/pdf'],
+    });
+    const firstItem = searchResults.results[0];
+    expect(firstItem.attachmentCount).toBeGreaterThan(0);
+    expect(firstItem.attachments).toBeFalsy();
+  });
 });
 
-describe('Exports search results for the specified search params', function () {
+describe('Exports search results for the specified search params', () => {
   const searchParams: OEQ.Search.SearchParams = {
     query: 'API',
     start: 0,

--- a/react-front-end/__mocks__/GallerySearchModule.mock.ts
+++ b/react-front-end/__mocks__/GallerySearchModule.mock.ts
@@ -35,6 +35,7 @@ export const basicImageSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
         commentCount: 0,
         starRatings: -1.0,
+        attachmentCount: 1,
         attachments: [
           {
             attachmentType: "file",
@@ -80,6 +81,7 @@ export const basicImageSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
         commentCount: 0,
         starRatings: -1.0,
+        attachmentCount: 3,
         attachments: [
           {
             attachmentType: "file",
@@ -157,6 +159,7 @@ export const basicImageSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
         commentCount: 0,
         starRatings: -1.0,
+        attachmentCount: 5,
         attachments: [
           {
             attachmentType: "file",
@@ -273,6 +276,7 @@ export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
         commentCount: 0,
         starRatings: -1.0,
+        attachmentCount: 1,
         attachments: [
           {
             attachmentType: "custom/youtube",
@@ -314,6 +318,7 @@ export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
         commentCount: 0,
         starRatings: -1.0,
+        attachmentCount: 1,
         attachments: [
           {
             attachmentType: "file",
@@ -358,6 +363,7 @@ export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         collectionId: "b790e41a-577e-4d9a-92c4-6736c18b2ba6",
         commentCount: 0,
         starRatings: -1.0,
+        attachmentCount: 4,
         attachments: [
           {
             attachmentType: "file",
@@ -449,6 +455,7 @@ export const basicVideoSearchResponse: OEQ.Search.SearchResult<OEQ.Search.Search
         modifiedDate: new Date("2021-07-20T16:53:24.430+10:00"),
         collectionId: "312be657-ae6a-4c60-b6fa-ced02c955915",
         starRatings: -1,
+        attachmentCount: 1,
         attachments: [
           {
             attachmentType: "custom/kaltura",

--- a/react-front-end/__mocks__/searchresult_mock_data.ts
+++ b/react-front-end/__mocks__/searchresult_mock_data.ts
@@ -29,6 +29,7 @@ const basicSearchObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 1,
   starRatings: 1,
+  attachmentCount: 0,
   attachments: [],
   thumbnail: "default",
   displayFields: [],
@@ -58,6 +59,7 @@ const attachSearchObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 2,
   starRatings: 1.5,
+  attachmentCount: 1,
   attachments: [
     {
       attachmentType: "file",
@@ -100,6 +102,7 @@ const keywordFoundInAttachmentObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 0,
   starRatings: -1,
+  attachmentCount: 1,
   attachments: [
     {
       attachmentType: "file",
@@ -142,6 +145,7 @@ const customMetaSearchObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 0,
   starRatings: -1,
+  attachmentCount: 1,
   attachments: [
     {
       attachmentType: "file",
@@ -200,6 +204,7 @@ const oneDeadAttachObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 2,
   starRatings: 1.5,
+  attachmentCount: 1,
   attachments: [
     {
       attachmentType: "file",
@@ -242,6 +247,7 @@ const oneDeadOneAliveAttachObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 2,
   starRatings: 1.5,
+  attachmentCount: 2,
   attachments: [
     {
       attachmentType: "file",
@@ -300,6 +306,7 @@ const drmAttachObj: OEQ.Search.SearchResultItem = {
   collectionId: "b28f1ffe-2008-4f5e-d559-83c8acd79316",
   commentCount: 2,
   starRatings: 1.5,
+  attachmentCount: 2,
   attachments: [
     {
       attachmentType: "file",

--- a/react-front-end/__tests__/tsrc/modules/GallerySearchModule.test.ts
+++ b/react-front-end/__tests__/tsrc/modules/GallerySearchModule.test.ts
@@ -157,6 +157,7 @@ describe("buildGallerySearchResultItem", () => {
     collectionId: "312be657-ae6a-4c60-b6fa-ced02c955915",
     commentCount: 0,
     starRatings: -1,
+    attachmentCount: 3,
     attachments: [
       {
         attachmentType: "file",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Short and simple, this updates the REST Module (oeq-ts-rest-api) to match the back-end changes for `includeAttachments` and `attachmentCount`.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
