### PR TITLE
fix: make sure 'SchemaId' and 'MigrationLog' are added in Hibernate entity binding map

### DIFF
--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6015,6 +6015,12 @@
   <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="NewEntity">
     <parameter id="class" value="com.tle.beans.newentity.Entity" />
   </extension>
+  <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="SchemaId">
+    <parameter id="class" value="com.tle.core.migration.beans.SchemaId" />
+  </extension>
+  <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="MigrationLog">
+    <parameter id="class" value="com.tle.core.migration.log.MigrationLog" />
+  </extension>
   <extension plugin-id="com.tle.core.freetext" point-id="indexingExtension" id="favouritesIndexer">
     <parameter id="class" value="bean:com.tle.core.favourites.index.FavouritesIndexer" />
   </extension>


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

After Hibernate was updated to version 5, adding a new database schema from the Institution Manager no longer works. 

According to my investigation, this is because Hibernate no longer has the entity bindings for 'SchemaId' and 'MigrationLog' after `TransactionModule` is configured. As a result, the SQL of creating the two tables are just empty strings, which fail the whole process of adding a new database. 

The fix is to add the two entities in the `plugin-jpf.xml` as plugins of `com.tle.core.hibernate`. This will make sure Hibernate has the bindings and the SQL of creating the two tables are correct.

Please grab to chat if it's hard to understand above description. 

