### PR TITLE
feat(rest): add thumbnailDetails to search2 response

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -22,7 +22,6 @@ import cats.Semigroup
 import cats.implicits._
 import com.dytech.edge.exceptions.{BadRequestException, DRMException}
 import com.tle.beans.entity.DynaCollection
-import com.tle.beans.item.attachments.Attachment
 import com.tle.beans.item.{Comment, ItemIdKey}
 import com.tle.common.Check
 import com.tle.common.beans.exception.NotFoundException
@@ -33,18 +32,17 @@ import com.tle.common.usermanagement.user.CurrentUser
 import com.tle.core.freetext.queries.FreeTextBooleanQuery
 import com.tle.core.item.security.ItemSecurityConstants
 import com.tle.core.item.serializer.{ItemSerializerItemBean, ItemSerializerService}
-import com.tle.core.item.service.AttachmentService.{
-  getFilePathForAttachment,
-  getMimetypeForAttachment,
-  recurseBrokenAttachmentCheck,
-  thumbExists
-}
 import com.tle.core.security.ACLChecks.hasAcl
 import com.tle.core.services.item.{FreetextResult, FreetextSearchResults}
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.interfaces.beans.AbstractExtendableBean
+import com.tle.web.api.item.impl.ItemLinkServiceImpl
 import com.tle.web.api.item.interfaces.beans.AttachmentBean
-import com.tle.web.api.search.AttachmentHelper.{buildAttachmentLinks, sanitiseAttachmentBean}
+import com.tle.web.api.search.AttachmentHelper.{
+  isViewable,
+  sanitiseAttachmentBean,
+  toSearchResultAttachment
+}
 import com.tle.web.api.search.model.AdditionalSearchParameters.buildAdvancedSearchCriteria
 import com.tle.web.api.search.model._
 
@@ -271,6 +269,7 @@ object SearchHelper {
       attachmentCount = Option(bean.getAttachments).map(_.size).getOrElse(0),
       attachments = if (includeAttachments) convertToAttachment(bean.getAttachments, key) else None,
       thumbnail = bean.getThumbnail,
+      thumbnailDetails = getThumbnailDetails(bean.getAttachments, key),
       displayFields = bean.getDisplayFields.asScala.toList,
       displayOptions = Option(bean.getDisplayOptions),
       keywordFoundInAttachment = item.keywordFound,
@@ -293,32 +292,9 @@ object SearchHelper {
       beans =>
         beans.asScala
         // Filter out restricted attachments if the user does not have permissions to view them
-          .filter(a => !a.isRestricted || hasRestrictedAttachmentPrivileges)
+          .filter(isViewable(hasRestrictedAttachmentPrivileges))
           .map(sanitiseAttachmentBean)
-          .map(bean => {
-            val attachment = recurseBrokenAttachmentCheck(itemKey, bean.getUuid)
-            def ifNotBroken[T](f: Attachment => Option[T], default: Option[T] = None) =
-              if (attachment.isDefined) f(attachment.get) else default
-
-            SearchResultAttachment(
-              attachmentType = bean.getRawAttachmentType,
-              id = bean.getUuid,
-              preview = bean.isPreview,
-              hasGeneratedThumb = thumbExists(itemKey, bean),
-              links = buildAttachmentLinks(bean),
-              filePath = getFilePathForAttachment(bean),
-              brokenAttachment = attachment.isEmpty,
-              // Use the `description` from the `Attachment` behind the `AttachmentBean` as this provides
-              // the value more commonly seen in the LegacyUI. And specifically uses any tweaks done for
-              // Custom Attachments - such as with Kaltura where the Kaltura Media `title` is pushed into
-              // the `description` rather than using the optional (and multi-line) Kaltura Media `description`.
-              // But if not available due to broken attachments, well something is better than
-              // nothing so use the on in `AttachmentBean`.
-              description = ifNotBroken((a: Attachment) => Option(a.getDescription),
-                                        Option(bean.getDescription)),
-              mimeType = ifNotBroken(_ => getMimetypeForAttachment(bean)),
-            )
-          })
+          .map(toSearchResultAttachment(itemKey, _))
           .toList)
   }
 
@@ -370,4 +346,46 @@ object SearchHelper {
     */
   def isLatestVersion(itemID: ItemIdKey): Boolean =
     itemID.getVersion == LegacyGuice.itemService.getLatestVersion(itemID.getUuid)
+
+  def getThumbnailDetails(attachmentBeans: java.util.List[AttachmentBean],
+                          itemKey: ItemIdKey): Option[ThumbnailDetails] = {
+    lazy val hasRestrictedAttachmentPrivileges: Boolean =
+      hasAcl(AttachmentConfigConstants.VIEW_RESTRICTED_ATTACHMENTS)
+
+    def determineThumbnailLink(a: SearchResultAttachment): Option[String] =
+      Option(a)
+        .filterNot(_.brokenAttachment)
+        .filter(a =>
+          (a.attachmentType, a.mimeType, a.hasGeneratedThumb) match {
+            // If a file attachment has a generatedThumb we use it
+            case ("file", _, Some(true)) => true
+            // If a 'custom/resource' (i.e. oEQ resource attachment) is of a mimeType other than
+            // those specified, we use the server provided thumbnail
+            case ("custom/resource", Some(mimeType), _)
+                if !List("equella/item", "equella/link", "text/html").contains(mimeType) =>
+              true
+            // For the custom attachment types pointing to external systems, we use the server
+            // provided thumbnail - which is typically a thumbnail provided by those systems
+            case (custom, _, _)
+                if custom
+                  .startsWith("custom/") && List("flickr", "googlebook", "kaltura", "youtube")
+                  .contains(custom.split("/").last) =>
+              true
+            // For all others, no thumbnail is provided
+            case _ => false
+        })
+        .flatMap(_.links.asScala.get(ItemLinkServiceImpl.REL_THUMB))
+
+    Option(attachmentBeans)
+      .flatMap(
+        _.asScala
+          .find(isViewable(hasRestrictedAttachmentPrivileges))
+      )
+      .map(toSearchResultAttachment(itemKey, _))
+      .map(
+        a =>
+          ThumbnailDetails(attachmentType = a.attachmentType,
+                           mimeType = a.mimeType,
+                           link = determineThumbnailLink(a)))
+  }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/SearchHelper.scala
@@ -352,8 +352,8 @@ object SearchHelper {
     lazy val hasRestrictedAttachmentPrivileges: Boolean =
       hasAcl(AttachmentConfigConstants.VIEW_RESTRICTED_ATTACHMENTS)
 
-    def determineThumbnailLink(a: SearchResultAttachment): Option[String] =
-      Option(a)
+    def determineThumbnailLink(searchResultAttachment: SearchResultAttachment): Option[String] =
+      Option(searchResultAttachment)
         .filterNot(_.brokenAttachment)
         .filter(a =>
           (a.attachmentType, a.mimeType, a.hasGeneratedThumb) match {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -18,9 +18,10 @@
 
 package com.tle.web.api.search.model
 
-import java.util.Date
 import com.tle.common.interfaces.I18NString
 import com.tle.web.api.item.equella.interfaces.beans.{DisplayField, DisplayOptions}
+
+import java.util.Date
 
 /**
   * This model class includes an item's information required in the new Search page.
@@ -59,6 +60,7 @@ case class SearchResultItem(
     attachmentCount: Int,
     attachments: Option[List[SearchResultAttachment]],
     thumbnail: String,
+    thumbnailDetails: Option[ThumbnailDetails],
     displayFields: List[DisplayField],
     displayOptions: Option[DisplayOptions],
     keywordFoundInAttachment: Boolean,
@@ -101,3 +103,16 @@ case class SearchResultAttachment(
   * @param isAuthorised Whether user is authorised to access Item or accept DRM.
   */
 case class DrmStatus(termsAccepted: Boolean, isAuthorised: Boolean)
+
+/**
+  * Provides details to assist with displaying a thumbnail for a search result, based on the
+  * attachment that is designated to be used as the basis for the thumbnail of this item (typically
+  * the first attachment).
+  *
+  * @param attachmentType The broad indicator of attachment type which which drives the content of
+  *                       the other properties. Example values are `file`, `link`, `custom/xyz`.
+  * @param mimeType Mostly used when `attachmentType` is `file` but also when `custom/resource`.
+  * @param link If the server has generated a specific thumbnail for this item, then this will
+  *             provide the URL for it.
+  */
+case class ThumbnailDetails(attachmentType: String, mimeType: Option[String], link: Option[String])

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/search/model/SearchResultItem.scala
@@ -37,7 +37,8 @@ import java.util.Date
   * @param starRatings The star ratings of an Item.
   * @param attachmentCount The total number of attachments for this item.
   * @param attachments A list of Item's attachments.
-  * @param thumbnail Item's thumbnail.
+  * @param thumbnail Item's thumbnail type.
+  * @param thumbnailDetails Details for displaying a thumbnail for an item.
   * @param displayFields A list of Item's displayFields.
   * @param displayOptions Item's displayOptions which can be null.
   * @param keywordFoundInAttachment Indicates if a search term has been found inside attachment content

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/item/impl/ItemLinkServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/item/impl/ItemLinkServiceImpl.java
@@ -53,11 +53,11 @@ public class ItemLinkServiceImpl implements ItemLinkService {
   private static final String CONTEXT_FILE_CONTENT = "content";
   private static final String CONTEXT_FILE_DIR = "dir";
 
-  private static final String REL_SELF = "self";
-  private static final String REL_VIEW = "view";
-  private static final String REL_CONTENT = "content";
-  private static final String REL_DIR = "dir";
-  private static final String REL_THUMB = "thumbnail";
+  public static final String REL_SELF = "self";
+  public static final String REL_VIEW = "view";
+  public static final String REL_CONTENT = "content";
+  public static final String REL_DIR = "dir";
+  public static final String REL_THUMB = "thumbnail";
 
   @Inject private ViewItemLinkFactory linkFactory;
   @Inject private InstitutionService institutionService;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

To assist with the display of suitable thumbnails (especially if `includeAttachments` is `false`) a new property has been added to the search2 response.

Included a slight refactor to push some code into `AttachmentHelper` for reuse.

![image](https://user-images.githubusercontent.com/43919233/157173703-b805f107-0d65-4f6e-9166-1df23a9a7aab.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
