### PR TITLE
feat(rest-module): add support for thumbnailDetails

### DIFF
--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openequella/rest-api-client",
-  "version": "2021.2.0-Alpha",
+  "version": "2022.1.0-Alpha",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -275,7 +275,7 @@ export interface DrmStatus {
  * attachment that is designated to be used as the basis for the thumbnail of this item (typically
  * the first attachment).
  */
-interface ThumbnailDetails {
+export interface ThumbnailDetails {
   /**
    * The broad indicator of attachment type which drives the content of the other properties.
    * Example values are `file`, `link`, `custom/xyz`.

--- a/oeq-ts-rest-api/src/Search.ts
+++ b/oeq-ts-rest-api/src/Search.ts
@@ -271,6 +271,28 @@ export interface DrmStatus {
 }
 
 /**
+ * Provides details to assist with displaying a thumbnail for a search result, based on the
+ * attachment that is designated to be used as the basis for the thumbnail of this item (typically
+ * the first attachment).
+ */
+interface ThumbnailDetails {
+  /**
+   * The broad indicator of attachment type which drives the content of the other properties.
+   * Example values are `file`, `link`, `custom/xyz`.
+   */
+  attachmentType: string;
+  /**
+   * Mostly used when `attachmentType` is `file` but also when `custom/resource`.
+   */
+  mimeType?: string;
+  /**
+   * If the server has generated a specific thumbnail for this item, then this will provide the URL
+   * for it.
+   */
+  link?: string;
+}
+
+/**
  * Shared properties or raw and transformed search result item
  */
 interface SearchResultItemBase {
@@ -319,6 +341,11 @@ interface SearchResultItemBase {
    * Item's thumbnail.
    */
   thumbnail: string;
+  /**
+   * Details for a thumbnail to represent this item - if available (depends on the item having
+   * attachments).
+   */
+  thumbnailDetails?: ThumbnailDetails;
   /**
    * Item's display fields.
    */

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -266,7 +266,7 @@ describe('search through a POST request', () => {
 });
 
 describe('Details for thumbnails', () => {
-  it('includes provides no thumbnailDetails for items with no attachments', async () => {
+  it('provides no thumbnailDetails for items with no attachments', async () => {
     const searchResult = await doSearch({
       query: 'SearchApiTest - Basic',
     });

--- a/oeq-ts-rest-api/test/Search.test.ts
+++ b/oeq-ts-rest-api/test/Search.test.ts
@@ -264,3 +264,29 @@ describe('search through a POST request', () => {
     expect(searchResult.available).toBe(6);
   });
 });
+
+describe('Details for thumbnails', () => {
+  it('includes provides no thumbnailDetails for items with no attachments', async () => {
+    const searchResult = await doSearch({
+      query: 'SearchApiTest - Basic',
+    });
+
+    expect(searchResult.results).toHaveLength(1);
+    const thumbnailDetails = searchResult.results.pop()!.thumbnailDetails;
+    expect(thumbnailDetails).toBeUndefined();
+  });
+
+  it('includes details for items which should have an explicit thumbnail', async () => {
+    const searchResult = await doSearch({
+      query: 'ItemApiViewTest - All attachments',
+    });
+
+    expect(searchResult.results).toHaveLength(1);
+    const thumbnailDetails = searchResult.results.pop()!.thumbnailDetails;
+    expect(thumbnailDetails).toBeDefined();
+    // The expected item should have a fully qualified thumbnail, so the optional fields
+    // are expected to be present.
+    expect(thumbnailDetails!.mimeType).toBeDefined();
+    expect(thumbnailDetails!.link).toBeDefined();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Adds support for the new `thumbnailDetails` field introduced in #3916 .

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
