### PR TITLE
Bugfix/slow search frontend

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/search/NewSearchPage.java
@@ -218,6 +218,22 @@ public class NewSearchPage extends AbstractPage<NewSearchPage> {
   }
 
   /**
+   * Give the unique title for a search result, click on the attachments section to display all the
+   * attachments.
+   *
+   * @param itemTitle the unique title of an item to show the attachments for
+   */
+  public void expandAttachments(String itemTitle) {
+    WebElement titleLink = driver.findElement(By.linkText(itemTitle));
+    WebElement searchResultItem = titleLink.findElement(By.xpath("ancestor::li[@data-item-id]"));
+    String itemUuid = searchResultItem.getAttribute("data-item-id");
+    String itemVersion = searchResultItem.getAttribute("data-item-version");
+
+    String id = "attachments-list-" + itemUuid + ":" + itemVersion;
+    searchResultItem.findElement(By.id(id)).click();
+  }
+
+  /**
    * Waits until the search results contain an Attachment with a name that matches the given text.
    *
    * @param attachmentText the attachment name to be present in the search.

--- a/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/search/NewSearchPageTest.java
@@ -107,6 +107,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
     // and verify the attachment appears when the item appears in a search.
     searchPage.changeQuery(searchTerm);
     searchPage.waitForSearchCompleted(1);
+    searchPage.expandAttachments(searchTerm);
     searchPage.verifyAttachmentDisplayed(attachmentTitle);
 
     // Then, logon as AutoTest (who doesn't have VIEW_RESTRICTED_ATTACHMENTS)
@@ -116,6 +117,7 @@ public class NewSearchPageTest extends AbstractSessionTest {
     // and verify that the attachment doesn't show when the item appears in a search.
     searchPage.changeQuery(searchTerm);
     searchPage.waitForSearchCompleted(1);
+    searchPage.expandAttachments(searchTerm);
     searchPage.verifyAttachmentNotDisplayed(attachmentTitle);
   }
 

--- a/oeq-ts-rest-api/.eslintrc.js
+++ b/oeq-ts-rest-api/.eslintrc.js
@@ -48,9 +48,19 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['*.test.ts'],
+      rules: {
+        // It is useful in tests to be able to use non-null-assertions - especially for values
+        // which will then be checked with expect matchers.
+        '@typescript-eslint/no-non-null-assertion': 'off',
+      },
+    },
+  ],
   settings: {
     jest: {
-      version: 26,
+      version: 27,
     },
   },
 };

--- a/react-front-end/__mocks__/OEQThumb.mock.ts
+++ b/react-front-end/__mocks__/OEQThumb.mock.ts
@@ -17,109 +17,43 @@
  */
 import * as OEQ from "@openequella/rest-api-client";
 
-export const fileAttachment: OEQ.Search.Attachment = {
+export const fileDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "file",
-  id: "9e751549-5cba-47dd-bccb-722c48072287",
-  description: "broken.png",
-  preview: false,
   mimeType: "image/png",
-  hasGeneratedThumb: true,
-  brokenAttachment: false,
-  links: {
-    view: "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/?attachment.uuid=78b8af7e-f0f5-4b5c-9f44-16f212583fe8",
-    thumbnail: "./thumb.jpg",
-  },
+  link: "./thumb.jpg",
 };
 
-export const brokenFileAttachment: OEQ.Search.Attachment = {
+export const brokenFileDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "file",
-  id: "9e751549-5cba-47dd-bccb-722c48072287",
-  description: "broken.png",
-  preview: false,
   mimeType: "image/png",
-  hasGeneratedThumb: true,
-  brokenAttachment: true,
-  links: {
-    view: "http://localhost:8080/rest/items/72558c1d-8788-4515-86c8-b24a28cc451e/1/?attachment.uuid=78b8af7e-f0f5-4b5c-9f44-16f212583fe8",
-    thumbnail: "./thumb.jpg",
-  },
 };
 
-export const resourceFileAttachment: OEQ.Search.Attachment = {
+export const resourceFileDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "custom/resource",
-  id: "2c663052-a472-4b3e-b4d1-a25a5cd45675",
-  description: "miss-violet.jpg",
-  brokenAttachment: false,
-  preview: false,
   mimeType: "image/jpeg",
-  links: {
-    view: "http://localhost:8080/rest/items/9ba9a328-4697-4ae0-9dba-3f82f1876fb8/1/?attachment.uuid=2c663052-a472-4b3e-b4d1-a25a5cd45675",
-    thumbnail: "./thumb.jpg",
-  },
+  link: "./thumb.jpg",
 };
-export const linkAttachment: OEQ.Search.Attachment = {
+
+export const linkDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "link",
-  id: "7d84f75e-1756-4af0-b4e1-2553b52885f0",
-  description: "https://www.google.com",
-  brokenAttachment: false,
-  preview: false,
-  links: {
-    view: "http://localhost:8080/rest/items/1dc04a21-9659-487f-b784-66726fa59bdc/1/?attachment.uuid=7d84f75e-1756-4af0-b4e1-2553b52885f0",
-    thumbnail: "./thumb.jpg",
-  },
 };
 
-export const resourceLinkAttachment: OEQ.Search.Attachment = {
+export const resourceLinkDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "custom/resource",
-  id: "02f8f12e-8222-4c5b-b89a-888cbbbc402d",
-  description: "https://www.google.com",
-  brokenAttachment: false,
-  preview: false,
   mimeType: "equella/link",
-  links: {
-    view: "http://localhost:8080/rest/items/a321a2f7-2228-4853-8292-54f390976049/1/?attachment.uuid=02f8f12e-8222-4c5b-b89a-888cbbbc402d",
-    thumbnail: "./thumb.jpg",
-  },
 };
 
-export const equellaItemAttachment: OEQ.Search.Attachment = {
+export const equellaItemDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "custom/resource",
-  id: "7140295f-7fe0-4b6b-b621-eb2adfbd386f",
-  description: "a321a2f7-2228-4853-8292-54f390976049",
-  brokenAttachment: false,
-  preview: false,
   mimeType: "equella/item",
-  links: {
-    view: "http://localhost:8080/rest/items/475a5e1b-4558-43f9-aeb4-9d49408197be/1/?attachment.uuid=7140295f-7fe0-4b6b-b621-eb2adfbd386f",
-    thumbnail:
-      "http://localhost:8080/rest/thumbs/475a5e1b-4558-43f9-aeb4-9d49408197be/1/7140295f-7fe0-4b6b-b621-eb2adfbd386f",
-  },
 };
 
-export const htmlAttachment: OEQ.Search.Attachment = {
+export const htmlDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "html",
-  id: "ef533d4c-15fc-45d4-91ee-0873e17fa7cb",
-  description: "New Page",
-  brokenAttachment: false,
-  preview: false,
   mimeType: "text/html",
-  links: {
-    view: "http://localhost:8080/rest/items/eb099d2a-d1a8-4e4e-98ff-fec42587adb4/1/?attachment.uuid=ef533d4c-15fc-45d4-91ee-0873e17fa7cb",
-    thumbnail:
-      "http://localhost:8080/rest/thumbs/eb099d2a-d1a8-4e4e-98ff-fec42587adb4/1/ef533d4c-15fc-45d4-91ee-0873e17fa7cb",
-  },
 };
 
-export const resourceHtmlAttachment: OEQ.Search.Attachment = {
+export const resourceHtmlDetails: OEQ.Search.ThumbnailDetails = {
   attachmentType: "custom/resource",
-  id: "1fa39170-ad0a-4607-9e37-bac86a8dea32",
-  description: "New Page",
-  brokenAttachment: false,
-  preview: false,
   mimeType: "text/html",
-  links: {
-    view: "http://localhost:8080/rest/items/550a3047-eb17-4db4-8b1e-6adbf6d63f3b/1/?attachment.uuid=1fa39170-ad0a-4607-9e37-bac86a8dea32",
-    thumbnail:
-      "http://localhost:8080/rest/thumbs/550a3047-eb17-4db4-8b1e-6adbf6d63f3b/1/1fa39170-ad0a-4607-9e37-bac86a8dea32",
-  },
 };

--- a/react-front-end/__stories__/components/OEQThumb.stories.tsx
+++ b/react-front-end/__stories__/components/OEQThumb.stories.tsx
@@ -18,14 +18,14 @@
 import { Meta, Story } from "@storybook/react";
 import * as React from "react";
 import {
-  brokenFileAttachment,
-  resourceFileAttachment,
-  equellaItemAttachment,
-  fileAttachment,
-  htmlAttachment,
-  linkAttachment,
-  resourceLinkAttachment,
-  resourceHtmlAttachment,
+  brokenFileDetails,
+  equellaItemDetails,
+  fileDetails,
+  htmlDetails,
+  linkDetails,
+  resourceFileDetails,
+  resourceHtmlDetails,
+  resourceLinkDetails,
 } from "../../__mocks__/OEQThumb.mock";
 import OEQThumb, { OEQThumbProps } from "../../tsrc/components/OEQThumb";
 
@@ -37,75 +37,59 @@ export default {
   },
 } as Meta<OEQThumbProps>;
 
-export const fileAttachmentStory: Story<OEQThumbProps> = (args) => (
-  <OEQThumb {...args} />
-);
-
-fileAttachmentStory.args = {
-  attachment: fileAttachment,
+export const file: Story<OEQThumbProps> = (args) => <OEQThumb {...args} />;
+file.args = {
+  details: fileDetails,
 };
 
-export const brokenFileAttachmentStory: Story<OEQThumbProps> = (args) => (
+export const brokenFile: Story<OEQThumbProps> = (args) => (
   <OEQThumb {...args} />
 );
-
-brokenFileAttachmentStory.args = {
-  attachment: brokenFileAttachment,
+brokenFile.args = {
+  details: brokenFileDetails,
 };
 
-export const customResourceAttachmentStory: Story<OEQThumbProps> = (args) => (
+export const customResource: Story<OEQThumbProps> = (args) => (
   <OEQThumb {...args} />
 );
-
-customResourceAttachmentStory.args = {
-  attachment: resourceFileAttachment,
+customResource.args = {
+  details: resourceFileDetails,
 };
 
-export const linkAttachmentStory: Story<OEQThumbProps> = (args) => (
-  <OEQThumb {...args} />
-);
-
-linkAttachmentStory.args = {
-  attachment: linkAttachment,
+export const link: Story<OEQThumbProps> = (args) => <OEQThumb {...args} />;
+link.args = {
+  details: linkDetails,
 };
 
-export const resourceLinkAttachmentStory: Story<OEQThumbProps> = (args) => (
+export const resourceLink: Story<OEQThumbProps> = (args) => (
   <OEQThumb {...args} />
 );
-
-resourceLinkAttachmentStory.args = {
-  attachment: resourceLinkAttachment,
+resourceLink.args = {
+  details: resourceLinkDetails,
 };
 
-export const equellaItemAttachmentStory: Story<OEQThumbProps> = (args) => (
+export const equellaItem: Story<OEQThumbProps> = (args) => (
   <OEQThumb {...args} />
 );
-
-equellaItemAttachmentStory.args = {
-  attachment: equellaItemAttachment,
+equellaItem.args = {
+  details: equellaItemDetails,
 };
 
-export const htmlAttachmentStory: Story<OEQThumbProps> = (args) => (
-  <OEQThumb {...args} />
-);
-
-htmlAttachmentStory.args = {
-  attachment: htmlAttachment,
+export const html: Story<OEQThumbProps> = (args) => <OEQThumb {...args} />;
+html.args = {
+  details: htmlDetails,
 };
 
-export const resourceHtmlAttachmentStory: Story<OEQThumbProps> = (args) => (
+export const resourceHtml: Story<OEQThumbProps> = (args) => (
   <OEQThumb {...args} />
 );
-
-resourceHtmlAttachmentStory.args = {
-  attachment: resourceHtmlAttachment,
+resourceHtml.args = {
+  details: resourceHtmlDetails,
 };
 
-export const placeHolderAttachmentStory: Story<OEQThumbProps> = (args) => (
+export const placeHolder: Story<OEQThumbProps> = (args) => (
   <OEQThumb {...args} />
 );
-
-placeHolderAttachmentStory.args = {
-  attachment: fileAttachment,
-  showPlaceholder: true,
+placeHolder.args = {
+  details: undefined,
 };

--- a/react-front-end/__stories__/search/SearchResult.stories.tsx
+++ b/react-front-end/__stories__/search/SearchResult.stories.tsx
@@ -42,6 +42,7 @@ export const AttachmentSearchResult: Story<SearchResultProps> = (args) => (
 AttachmentSearchResult.args = {
   ...BasicSearchResult.args,
   item: mockData.attachSearchObj,
+  getItemAttachments: async () => mockData.attachSearchObj.attachments ?? [],
 };
 
 export const KeywordFoundInAttachmentSearchResult: Story<SearchResultProps> = (
@@ -50,6 +51,7 @@ export const KeywordFoundInAttachmentSearchResult: Story<SearchResultProps> = (
 KeywordFoundInAttachmentSearchResult.args = {
   ...BasicSearchResult.args,
   item: { ...mockData.attachSearchObj, keywordFoundInAttachment: true },
+  getItemAttachments: async () => mockData.attachSearchObj.attachments ?? [],
 };
 
 export const CustomMetadataSearchResult: Story<SearchResultProps> = (args) => (
@@ -61,6 +63,8 @@ CustomMetadataSearchResult.args = {
     ...mockData.customMetaSearchObj,
     keywordFoundInAttachment: false,
   },
+  getItemAttachments: async () =>
+    mockData.customMetaSearchObj.attachments ?? [],
 };
 
 export const HighlightedSearchResult: Story<SearchResultProps> = (args) => (

--- a/react-front-end/__tests__/tsrc/components/OEQThumb.test.tsx
+++ b/react-front-end/__tests__/tsrc/components/OEQThumb.test.tsx
@@ -15,90 +15,70 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as OEQ from "@openequella/rest-api-client";
+import "@testing-library/jest-dom/extend-expect";
 import { queryByLabelText, render } from "@testing-library/react";
 import * as React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import {
-  brokenFileAttachment,
-  equellaItemAttachment,
-  fileAttachment,
-  htmlAttachment,
-  linkAttachment,
-  resourceHtmlAttachment,
-  resourceLinkAttachment,
+  brokenFileDetails,
+  equellaItemDetails,
+  fileDetails,
+  htmlDetails,
+  linkDetails,
+  resourceHtmlDetails,
+  resourceLinkDetails,
 } from "../../../__mocks__/OEQThumb.mock";
 import OEQThumb from "../../../tsrc/components/OEQThumb";
-import * as OEQ from "@openequella/rest-api-client";
 import { languageStrings } from "../../../tsrc/util/langstrings";
 
 describe("<OEQThumb/>", () => {
   const thumbLabels = languageStrings.searchpage.thumbnails;
-  const buildOEQThumb = (
-    attachment: OEQ.Search.Attachment,
-    showPlaceHolder: boolean
-  ) =>
-    render(
-      <OEQThumb attachment={attachment} showPlaceholder={showPlaceHolder} />
-    );
 
-  it.each<[string, OEQ.Search.Attachment, boolean, string]>([
+  it.each<[string, OEQ.Search.ThumbnailDetails | undefined, string]>([
     [
-      "shows the placeholder icon when showPlaceholder is true",
-      fileAttachment,
-      true,
+      "shows the placeholder icon when no details are provided",
+      undefined,
       thumbLabels.placeholder,
     ],
+    ["shows thumbnail image when available", fileDetails, thumbLabels.provided],
     [
-      "shows thumbnail image when showPlaceholder is false",
-      fileAttachment,
-      false,
-      thumbLabels.provided,
-    ],
-    [
-      "shows default file thumbnail when brokenAttachment is true",
-      brokenFileAttachment,
-      false,
-      thumbLabels.file,
+      "shows thumbnail based on MIME type when no thumbnail link is provided for file attachments - e.g. broken attachments",
+      brokenFileDetails,
+      thumbLabels.image,
     ],
     [
       "shows link icon thumbnail for a link attachment",
-      linkAttachment,
-      false,
+      linkDetails,
       thumbLabels.link,
     ],
     [
       "shows link icon thumbnail for a resource link attachment",
-      resourceLinkAttachment,
-      false,
+      resourceLinkDetails,
       thumbLabels.link,
     ],
     [
       "shows equella item thumbnail for a resource attachment pointing at an item summary",
-      equellaItemAttachment,
-      false,
+      equellaItemDetails,
       thumbLabels.item,
     ],
     [
       "shows html thumbnail for a web page attachment",
-      htmlAttachment,
-      false,
+      htmlDetails,
       thumbLabels.html,
     ],
     [
       "shows html thumbnail for a resource web page attachment",
-      resourceHtmlAttachment,
-      false,
+      resourceHtmlDetails,
       thumbLabels.html,
     ],
   ])(
     "%s",
     (
       _: string,
-      attachment: OEQ.Search.Attachment,
-      showPlaceHolder: boolean,
+      details: OEQ.Search.ThumbnailDetails | undefined,
       query: string
     ) => {
-      const { container } = buildOEQThumb(attachment, showPlaceHolder);
+      const { container } = render(<OEQThumb details={details} />);
       expect(queryByLabelText(container, query)).toBeInTheDocument();
     }
   );

--- a/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/SearchPage.test.tsx
@@ -28,6 +28,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { omit } from "lodash";
 import * as CategorySelectorMock from "../../../__mocks__/CategorySelector.mock";
 import {
   transformedBasicImageSearchResponse,
@@ -47,6 +48,7 @@ import * as CollectionsModule from "../../../tsrc/modules/CollectionsModule";
 import { getGlobalCourseList } from "../../../tsrc/modules/LegacySelectionSessionModule";
 import type { SelectedCategories } from "../../../tsrc/modules/SearchFacetsModule";
 import * as SearchFacetsModule from "../../../tsrc/modules/SearchFacetsModule";
+import { SearchOptions } from "../../../tsrc/modules/SearchModule";
 import * as SearchModule from "../../../tsrc/modules/SearchModule";
 import * as SearchSettingsModule from "../../../tsrc/modules/SearchSettingsModule";
 import * as SearchPageHelper from "../../../tsrc/search/SearchPageHelper";
@@ -111,6 +113,7 @@ const defaultSearchPageOptions: SearchPageOptions = {
   dateRangeQuickModeEnabled: true,
   mimeTypeFilters: [],
   displayMode: "list",
+  includeAttachments: false, // in 'list' displayMode we exclude attachments
 };
 const defaultCollectionPrivileges = [OEQ.Acl.ACL_SEARCH_COLLECTION];
 
@@ -625,10 +628,19 @@ describe("<SearchPage/>", () => {
   it("should also update Classification list with selected categories", async () => {
     clickCategory(page.container, JAVA_CATEGORY);
     await waitForSearch(searchPromise); // The intention of this line is to avoid Jest act warning.
-    expect(SearchFacetsModule.listClassifications).toHaveBeenLastCalledWith({
-      ...defaultSearchPageOptions,
-      selectedCategories: selectedCategories,
-    });
+
+    // Drop 'includeAttachments' as it is not passed in for listClassification calls
+    const expected: SearchOptions = omit(
+      {
+        ...defaultSearchPageOptions,
+        selectedCategories: selectedCategories,
+      },
+      "includeAttachments"
+    );
+
+    expect(SearchFacetsModule.listClassifications).toHaveBeenLastCalledWith(
+      expected
+    );
   });
 
   it("should copy a search link to clipboard, and show a snackbar", async () => {

--- a/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
+++ b/react-front-end/__tests__/tsrc/search/components/SearchResult.test.tsx
@@ -83,13 +83,16 @@ describe("<SearchResult/>", () => {
     theme: Theme = defaultTheme
   ) => {
     const renderResult = render(
-      //This needs to be wrapped inside a BrowserRouter, to prevent an `Invariant failed: You should not use <Link> outside a <Router>` error  because of the <Link/> tag within SearchResult
+      // This needs to be wrapped inside a BrowserRouter, to prevent an
+      // `Invariant failed: You should not use <Link> outside a <Router>`
+      // error  because of the <Link/> tag within SearchResult
       <MuiThemeProvider theme={theme}>
         <BrowserRouter>
           <SearchResult
             key={itemResult.uuid}
             item={itemResult}
             highlights={[]}
+            getItemAttachments={async () => itemResult.attachments!}
           />
         </BrowserRouter>
       </MuiThemeProvider>
@@ -428,7 +431,7 @@ describe("<SearchResult/>", () => {
         mockData.keywordFoundInAttachmentObj
       );
       expect(expandedAttachment.queryByText("image.png")).toBeVisible();
-      expect(collapsedAttachment.queryByText("config.json")).not.toBeVisible();
+      expect(collapsedAttachment.queryByText("config.json")).toBeFalsy(); // i.e. not rendered so not visible
     });
 
     it("should make each attachment draggable", async () => {

--- a/react-front-end/tsrc/components/OEQThumb.tsx
+++ b/react-front-end/tsrc/components/OEQThumb.tsx
@@ -56,7 +56,7 @@ interface ThumbProps {
 
 export interface OEQThumbProps {
   /**
-   * Details to determine what and how the thumbnail should be displayed. Of if none are provided
+   * Details to determine what and how the thumbnail should be displayed. Or if none are provided
    * a simple placeholder icon will be used instead.
    *
    * If `details` includes a `link` then that will have priority over any others and be used to

--- a/react-front-end/tsrc/components/OEQThumb.tsx
+++ b/react-front-end/tsrc/components/OEQThumb.tsx
@@ -15,18 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from "react";
-import { makeStyles } from "@material-ui/core/styles";
 import { Theme } from "@material-ui/core";
-import * as OEQ from "@openequella/rest-api-client";
+import { makeStyles } from "@material-ui/core/styles";
+import DefaultFileIcon from "@material-ui/icons/InsertDriveFile";
+import WebIcon from "@material-ui/icons/Language";
 import LinkIcon from "@material-ui/icons/Link";
 import VideoIcon from "@material-ui/icons/Movie";
 import ImageIcon from "@material-ui/icons/Panorama";
-import DefaultFileIcon from "@material-ui/icons/InsertDriveFile";
-import WebIcon from "@material-ui/icons/Language";
-import Web from "@material-ui/icons/Web";
 import PlaceholderIcon from "@material-ui/icons/TextFields";
+import Web from "@material-ui/icons/Web";
+import * as OEQ from "@openequella/rest-api-client";
+import { flow, pipe } from "fp-ts/function";
+import * as React from "react";
 import { languageStrings } from "../util/langstrings";
+import * as O from "fp-ts/Option";
+import { simpleMatch } from "../util/match";
+import * as S from "fp-ts/string";
+import * as RNEA from "fp-ts/ReadonlyNonEmptyArray";
 
 const useStyles = makeStyles((theme: Theme) => {
   return {
@@ -51,25 +56,20 @@ interface ThumbProps {
 
 export interface OEQThumbProps {
   /**
-   * On object representing an oEQ attachment. If undefined, a placeholder icon is returned
+   * Details to determine what and how the thumbnail should be displayed. Of if none are provided
+   * a simple placeholder icon will be used instead.
+   *
+   * If `details` includes a `link` then that will have priority over any others and be used to
+   * display an image based thumbnail.
    */
-  attachment?: OEQ.Search.Attachment;
-  /**
-   * True indicates that a placeholder icon should be used instead of the 'real' thumbnail
-   */
-  showPlaceholder: boolean;
+  details?: OEQ.Search.ThumbnailDetails;
 }
 
 /**
- * OEQThumb component
- * Takes an OEQ.Search.Attachment object as a parameter.
- * The thumbnail will be served up from oEQ if the attachment has had a thumbnail generated (Image, video, pdf based files, Youtube, Flickr, Google books)
- * Otherwise, an appropriate Icon is returned
+ * Displays a standard thumbnail using either the details provided to display an appropriate icon or
+ * image from the server. Of if no details provided will display a generic placeholder.
  */
-export default function OEQThumb({
-  attachment,
-  showPlaceholder,
-}: OEQThumbProps) {
+export default function OEQThumb({ details }: OEQThumbProps) {
   const classes = useStyles();
   const thumbLabels = languageStrings.searchpage.thumbnails;
   const generalThumbStyles: ThumbProps = {
@@ -77,103 +77,110 @@ export default function OEQThumb({
     fontSize: "large",
   };
 
-  if (!attachment || showPlaceholder) {
-    return (
-      <PlaceholderIcon
-        aria-label={thumbLabels.placeholder}
-        {...generalThumbStyles}
-      />
-    );
-  }
-
-  const { description, mimeType, attachmentType, hasGeneratedThumb, links } =
-    attachment;
-
-  const oeqProvidedThumb: React.ReactElement = (
-    <img
-      aria-label={thumbLabels.provided}
-      className={`MuiPaper-elevation1 MuiPaper-rounded ${classes.thumbnail}`}
-      src={links.thumbnail}
-      alt={description}
-    />
-  );
-
-  const defaultThumb = (
+  const defaultThumb = () => (
     <DefaultFileIcon aria-label={thumbLabels.file} {...generalThumbStyles} />
   );
 
   /**
-   * We need to check if a thumbnail has been generated, and return a generic icon if not
-   * @param {string} mimeType - Attachment's Mimetype. eg. image/png application/pdf
-   * @return {ReactElement} Image, video and pdf based mimetypes are thumbnailed by oEQ.
+   * Build an `img` based thumb if link is available, otherwise use the `defaultThumb`.
+   *
+   * @param link a URL to an image thumbnail on the server
    */
-  const handleMimeType = (mimeType?: string): React.ReactElement => {
-    if (hasGeneratedThumb) {
-      return oeqProvidedThumb;
-    }
-    let result = defaultThumb;
-    if (mimeType?.startsWith("image")) {
-      result = (
-        <ImageIcon aria-label={thumbLabels.image} {...generalThumbStyles} />
-      );
-    } else if (mimeType?.startsWith("video")) {
-      result = (
-        <VideoIcon aria-label={thumbLabels.video} {...generalThumbStyles} />
-      );
-    }
-    return result;
-  };
+  const buildServerProvidedThumb = (link?: string): JSX.Element =>
+    link ? (
+      <img
+        aria-label={thumbLabels.provided}
+        className={`MuiPaper-elevation1 MuiPaper-rounded ${classes.thumbnail}`}
+        src={link}
+        alt={thumbLabels.provided}
+      />
+    ) : (
+      defaultThumb()
+    );
 
   /**
-   * Resource attachments point to other attachments or items, so we need to use the MIME type
-   * to determine the thumbnail to use, rather than the attachment type which will be custom/resource.
+   * Builds generic thumbs for files based on the supplied `mimeType`.
    *
-   * @param mimeType The MIME type of the resource attachment's target.
+   * @param mimeType expects values like `image/jpeg` or `video/mpeg` etc.
    */
-  const handleResourceAttachmentThumb = (mimeType?: string) => {
-    switch (mimeType) {
-      case "equella/item":
-        return <Web aria-label={thumbLabels.item} {...generalThumbStyles} />;
-      case "equella/link":
-        return (
-          <LinkIcon aria-label={thumbLabels.link} {...generalThumbStyles} />
-        );
-      case "text/html":
-        return (
-          <WebIcon aria-label={thumbLabels.html} {...generalThumbStyles} />
-        );
-      default:
-        return oeqProvidedThumb;
-    }
+  const buildGenericFileThumb = (mimeType?: string): JSX.Element => {
+    const mimeTypeBasedThumb = (type: string): JSX.Element =>
+      pipe(
+        type,
+        simpleMatch<JSX.Element>({
+          image: () => (
+            <ImageIcon aria-label={thumbLabels.image} {...generalThumbStyles} />
+          ),
+          video: () => (
+            <VideoIcon aria-label={thumbLabels.video} {...generalThumbStyles} />
+          ),
+          _: defaultThumb,
+        })
+      );
+
+    return pipe(
+      mimeType,
+      O.fromNullable,
+      O.map(flow(S.split("/"), RNEA.head, mimeTypeBasedThumb)),
+      O.getOrElse(defaultThumb)
+    );
   };
 
-  let oeqThumb = defaultThumb;
-  if (attachment.brokenAttachment) {
-    return defaultThumb;
-  }
-  switch (attachmentType) {
-    case "file":
-      oeqThumb = handleMimeType(mimeType);
-      break;
-    case "link":
-      oeqThumb = (
-        <LinkIcon aria-label={thumbLabels.link} {...generalThumbStyles} />
-      );
-      break;
-    case "html":
-      oeqThumb = (
-        <WebIcon aria-label={thumbLabels.html} {...generalThumbStyles} />
-      );
-      break;
-    case "custom/resource":
-      oeqThumb = handleResourceAttachmentThumb(mimeType);
-      break;
-    case "custom/flickr":
-    case "custom/youtube":
-    case "custom/kaltura":
-    case "custom/googlebook":
-      oeqThumb = oeqProvidedThumb;
-      break;
-  }
-  return oeqThumb;
+  const buildGenericResourceAttachmentThumb = (
+    mimeType?: string
+  ): JSX.Element =>
+    pipe(
+      mimeType,
+      O.fromNullable,
+      O.map(
+        simpleMatch<JSX.Element>({
+          "equella/item": () => (
+            <Web aria-label={thumbLabels.item} {...generalThumbStyles} />
+          ),
+          "equella/link": () => (
+            <LinkIcon aria-label={thumbLabels.link} {...generalThumbStyles} />
+          ),
+          "text/html": () => (
+            <WebIcon aria-label={thumbLabels.html} {...generalThumbStyles} />
+          ),
+          _: defaultThumb,
+        })
+      ),
+      O.getOrElse(defaultThumb)
+    );
+
+  const buildGenericThumb = (
+    attachmentType: string,
+    mimeType?: string
+  ): JSX.Element =>
+    pipe(
+      attachmentType,
+      simpleMatch<JSX.Element>({
+        link: () => (
+          <LinkIcon aria-label={thumbLabels.link} {...generalThumbStyles} />
+        ),
+        html: () => (
+          <WebIcon aria-label={thumbLabels.html} {...generalThumbStyles} />
+        ),
+        file: () => buildGenericFileThumb(mimeType),
+        "custom/resource": () => buildGenericResourceAttachmentThumb(mimeType),
+        _: defaultThumb,
+      })
+    );
+
+  return pipe(
+    details,
+    O.fromNullable,
+    O.map(({ attachmentType, mimeType, link }) =>
+      link
+        ? buildServerProvidedThumb(link)
+        : buildGenericThumb(attachmentType, mimeType)
+    ),
+    O.getOrElse(() => (
+      <PlaceholderIcon
+        aria-label={thumbLabels.placeholder}
+        {...generalThumbStyles}
+      />
+    ))
+  );
 }

--- a/react-front-end/tsrc/modules/SearchModule.ts
+++ b/react-front-end/tsrc/modules/SearchModule.ts
@@ -347,11 +347,12 @@ export const searchItemAttachments = async (
     TE.mapLeft(E.toError)
   )();
 
-  if (E.isLeft(attachmentsMaybe)) {
-    throw attachmentsMaybe.left;
-  }
-
-  return attachmentsMaybe.right;
+  return pipe(
+    attachmentsMaybe,
+    E.getOrElseW((err) => {
+      throw err;
+    })
+  );
 };
 
 /**

--- a/react-front-end/tsrc/modules/SearchModule.ts
+++ b/react-front-end/tsrc/modules/SearchModule.ts
@@ -324,7 +324,7 @@ export const searchItemAttachments = async (
     item: OEQ.Search.SearchResultItem
   ) => OEQ.Search.Attachment[] = flow(
     ({ attachments }) => attachments,
-    O.fromPredicate((x): x is OEQ.Search.Attachment[] => x !== undefined),
+    O.fromNullable,
     O.getOrElse(() => [] as OEQ.Search.Attachment[])
   );
 

--- a/react-front-end/tsrc/modules/SearchModule.ts
+++ b/react-front-end/tsrc/modules/SearchModule.ts
@@ -17,9 +17,12 @@
  */
 
 import * as OEQ from "@openequella/rest-api-client";
-import { pipe } from "fp-ts/function";
-import * as O from "fp-ts/Option";
 import * as A from "fp-ts/Array";
+import * as E from "fp-ts/Either";
+import { flow, pipe } from "fp-ts/function";
+import * as NEA from "fp-ts/NonEmptyArray";
+import * as O from "fp-ts/Option";
+import * as TE from "fp-ts/TaskEither";
 import { Literal, Static, Union } from "runtypes";
 import { API_BASE_URL } from "../AppConfig";
 import { DateRange, getISODateString } from "../util/Date";
@@ -106,6 +109,13 @@ export interface SearchOptions {
    * A list of categories selected in the Category Selector and grouped by Classification ID.
    */
   selectedCategories?: SelectedCategories[];
+  /**
+   * Whether to include full attachment details in results. Including attachments incurs extra
+   * processing and can slow down response times. In a typical 'list' search we don't include
+   * them so that they're only requested _if_ a user expands out the attachments. This allows
+   * the search page to render quicker.
+   */
+  includeAttachments?: boolean;
   /**
    * Whether to search attachments or not.
    */
@@ -212,6 +222,7 @@ const buildSearchParams = ({
   lastModifiedDateRange,
   owner,
   status = liveStatuses,
+  includeAttachments,
   searchAttachments,
   selectedCategories,
   mimeTypes,
@@ -238,6 +249,7 @@ const buildSearchParams = ({
     modifiedAfter: getISODateString(lastModifiedDateRange?.start),
     modifiedBefore: getISODateString(lastModifiedDateRange?.end),
     owner: owner?.id,
+    includeAttachments: includeAttachments,
     searchAttachments: searchAttachments,
     whereClause: generateCategoryWhereQuery(selectedCategories),
     mimeTypes: externalMimeTypes ?? _mimeTypes,
@@ -283,6 +295,63 @@ export const searchItems = (
         )
     )
   );
+};
+
+/**
+ * Retrieve the search results for a single item - including attachment details. Useful if a
+ * search has been done excluding attachment results to delay retrieval of attachments to a later
+ * time.
+ *
+ * @param uuid The UUID of the target item
+ * @param version The specific version of the target item
+ */
+export const searchItemAttachments = async (
+  uuid: string,
+  version: number
+): Promise<OEQ.Search.Attachment[]> => {
+  const extractAndValidateItem: (
+    searchResult: OEQ.Search.SearchResult<OEQ.Search.SearchResultItem>
+  ) => TE.TaskEither<string, OEQ.Search.SearchResultItem> = flow(
+    ({ results }) => results,
+    TE.fromPredicate(
+      A.isNonEmpty,
+      () => `Search for item ${uuid}/${version} returned no results`
+    ),
+    TE.map(NEA.head)
+  );
+
+  const extractAttachments: (
+    item: OEQ.Search.SearchResultItem
+  ) => OEQ.Search.Attachment[] = flow(
+    ({ attachments }) => attachments,
+    O.fromPredicate((x): x is OEQ.Search.Attachment[] => x !== undefined),
+    O.getOrElse(() => [] as OEQ.Search.Attachment[])
+  );
+
+  const attachmentsMaybe = await pipe(
+    TE.tryCatch(
+      () =>
+        searchItems({
+          ...defaultSearchOptions,
+          musts: [
+            ["uuid", [uuid]],
+            ["version", [`${version}`]],
+          ],
+          searchAttachments: false,
+        }),
+      (reason) =>
+        `Failed to retrieve details of item ${uuid}/${version}: ${reason}`
+    ),
+    TE.chain(extractAndValidateItem),
+    TE.map(extractAttachments),
+    TE.mapLeft(E.toError)
+  )();
+
+  if (E.isLeft(attachmentsMaybe)) {
+    throw attachmentsMaybe.left;
+  }
+
+  return attachmentsMaybe.right;
 };
 
 /**

--- a/react-front-end/tsrc/search/SearchPage.tsx
+++ b/react-front-end/tsrc/search/SearchPage.tsx
@@ -418,7 +418,13 @@ const SearchPage = ({ updateTemplate, advancedSearchId }: SearchPageProps) => {
           case "gallery-video":
             return gallerySearch(videoGallerySearch, options);
           case "list":
-            return { from: "item-search", content: await searchItems(options) };
+            return {
+              from: "item-search",
+              content: await searchItems({
+                ...options,
+                includeAttachments: false,
+              }),
+            };
           default:
             throw new TypeError("Unexpected `displayMode` for searching");
         }

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -153,7 +153,6 @@ export default function SearchResult({
   item,
 }: SearchResultProps) {
   const {
-    thumbnailDetails,
     bookmarkId: bookmarkDefaultId,
     commentCount = 0,
     description,
@@ -165,6 +164,7 @@ export default function SearchResult({
     name,
     starRatings,
     status,
+    thumbnailDetails,
     uuid,
     version,
   } = item;

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -318,8 +318,8 @@ export default function SearchResult({
             color="textPrimary"
           >
             {
-              /**Custom metadata can contain html tags, we should make sure that is
-                             preserved */
+              // Custom metadata can contain html tags,
+              // we should make sure that is preserved
               HTMLReactParser(element.html)
             }
           </Typography>

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -57,6 +57,7 @@ import {
   selectResource,
 } from "../../modules/LegacySelectionSessionModule";
 import { getMimeTypeDefaultViewerDetails } from "../../modules/MimeTypesModule";
+import { searchItemAttachments } from "../../modules/SearchModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
 import { buildOpenSummaryPageHandler } from "../SearchPageHelper";
@@ -114,6 +115,13 @@ export interface SearchResultProps {
     mimeType: string
   ) => Promise<OEQ.MimeType.MimeTypeViewerDetail>;
   /**
+   * A function which can retrieve attachments for a specified item.
+   */
+  getItemAttachments?: (
+    uuid: string,
+    version: number
+  ) => Promise<OEQ.Search.Attachment[]>;
+  /**
    * The list of words which should be highlighted.
    */
   highlights: string[];
@@ -140,6 +148,7 @@ export const ItemDrmContext = React.createContext<{
 
 export default function SearchResult({
   getViewerDetails = getMimeTypeDefaultViewerDetails,
+  getItemAttachments = searchItemAttachments,
   highlights,
   item,
 }: SearchResultProps) {
@@ -385,6 +394,8 @@ export default function SearchResult({
         alignItems="flex-start"
         divider
         aria-label={searchResultStrings.ariaLabel}
+        data-item-id={uuid}
+        data-item-version={version}
       >
         <OEQThumb
           attachment={attachments[0]}
@@ -406,6 +417,7 @@ export default function SearchResult({
                 <SearchResultAttachmentsList
                   item={item}
                   getViewerDetails={getViewerDetails}
+                  getItemAttachments={getItemAttachments}
                 />
               </ItemDrmContext.Provider>
               {generateItemMetadata()}

--- a/react-front-end/tsrc/search/components/SearchResult.tsx
+++ b/react-front-end/tsrc/search/components/SearchResult.tsx
@@ -31,9 +31,9 @@ import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
 import FavoriteIcon from "@material-ui/icons/Favorite";
 import FavoriteBorderIcon from "@material-ui/icons/FavoriteBorder";
 import * as OEQ from "@openequella/rest-api-client";
+import HTMLReactParser from "html-react-parser";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import HTMLReactParser from "html-react-parser";
 import { useHistory } from "react-router";
 import { HashLink } from "react-router-hash-link";
 import { sprintf } from "sprintf-js";
@@ -43,8 +43,8 @@ import OEQThumb from "../../components/OEQThumb";
 import { StarRating } from "../../components/StarRating";
 import { TooltipIconButton } from "../../components/TooltipIconButton";
 import { createDrmDialog } from "../../drm/DrmHelper";
-import { defaultDrmStatus } from "../../modules/DrmModule";
 import { routes } from "../../mainui/routes";
+import { defaultDrmStatus } from "../../modules/DrmModule";
 import {
   addFavouriteItem,
   deleteFavouriteItem,
@@ -61,11 +61,11 @@ import { searchItemAttachments } from "../../modules/SearchModule";
 import { formatSize, languageStrings } from "../../util/langstrings";
 import { highlight } from "../../util/TextUtils";
 import { buildOpenSummaryPageHandler } from "../SearchPageHelper";
-import { FavouriteItemDialog } from "./FavouriteItemDialog";
 import type {
   FavDialogConfirmToAdd,
   FavDialogConfirmToDelete,
 } from "./FavouriteItemDialog";
+import { FavouriteItemDialog } from "./FavouriteItemDialog";
 import { ResourceSelector } from "./ResourceSelector";
 import { SearchResultAttachmentsList } from "./SearchResultAttachmentsList";
 
@@ -153,20 +153,20 @@ export default function SearchResult({
   item,
 }: SearchResultProps) {
   const {
-    name,
-    version,
-    uuid,
+    thumbnailDetails,
+    bookmarkId: bookmarkDefaultId,
+    commentCount = 0,
     description,
     displayFields,
-    modifiedDate,
-    status,
     displayOptions,
-    attachments = [],
-    commentCount = 0,
-    starRatings,
-    bookmarkId: bookmarkDefaultId,
-    isLatestVersion,
     drmStatus: initialDrmStatus = defaultDrmStatus,
+    isLatestVersion,
+    modifiedDate,
+    name,
+    starRatings,
+    status,
+    uuid,
+    version,
   } = item;
   const itemKey = `${uuid}/${version}`;
   const classes = useStyles();
@@ -319,7 +319,7 @@ export default function SearchResult({
           >
             {
               /**Custom metadata can contain html tags, we should make sure that is
-          preserved */
+                             preserved */
               HTMLReactParser(element.html)
             }
           </Typography>
@@ -398,8 +398,9 @@ export default function SearchResult({
         data-item-version={version}
       >
         <OEQThumb
-          attachment={attachments[0]}
-          showPlaceholder={displayOptions?.disableThumbnail ?? false}
+          details={
+            displayOptions?.disableThumbnail ? undefined : thumbnailDetails
+          }
         />
         <ListItemText
           primary={itemPrimaryContent}

--- a/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -35,13 +35,17 @@ import { makeStyles } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
 import AttachFile from "@material-ui/icons/AttachFile";
 import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
+import ErrorIcon from "@material-ui/icons/Error";
 import ExpandMore from "@material-ui/icons/ExpandMore";
 import InsertDriveFile from "@material-ui/icons/InsertDriveFile";
 import Search from "@material-ui/icons/Search";
 import Warning from "@material-ui/icons/Warning";
+import { Skeleton } from "@material-ui/lab";
 import * as OEQ from "@openequella/rest-api-client";
+import { pipe } from "fp-ts/function";
+import * as NEA from "fp-ts/NonEmptyArray";
 import * as React from "react";
-import { SyntheticEvent, useContext, useEffect, useState } from "react";
+import { SyntheticEvent, useEffect, useState } from "react";
 import ItemAttachmentLink from "../../components/ItemAttachmentLink";
 import {
   getSearchPageAttachmentClass,
@@ -56,7 +60,6 @@ import {
   buildViewerConfigForAttachments,
 } from "../../modules/ViewerModule";
 import { languageStrings } from "../../util/langstrings";
-import { SearchPageRenderErrorContext } from "../SearchPage";
 import { ResourceSelector } from "./ResourceSelector";
 
 const {
@@ -83,10 +86,23 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export interface SearchResultAttachmentsListProps {
+  /**
+   * The item to display attachments for.
+   */
   item: OEQ.Search.SearchResultItem;
+  /**
+   * A function which can provide Viewer Details for attachments.
+   */
   getViewerDetails: (
     mimeType: string
   ) => Promise<OEQ.MimeType.MimeTypeViewerDetail>;
+  /**
+   * A function which can retrieve attachments for a specified item.
+   */
+  getItemAttachments: (
+    uuid: string,
+    version: number
+  ) => Promise<OEQ.Search.Attachment[]>;
 }
 
 export const SearchResultAttachmentsList = ({
@@ -95,9 +111,10 @@ export const SearchResultAttachmentsList = ({
     version,
     displayOptions,
     keywordFoundInAttachment,
-    attachments = [],
+    attachmentCount,
   },
   getViewerDetails,
+  getItemAttachments,
 }: SearchResultAttachmentsListProps) => {
   const itemKey = `${uuid}/${version}`;
 
@@ -106,9 +123,7 @@ export const SearchResultAttachmentsList = ({
   const inSkinny = isSelectionSessionInSkinny();
   const inStructured = isSelectionSessionInStructured();
 
-  const { handleError } = useContext(SearchPageRenderErrorContext);
-
-  const [attachExpanded, setAttachExpanded] = useState(
+  const [attachExpanded, setAttachExpanded] = useState<boolean>(
     (inSelectionSession
       ? displayOptions?.integrationOpen
       : displayOptions?.standardOpen) ?? false
@@ -116,6 +131,8 @@ export const SearchResultAttachmentsList = ({
 
   const [attachmentsAndViewerConfigs, setAttachmentsAndViewerConfigs] =
     useState<AttachmentAndViewerConfig[]>([]);
+
+  const [error, setError] = useState<Error>();
 
   // In Selection Session, make each intact attachment draggable.
   useEffect(() => {
@@ -128,11 +145,16 @@ export const SearchResultAttachmentsList = ({
     }
   }, [attachmentsAndViewerConfigs, inStructured]);
 
-  // Responsible for determining the MIME type viewer for the provided attachments
+  // Responsible for retrieving the attachments and then determining the MIME type viewer for each.
   useEffect(() => {
     let mounted = true;
-    if (!attachments.length) {
-      // If there are no attachments, skip this effect
+    if (!attachExpanded) {
+      // clear any previous errors on collapse of attachments
+      setError(undefined);
+
+      return;
+    } else if (attachmentCount < 1 || attachmentsAndViewerConfigs.length > 0) {
+      // If there are no attachments or if they've already been processed, skip this effect
       return;
     }
 
@@ -154,6 +176,11 @@ export const SearchResultAttachmentsList = ({
 
     (async () => {
       try {
+        const attachments: OEQ.Search.Attachment[] = await getItemAttachments(
+          uuid,
+          version
+        );
+
         const attachmentsAndViewerDefinitions =
           await buildViewerConfigForAttachments(
             attachments,
@@ -165,7 +192,7 @@ export const SearchResultAttachmentsList = ({
           setAttachmentsAndViewerConfigs(attachmentsAndViewerDefinitions);
         }
       } catch (error) {
-        handleError(
+        setError(
           error instanceof Error
             ? error
             : new Error(`${stringGetViewerDetailsFailure}: ${error}`)
@@ -177,7 +204,16 @@ export const SearchResultAttachmentsList = ({
       // Short circuit if this component is unmounted before all its comms are done.
       mounted = false;
     };
-  }, [attachments, getViewerDetails, handleError, uuid, version]);
+  }, [
+    attachExpanded,
+    attachmentCount,
+    attachmentsAndViewerConfigs.length,
+    getItemAttachments,
+    getViewerDetails,
+    setError,
+    uuid,
+    version,
+  ]);
 
   const handleAttachmentPanelClick = (event: SyntheticEvent) => {
     /** prevents the SearchResult onClick from firing when attachment panel is clicked */
@@ -198,6 +234,21 @@ export const SearchResultAttachmentsList = ({
 
   const isAttachmentSelectable = (broken: boolean) =>
     inSelectionSession && !broken;
+
+  const buildSkeletonList = (howMany: number): JSX.Element[] =>
+    pipe(
+      NEA.range(1, howMany),
+      NEA.map((id) => (
+        <ListItem key={id}>
+          <ListItemIcon>
+            <Skeleton variant="rect" width={24} height={24} animation="wave" />
+          </ListItemIcon>
+          <ListItemText>
+            <Skeleton variant="text" animation="wave" />
+          </ListItemText>
+        </ListItem>
+      ))
+    );
 
   const attachmentsList = attachmentsAndViewerConfigs.map(
     (attachmentAndViewerConfig: AttachmentAndViewerConfig) => {
@@ -244,10 +295,32 @@ export const SearchResultAttachmentsList = ({
     }
   );
 
+  const buildErrorListItem = (e: Error) => (
+    <ListItem>
+      <ListItemIcon>
+        <ErrorIcon color="secondary" />
+      </ListItemIcon>
+      <ListItemText color="primary" primary={e.message} />
+    </ListItem>
+  );
+
+  const buildAttachmentList = (): JSX.Element => {
+    const items =
+      attachmentsList.length > 0
+        ? attachmentsList
+        : buildSkeletonList(attachmentCount);
+
+    return (
+      <List disablePadding className={classes.attachmentListItem}>
+        {error ? buildErrorListItem(error) : items}
+      </List>
+    );
+  };
+
   const accordionText = (
     <Typography component="div">
       {searchResultStrings.attachments}&nbsp;&nbsp;
-      <Chip label={attachments.length} size="small" color="primary" />
+      <Chip label={attachmentCount} size="small" color="primary" />
     </Typography>
   );
 
@@ -305,8 +378,9 @@ export const SearchResultAttachmentsList = ({
     </Badge>
   );
 
-  return attachmentsList.length > 0 ? (
+  return attachmentCount > 0 ? (
     <Accordion
+      id={`attachments-list-${uuid}:${version}`}
       className={classes.attachmentExpander}
       expanded={attachExpanded}
       onClick={(event) => handleAttachmentPanelClick(event)}
@@ -318,9 +392,7 @@ export const SearchResultAttachmentsList = ({
         </Grid>
       </AccordionSummary>
       <AccordionDetails>
-        <List disablePadding className={classes.attachmentListItem}>
-          {attachmentsList}
-        </List>
+        {attachExpanded && buildAttachmentList()}
       </AccordionDetails>
     </Accordion>
   ) : null;

--- a/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
+++ b/react-front-end/tsrc/search/components/SearchResultAttachmentsList.tsx
@@ -42,8 +42,11 @@ import Search from "@material-ui/icons/Search";
 import Warning from "@material-ui/icons/Warning";
 import { Skeleton } from "@material-ui/lab";
 import * as OEQ from "@openequella/rest-api-client";
+import * as A from "fp-ts/Array";
 import { pipe } from "fp-ts/function";
 import * as NEA from "fp-ts/NonEmptyArray";
+import * as O from "fp-ts/Option";
+import { not } from "fp-ts/Predicate";
 import * as React from "react";
 import { SyntheticEvent, useEffect, useState } from "react";
 import ItemAttachmentLink from "../../components/ItemAttachmentLink";
@@ -304,18 +307,17 @@ export const SearchResultAttachmentsList = ({
     </ListItem>
   );
 
-  const buildAttachmentList = (): JSX.Element => {
-    const items =
-      attachmentsList.length > 0
-        ? attachmentsList
-        : buildSkeletonList(attachmentCount);
-
-    return (
-      <List disablePadding className={classes.attachmentListItem}>
-        {error ? buildErrorListItem(error) : items}
-      </List>
-    );
-  };
+  const buildAttachmentList = (): JSX.Element => (
+    <List disablePadding className={classes.attachmentListItem}>
+      {error
+        ? buildErrorListItem(error)
+        : pipe(
+            attachmentsList,
+            O.fromPredicate(not(A.isEmpty)),
+            O.getOrElse(() => buildSkeletonList(attachmentCount))
+          )}
+    </List>
+  );
 
   const accordionText = (
     <Typography component="div">


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

This is the (hopefully) last PR in the slow search performance enhancement series consisting of:

- #3868 
- #3891 
- #3893 
- #3916 and
- #3922 

Basically this PR modifies the front-end such that:

- When in list mode, sets the new `includeAttachments` to `false` for the inital request;
- When a user expands the list of attachments, then does an additional search targetting that specific item (with version) via `must` specifiers;
- Displays a `skeleton` in place of the attachment list while waiting; and
- When second search for attachments completes renders all the attachments as usual.

However, this also impacted thumbnails. To address that:

- `OEQThumb` was basically rewritten to use ThumbnailDetails instead;
- `SearchResult` now uses an item's `thumbnailDetails` with `OEQThumb`; and
- Rather than having a separate flag to control whether or not to explicitly use a 'placeholder' thumbnail, that can be controlled by simply not providing `thumbnailDetails`.

Also the code around `OEQThumb` could skip some additional logic which is now be handled by the server - and that extends to not needing to know of the concept of a 'broken' attachment etc.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
