### PR TITLE
fix: make sure multiple database schemas can be added

### DIFF
--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6015,12 +6015,6 @@
   <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="NewEntity">
     <parameter id="class" value="com.tle.beans.newentity.Entity" />
   </extension>
-  <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="SchemaId">
-    <parameter id="class" value="com.tle.core.migration.beans.SchemaId" />
-  </extension>
-  <extension plugin-id="com.tle.core.hibernate" point-id="domainObjects" id="MigrationLog">
-    <parameter id="class" value="com.tle.core.migration.log.MigrationLog" />
-  </extension>
   <extension plugin-id="com.tle.core.freetext" point-id="indexingExtension" id="favouritesIndexer">
     <parameter id="class" value="bean:com.tle.core.favourites.index.FavouritesIndexer" />
   </extension>

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/system/migration/InitialMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/system/migration/InitialMigration.java
@@ -78,7 +78,7 @@ public class InitialMigration extends AbstractHibernateSchemaMigration {
       filter.setIncludeGenerators(true);
     }
     session.close();
-    return helper.getCreationSql(filter);
+    return helper.getCreationSql(filter, true);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/system/migration/InitialMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/system/migration/InitialMigration.java
@@ -36,6 +36,11 @@ import java.util.List;
 import javax.inject.Singleton;
 import org.hibernate.Session;
 
+/**
+ * This migration creates two tables: sys_system_config and sys_database_schema. Usually, it's
+ * executed after we fill out the OEQ new instance form and click the 'install' button. And then it
+ * will save the form data to the two tables.
+ */
 @Bind
 @Singleton
 @SuppressWarnings("nls")
@@ -78,6 +83,8 @@ public class InitialMigration extends AbstractHibernateSchemaMigration {
       filter.setIncludeGenerators(true);
     }
     session.close();
+    // Because `SystemConfig` and `DatabaseSchema` are classified as system tables,
+    //  pass `true` to `getCreationSql`.
     return helper.getCreationSql(filter, true);
   }
 

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/ExtendedAnnotationConfiguration.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/ExtendedAnnotationConfiguration.java
@@ -53,9 +53,14 @@ public class ExtendedAnnotationConfiguration extends Configuration {
 
   private static class MetadataCapture implements Integrator {
     private Metadata metadata;
+    private final Map<String, Table> systemTables = new HashMap<>();
 
     public Metadata getMetadata() {
       return metadata;
+    }
+
+    public Map<String, Table> getSystemTables() {
+      return systemTables;
     }
 
     @Override
@@ -64,6 +69,15 @@ public class ExtendedAnnotationConfiguration extends Configuration {
         SessionFactoryImplementor sessionFactory,
         SessionFactoryServiceRegistry serviceRegistry) {
       LOGGER.trace("integrating metadata");
+
+      // When this.metadata is null, the metadata passed in must provide the entity
+      // bindings for system tables such as 'sys_schema_id'.
+      if (this.metadata == null) {
+        for (Table t : metadata.collectTableMappings()) {
+          systemTables.put(t.getName(), t);
+        }
+      }
+
       this.metadata = metadata;
     }
 
@@ -90,7 +104,7 @@ public class ExtendedAnnotationConfiguration extends Configuration {
     logProps(super.getProperties(), "Hibernate properties after building config object");
   }
 
-  public Map<String, Table> getTableMap() {
+  public Map<String, Table> getNormalTableMap() {
     if (METADATA_CAPTURE.getMetadata() == null) {
       throw new IllegalStateException(
           "Cannot access Hibernate Metadata before a SessionFactory has been created");
@@ -100,6 +114,10 @@ public class ExtendedAnnotationConfiguration extends Configuration {
       tables.put(t.getName(), t);
     }
     return tables;
+  }
+
+  public Map<String, Table> getSysTableMap() {
+    return METADATA_CAPTURE.getSystemTables();
   }
 
   public List<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects() {

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/migration/impl/HibernateMigrationService.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/migration/impl/HibernateMigrationService.java
@@ -21,6 +21,7 @@ package com.tle.core.migration.impl;
 import com.google.inject.Singleton;
 import com.tle.beans.ConfigurationProperty;
 import com.tle.beans.ConfigurationProperty.PropertyKey;
+import com.tle.beans.DatabaseSchema;
 import com.tle.beans.Institution;
 import com.tle.common.Check;
 import com.tle.common.hash.Hash;
@@ -88,6 +89,7 @@ public class HibernateMigrationService {
               ConfigurationProperty.class,
               ConfigurationProperty.PropertyKey.class,
               SystemConfig.class,
+              DatabaseSchema.class,
               SchemaId.class);
     }
     return configuration;
@@ -101,12 +103,12 @@ public class HibernateMigrationService {
         new HibernateMigrationHelper(getHibernateFactory(), dataSource.getDefaultSchema());
     if (!helper.tableExists(session, "migration_log")) {
       Transaction tx = session.beginTransaction();
-      List<String> tableScripts = helper.getCreationSql(new TablesOnlyFilter("migration_log"));
+      List<String> tableScripts =
+          helper.getCreationSql(new TablesOnlyFilter("migration_log"), true);
       for (String sql : tableScripts) {
         session.createSQLQuery(sql).executeUpdate();
       }
-      if (helper.tableExists(session, "item")) // $NON-NLS-1$
-      {
+      if (helper.tableExists(session, "item")) {
         MigrationLog log = new MigrationLog();
         log.setStatus(LogStatus.SKIPPED);
         log.setExecuted(new Date());
@@ -116,11 +118,10 @@ public class HibernateMigrationService {
       }
       tx.commit();
     }
-    if (!helper.tableExists(session, "sys_schema_id")) // $NON-NLS-1$
-    {
+    if (!helper.tableExists(session, "sys_schema_id")) {
       Transaction tx = session.beginTransaction();
       List<String> tableScripts =
-          helper.getCreationSql(new TablesOnlyFilter("sys_schema_id")); // $NON-NLS-1$
+          helper.getCreationSql(new TablesOnlyFilter("sys_schema_id"), true);
       for (String sql : tableScripts) {
         session.createSQLQuery(sql).executeUpdate();
       }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The previous fix does not completely fix the issue. After a new database is added and initialised, adding more databases will result in the error about missing table `sys_schema_id` again.

The reason is initialising the firstly added database will change the Hibernate entity bindings, so when the second new database is added, entity bindings for those system level tables are missing.

So I think the proper fix is to save the entity bindings for system tables so they are accessible when needed.

https://user-images.githubusercontent.com/47203811/157595259-86704a69-6bdd-4816-b028-1aa8f4ed764c.mp4


