### PR TITLE
fix: ensure each view of a webpage has an audit log

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/web/attachments/MyPagesSummariser.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/web/attachments/MyPagesSummariser.java
@@ -185,7 +185,7 @@ public class MyPagesSummariser
 
     @Override
     public ViewAuditEntry getViewAuditEntry() {
-      return new ViewAuditEntry("htmlpage", attachment.getDescription());
+      return new ViewAuditEntry("file:" + getMimeType(), attachment.getFilename());
     }
 
     public class MyPagesContentStream extends WrappedContentStream {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/web/attachments/MyPagesSummariser.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/web/attachments/MyPagesSummariser.java
@@ -196,6 +196,12 @@ public class MyPagesSummariser
       }
 
       @Override
+      public boolean useDefaultCacheControl() {
+        // Use the default cache control so that an audit log is created for each view of a webpage.
+        return true;
+      }
+
+      @Override
       public File getDirectFile() {
         return null;
       }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/stream/WrappedContentStream.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/stream/WrappedContentStream.java
@@ -27,6 +27,11 @@ import javax.annotation.Nullable;
 public abstract class WrappedContentStream implements ContentStream {
   protected ContentStream inner;
 
+  // Set 'max-age' to 0 so that the content of cache is always stale.
+  // Hence, the browser sends every request to the the Equella server which will then
+  // re-validate the content.
+  private final String defaultCacheControl = "max-age=0, s-maxage=0, must-revalidate";
+
   public WrappedContentStream(ContentStream inner) {
     this.inner = inner;
   }
@@ -82,9 +87,13 @@ public abstract class WrappedContentStream implements ContentStream {
     return inner.getInputStream();
   }
 
+  public boolean useDefaultCacheControl() {
+    return false;
+  }
+
   @Override
   public String getCacheControl() {
-    return inner.getCacheControl();
+    return useDefaultCacheControl() ? defaultCacheControl : inner.getCacheControl();
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/ItemFilestoreServlet.java
@@ -182,13 +182,9 @@ public class ItemFilestoreServlet extends HttpServlet {
       this.itemId = itemId;
     }
 
-    @SuppressWarnings("nls")
     @Override
-    public String getCacheControl() {
-      // Set 'max-age' to 0 so that the content of cache is always stale.
-      // Hence, the browser sends every request to the the Equella server which will then
-      // re-validate the content.
-      return "max-age=0, s-maxage=0, must-revalidate";
+    public boolean useDefaultCacheControl() {
+      return true;
     }
 
     @Override


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The audit logs for webpage attachments were missing because cache of the webpage
was used and no requests were sent to server. So we need to update the cache control
for webpage attachment so that a request is sent to check whether the cache is still
valid and this request will also trigger an audit log.

I also noticed the audit log event type for webpage viewing is wrong. It should be `CONTENT_VIEWED` rather than `SUMMARY_VIEWED`. So I added a fix for this as well.