### PR TITLE
fix: handle multiple status for api search

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
@@ -133,7 +133,7 @@ public interface EquellaSearchResource extends SearchResource {
                   "DRAFT,LIVE,REJECTED,MODERATING,ARCHIVED,SUSPENDED,DELETED,REVIEW,PERSONAL",
               allowMultiple = true)
           @QueryParam("status")
-          String status,
+          CsvList status,
       @ApiParam(value = "An ISO date format (yyyy-MM-dd)", required = false)
           @QueryParam("modifiedAfter")
           String modifiedAfter,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
@@ -67,6 +67,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.UriInfo;
@@ -100,7 +101,7 @@ public class SearchResourceImpl implements EquellaSearchResource {
       CsvList info,
       String showall,
       String dynaCollectionCompound,
-      String status,
+      CsvList status,
       String modifiedAfter,
       String modifiedBefore,
       String advancedSearch,
@@ -267,7 +268,7 @@ public class SearchResourceImpl implements EquellaSearchResource {
       String modifiedAfter,
       String modifiedBefore,
       String dynaCollectionCompound,
-      String status,
+      CsvList status,
       String owner,
       DefaultSearch search) {
     FreeTextBooleanQuery freetextQuery = null;
@@ -308,7 +309,11 @@ public class SearchResourceImpl implements EquellaSearchResource {
     boolean useStatus = false;
     if (status != null) {
       try {
-        search.setItemStatuses(ItemStatus.valueOf(status.toUpperCase()));
+        List<ItemStatus> statusT =
+            CsvList.asList(status).stream()
+                .map(sta -> ItemStatus.valueOf(sta.toUpperCase()))
+                .collect(Collectors.toList());
+        search.setItemStatuses(statusT);
         useStatus = true;
       } catch (IllegalArgumentException iae) {
         // Invalid status

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/SearchResourceImpl.java
@@ -119,6 +119,7 @@ public class SearchResourceImpl implements EquellaSearchResource {
     final int offset = (start < 0 ? 0 : start);
     final int count = (length < 0 ? 10 : length);
     final List<String> infos = CsvList.asList(info, ItemSerializerService.CATEGORY_BASIC);
+    final List<String> statuses = Optional.ofNullable(status).map(CsvList::asList).orElse(null);
 
     // String dynaCollectionCompound =
     // uriInfo.getQueryParameters().getFirst("dynacollection");
@@ -149,7 +150,7 @@ public class SearchResourceImpl implements EquellaSearchResource {
             modifiedAfter,
             modifiedBefore,
             dynaCollectionCompound,
-            status,
+            statuses,
             owner,
             new DefaultSearch());
 
@@ -268,7 +269,7 @@ public class SearchResourceImpl implements EquellaSearchResource {
       String modifiedAfter,
       String modifiedBefore,
       String dynaCollectionCompound,
-      CsvList status,
+      List<String> statuses,
       String owner,
       DefaultSearch search) {
     FreeTextBooleanQuery freetextQuery = null;
@@ -307,16 +308,18 @@ public class SearchResourceImpl implements EquellaSearchResource {
     search.setFreeTextQuery(freetextQuery);
 
     boolean useStatus = false;
-    if (status != null) {
+    if (statuses != null) {
       try {
-        List<ItemStatus> statusT =
-            CsvList.asList(status).stream()
-                .map(sta -> ItemStatus.valueOf(sta.toUpperCase()))
+        List<ItemStatus> itemStatuses =
+            statuses.stream()
+                .map(String::toUpperCase)
+                .map(ItemStatus::valueOf)
                 .collect(Collectors.toList());
-        search.setItemStatuses(statusT);
+        search.setItemStatuses(itemStatuses);
         useStatus = true;
       } catch (IllegalArgumentException iae) {
         // Invalid status
+        LOGGER.warn("Illegal statuses: " + statuses.toString());
       }
     }
     if (!useStatus && onlyLive) {

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/SearchApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/SearchApiTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.tle.beans.item.ItemStatus;
 import com.tle.common.Pair;
 import java.net.URI;
 import java.util.HashMap;
@@ -118,14 +117,16 @@ public class SearchApiTest extends AbstractRestApiTest {
   @Test
   public void testStatuses() throws Exception {
     String token = requestToken(OAUTH_CLIENT_ID);
+    final String LIVE = "LIVE";
+    final String DRAFT = "DRAFT";
 
     JsonNode liveResultsNode =
-        doSearch(BASIC, SEARCH_API_TEST, ImmutableMap.of("status", ItemStatus.LIVE), token);
+        doSearch(BASIC, SEARCH_API_TEST, ImmutableMap.of("status", LIVE), token);
     Integer liveItemLength = liveResultsNode.get("length").asInt();
     Integer liveItemAvailable = liveResultsNode.get("available").asInt();
 
     JsonNode draftResultsNode =
-        doSearch(BASIC, SEARCH_API_TEST, ImmutableMap.of("status", ItemStatus.DRAFT), token);
+        doSearch(BASIC, SEARCH_API_TEST, ImmutableMap.of("status", DRAFT), token);
     Integer draftItemLength = draftResultsNode.get("length").asInt();
     Integer draftItemAvailable = draftResultsNode.get("available").asInt();
 
@@ -133,7 +134,7 @@ public class SearchApiTest extends AbstractRestApiTest {
         doSearch(
             BASIC,
             SEARCH_API_TEST,
-            ImmutableMap.of("status", String.format("%s,%s", ItemStatus.DRAFT, ItemStatus.LIVE)),
+            ImmutableMap.of("status", String.format("%s,%s", DRAFT, LIVE)),
             token);
     assertEquals(draftAndLiveResultsNode.get("start").asInt(), 0);
     assertEquals(draftAndLiveResultsNode.get("length").asInt(), liveItemLength + draftItemLength);

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/SearchApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/SearchApiTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.tle.beans.item.ItemStatus;
 import com.tle.common.Pair;
 import java.net.URI;
 import java.util.HashMap;
@@ -112,6 +113,32 @@ public class SearchApiTest extends AbstractRestApiTest {
       String[] itemDeets = ITEMS[itemIndexes[i]];
       asserter.assertBasic((ObjectNode) itemNode, itemDeets[0], itemDeets[1]);
     }
+  }
+
+  @Test
+  public void testStatuses() throws Exception {
+    String token = requestToken(OAUTH_CLIENT_ID);
+
+    JsonNode liveResultsNode =
+        doSearch(BASIC, SEARCH_API_TEST, ImmutableMap.of("status", ItemStatus.LIVE), token);
+    Integer liveItemLength = liveResultsNode.get("length").asInt();
+    Integer liveItemAvailable = liveResultsNode.get("available").asInt();
+
+    JsonNode draftResultsNode =
+        doSearch(BASIC, SEARCH_API_TEST, ImmutableMap.of("status", ItemStatus.DRAFT), token);
+    Integer draftItemLength = draftResultsNode.get("length").asInt();
+    Integer draftItemAvailable = draftResultsNode.get("available").asInt();
+
+    JsonNode draftAndLiveResultsNode =
+        doSearch(
+            BASIC,
+            SEARCH_API_TEST,
+            ImmutableMap.of("status", String.format("%s,%s", ItemStatus.DRAFT, ItemStatus.LIVE)),
+            token);
+    assertEquals(draftAndLiveResultsNode.get("start").asInt(), 0);
+    assertEquals(draftAndLiveResultsNode.get("length").asInt(), liveItemLength + draftItemLength);
+    assertEquals(
+        draftAndLiveResultsNode.get("available").asInt(), liveItemAvailable + draftItemAvailable);
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] the [contributor license agreement][] is signed
- [X] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Change query param status type from string to CsvList.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
