### PR TITLE
fix: align prompt input position with real input

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -484,7 +484,7 @@ select[multiple="multiple"] {
   border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   border-radius: $standardBorderRadius $standardBorderRadius 0 0;
   background-color: #f5f5f5;
-  &:not(#q):not(.prompt) {
+  &:not(#q) {
     //so as to avoid affecting searchbars
     padding: $doubleMargin;
     font-size: 16px;

--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -484,7 +484,7 @@ select[multiple="multiple"] {
   border-bottom: 1px solid rgba(0, 0, 0, 0.42);
   border-radius: $standardBorderRadius $standardBorderRadius 0 0;
   background-color: #f5f5f5;
-  &:not(#q) {
+  &:not(#q):not(.prompt) {
     //so as to avoid affecting searchbars
     padding: $doubleMargin;
     font-size: 16px;
@@ -4602,6 +4602,12 @@ img.warningimg {
   margin: 0 3px 0 0;
   padding: 5px 5px $minimalMargin;
   box-sizing: border-box;
+}
+
+.compactQuery input.prompt {
+  //fix overlapping issue
+  padding: $doubleMargin;
+  font-size: 16px;
 }
 
 .compactQuery .compactQueryButton {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Before fix:
![image](https://user-images.githubusercontent.com/92769668/158709567-d134c204-a564-4d4e-b650-a3808b645d5c.png)

After fix: 
![image](https://user-images.githubusercontent.com/92769668/158709494-01a5d18f-4102-4965-9cfb-1eeee297cc01.png)

Also, I didn't see the search bar is changed.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
