### PR TITLE
fix: make sure Login page shows the captured token error

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/TokenUserStateHook.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/TokenUserStateHook.java
@@ -67,10 +67,10 @@ public class TokenUserStateHook implements UserStateHook {
           LOGGER.warn("Error with token:" + token);
 
           // We can save the login token error in the request attribute in Old UI, but we can't do
-          // this
-          // in New UI because New UI sends another POST request to query the page content. So we
-          // should
-          // call 'LogonSection.setLoginTokenError' to save the error.
+          // this in New UI because it sends another POST request to query the page content.
+          // Instead,
+          // we need to store it in the current session so that it can be persisted across the two
+          // requests.
           if (RenderNewTemplate.isNewUIEnabled()) {
             sessionService.setAttribute(WebConstants.KEY_LOGIN_EXCEPTION, ex.getLocalizedMessage());
           } else {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/TokenUserStateHook.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/TokenUserStateHook.java
@@ -24,9 +24,9 @@ import com.tle.common.Check;
 import com.tle.common.usermanagement.user.UserState;
 import com.tle.core.guice.Bind;
 import com.tle.core.services.user.UserService;
+import com.tle.core.services.user.UserSessionService;
 import com.tle.exceptions.TokenException;
 import com.tle.web.core.filter.UserStateResult.Result;
-import com.tle.web.login.LogonSection;
 import com.tle.web.template.RenderNewTemplate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -41,6 +41,7 @@ public class TokenUserStateHook implements UserStateHook {
   private static final Logger LOGGER = LoggerFactory.getLogger(TokenUserStateHook.class);
 
   @Inject private UserService userService;
+  @Inject private UserSessionService sessionService;
 
   @Override
   public UserStateResult getUserState(HttpServletRequest request, UserState userState)
@@ -71,7 +72,7 @@ public class TokenUserStateHook implements UserStateHook {
           // should
           // call 'LogonSection.setLoginTokenError' to save the error.
           if (RenderNewTemplate.isNewUIEnabled()) {
-            LogonSection.setLoginTokenError(ex.getLocalizedMessage());
+            sessionService.setAttribute(WebConstants.KEY_LOGIN_EXCEPTION, ex.getLocalizedMessage());
           } else {
             request.setAttribute(WebConstants.KEY_LOGIN_EXCEPTION, ex);
           }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/TokenUserStateHook.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/TokenUserStateHook.java
@@ -26,6 +26,8 @@ import com.tle.core.guice.Bind;
 import com.tle.core.services.user.UserService;
 import com.tle.exceptions.TokenException;
 import com.tle.web.core.filter.UserStateResult.Result;
+import com.tle.web.login.LogonSection;
+import com.tle.web.template.RenderNewTemplate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
@@ -62,7 +64,17 @@ public class TokenUserStateHook implements UserStateHook {
           return null;
         } catch (TokenException ex) {
           LOGGER.warn("Error with token:" + token);
-          request.setAttribute(WebConstants.KEY_LOGIN_EXCEPTION, ex);
+
+          // We can save the login token error in the request attribute in Old UI, but we can't do
+          // this
+          // in New UI because New UI sends another POST request to query the page content. So we
+          // should
+          // call 'LogonSection.setLoginTokenError' to save the error.
+          if (RenderNewTemplate.isNewUIEnabled()) {
+            LogonSection.setLoginTokenError(ex.getLocalizedMessage());
+          } else {
+            request.setAttribute(WebConstants.KEY_LOGIN_EXCEPTION, ex);
+          }
 
           if (!noExistingSessionOrGuest) {
             // We want to make sure they logout of their invalid

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/login/LogonSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/login/LogonSection.java
@@ -117,18 +117,6 @@ public class LogonSection extends AbstractPrototypeSection<LogonSection.LogonMod
   @PlugKey("logon.login")
   private Button logonButton;
 
-  private static String loginTokenError;
-
-  /**
-   * Save a login token error captured when login with a shared secret in New UI. This method should
-   * only be used when New UI is turned on.
-   *
-   * @param error Error message which is typically extracted from `TokenException`.
-   */
-  public static void setLoginTokenError(String error) {
-    loginTokenError = error;
-  }
-
   @Override
   public String getDefaultPropertyName() {
     return "";
@@ -258,10 +246,12 @@ public class LogonSection extends AbstractPrototypeSection<LogonSection.LogonMod
     }
     model.setLoginLinks(loginLinksRenderables);
 
-    // In New UI, if a login token error is captured, update the model to show the error.
+    // In New UI, if a login token error is captured and saved in Session, update the model
+    // to show the error and then clear the error from Session.
+    String loginTokenError = sessionService.getAttribute(WebConstants.KEY_LOGIN_EXCEPTION);
     if (RenderNewTemplate.isNewUIEnabled() && loginTokenError != null) {
       model.setError(loginTokenError);
-      setLoginTokenError(null);
+      sessionService.removeAttribute(WebConstants.KEY_LOGIN_EXCEPTION);
     }
 
     return viewFactory.createResult("logon/logon.ftl", context);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/login/LogonSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/login/LogonSection.java
@@ -67,6 +67,7 @@ import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
 import com.tle.web.template.Decorations;
 import com.tle.web.template.Decorations.MenuMode;
+import com.tle.web.template.RenderNewTemplate;
 import hurl.build.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
@@ -115,6 +116,18 @@ public class LogonSection extends AbstractPrototypeSection<LogonSection.LogonMod
   @Component
   @PlugKey("logon.login")
   private Button logonButton;
+
+  private static String loginTokenError;
+
+  /**
+   * Save a login token error captured when login with a shared secret in New UI. This method should
+   * only be used when New UI is turned on.
+   *
+   * @param error Error message which is typically extracted from `TokenException`.
+   */
+  public static void setLoginTokenError(String error) {
+    loginTokenError = error;
+  }
 
   @Override
   public String getDefaultPropertyName() {
@@ -244,6 +257,12 @@ public class LogonSection extends AbstractPrototypeSection<LogonSection.LogonMod
       }
     }
     model.setLoginLinks(loginLinksRenderables);
+
+    // In New UI, if a login token error is captured, update the model to show the error.
+    if (RenderNewTemplate.isNewUIEnabled() && loginTokenError != null) {
+      model.setError(loginTokenError);
+      setLoginTokenError(null);
+    }
 
     return viewFactory.createResult("logon/logon.ftl", context);
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/login/LogonSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/login/LogonSection.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -248,11 +249,13 @@ public class LogonSection extends AbstractPrototypeSection<LogonSection.LogonMod
 
     // In New UI, if a login token error is captured and saved in Session, update the model
     // to show the error and then clear the error from Session.
-    String loginTokenError = sessionService.getAttribute(WebConstants.KEY_LOGIN_EXCEPTION);
-    if (RenderNewTemplate.isNewUIEnabled() && loginTokenError != null) {
-      model.setError(loginTokenError);
-      sessionService.removeAttribute(WebConstants.KEY_LOGIN_EXCEPTION);
-    }
+    Optional.ofNullable(sessionService.<String>getAttribute(WebConstants.KEY_LOGIN_EXCEPTION))
+        .filter(err -> RenderNewTemplate.isNewUIEnabled())
+        .ifPresent(
+            err -> {
+              model.setError(err);
+              sessionService.removeAttribute(WebConstants.KEY_LOGIN_EXCEPTION);
+            });
 
     return viewFactory.createResult("logon/logon.ftl", context);
   }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/users/TokenLoginTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/users/TokenLoginTest.java
@@ -44,7 +44,7 @@ public class TokenLoginTest extends AbstractSessionTest {
     token = TokenSecurity.createSecureToken("tokenuser", "sso_group", "sso_group", null);
     openHome(token);
 
-    // Browser should stay in the login page now the page should show the token warning.
+    // Browser should stay in the login page and show the token warning.
     new LoginPage(context).get();
     assertTrue(isTextPresent("You do not have permissions to use this token"));
   }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/users/TokenLoginTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/users/TokenLoginTest.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.tle.webtests.framework.TestInstitution;
 import com.tle.webtests.pageobject.HomePage;
+import com.tle.webtests.pageobject.LoginPage;
 import com.tle.webtests.test.AbstractSessionTest;
 import java.net.URLEncoder;
 import org.testng.annotations.Test;
@@ -42,9 +43,9 @@ public class TokenLoginTest extends AbstractSessionTest {
     logout();
     token = TokenSecurity.createSecureToken("tokenuser", "sso_group", "sso_group", null);
     openHome(token);
-    if (!home.usingNewUI()) {
-      // error handling for this is not yet implemented in the new UI
-      assertTrue(isTextPresent("You do not have permissions to use this token"));
-    }
+
+    // Browser should stay in the login page now the page should show the token warning.
+    new LoginPage(context).get();
+    assertTrue(isTextPresent("You do not have permissions to use this token"));
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

In New UI, if a user logins with an invalid shared secret or with one that the user does not have permission to use, the token error is not showed in the Login page. 

The reason is `TokenUserStateHook` fails to keep the token error in New UI. In Old UI, the error is saved in the attribute of the login request which is a GET request, but when New UI is turned on, the GET request only returns the page which triggers another POST request to get the page content. Obviously, the POST request does not know anything about the token error. 

If above sounds confusing please grab me to explain in more detail. 

I have tried different approaches to fix the issue, and in the end I chose the one in this PR which I believe is the safest fix and have least impacts on others. It's to save the token error in `LogonSection` rather than the request attribute in New UI.

#1146