### PR TITLE
fix: ensure audit level has a non-null default value

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/guice/ViewItemModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/guice/ViewItemModule.java
@@ -19,6 +19,7 @@
 package com.tle.web.viewitem.guice;
 
 import com.tle.core.config.guice.PropertiesModule;
+import com.tle.web.sections.equella.SectionAuditable.AuditLevel;
 import com.tle.web.sections.equella.guice.SectionsModule;
 
 public class ViewItemModule extends SectionsModule {
@@ -30,7 +31,7 @@ public class ViewItemModule extends SectionsModule {
   public static class ViewItemPropsModule extends PropertiesModule {
     @Override
     protected void configure() {
-      bindProp("audit.level"); // $NON-NLS-1$
+      bindProp("audit.level", AuditLevel.NONE.name());
     }
 
     @Override


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Since 2022.1, if the audit level is null it will break thumbnails. So we use 'NONE' as the default value.

