### PR TITLE
fix: brightspace connector 500 error and automatically close dialog

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/brightspace/editor/BrightspaceConnectorEditor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/brightspace/editor/BrightspaceConnectorEditor.java
@@ -40,6 +40,8 @@ import com.tle.web.sections.annotations.EventHandlerMethod;
 import com.tle.web.sections.equella.annotation.PlugKey;
 import com.tle.web.sections.events.RenderEventContext;
 import com.tle.web.sections.events.js.EventGenerator;
+import com.tle.web.sections.jquery.libraries.JQueryFancyBox;
+import com.tle.web.sections.js.generic.function.ParentFrameFunction;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.SectionRenderable;
 import com.tle.web.sections.result.util.KeyLabel;
@@ -47,6 +49,7 @@ import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.Div;
 import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
+import com.tle.web.template.RenderNewTemplate;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -125,6 +128,19 @@ public class BrightspaceConnectorEditor
   @Override
   protected SectionRenderable renderFields(
       RenderEventContext context, EntityEditingSession<ConnectorEditingBean, Connector> session) {
+    // Set custom close function to auto close fancy dialog in new UI.
+    // Because the script is inside the iframe so the close function should be a
+    // ParentFrameFunction.
+    // Otherwise, it won't be able to close the auth dialog where outside the iframe.
+    // Besides, this change will cause redundant submission (don't know why) and pop up an alert in
+    // old UI,
+    // therefore reset to null if in old UI (the whole page will be refreshed and dialog will
+    // disappear anyway).
+    if (RenderNewTemplate.isNewUIEnabled()) {
+      authDialog.setCustomCloseFunction(new ParentFrameFunction(JQueryFancyBox.CLOSE));
+    } else {
+      authDialog.setCustomCloseFunction(null);
+    }
     final BrightspaceConnectorEditorModel model = getModel(context);
     final ConnectorEditingBean connector = session.getBean();
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/brightspace/editor/BrightspaceConnectorEditor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/brightspace/editor/BrightspaceConnectorEditor.java
@@ -40,8 +40,6 @@ import com.tle.web.sections.annotations.EventHandlerMethod;
 import com.tle.web.sections.equella.annotation.PlugKey;
 import com.tle.web.sections.events.RenderEventContext;
 import com.tle.web.sections.events.js.EventGenerator;
-import com.tle.web.sections.jquery.libraries.JQueryFancyBox;
-import com.tle.web.sections.js.generic.function.ParentFrameFunction;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.SectionRenderable;
 import com.tle.web.sections.result.util.KeyLabel;
@@ -49,7 +47,6 @@ import com.tle.web.sections.standard.Button;
 import com.tle.web.sections.standard.Div;
 import com.tle.web.sections.standard.TextField;
 import com.tle.web.sections.standard.annotations.Component;
-import com.tle.web.template.RenderNewTemplate;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -128,19 +125,6 @@ public class BrightspaceConnectorEditor
   @Override
   protected SectionRenderable renderFields(
       RenderEventContext context, EntityEditingSession<ConnectorEditingBean, Connector> session) {
-    // Set custom close function to auto close fancy dialog in new UI.
-    // Because the script is inside the iframe so the close function should be a
-    // ParentFrameFunction.
-    // Otherwise, it won't be able to close the auth dialog where outside the iframe.
-    // Besides, this change will cause redundant submission (don't know why) and pop up an alert in
-    // old UI,
-    // therefore reset to null if in old UI (the whole page will be refreshed and dialog will
-    // disappear anyway).
-    if (RenderNewTemplate.isNewUIEnabled()) {
-      authDialog.setCustomCloseFunction(new ParentFrameFunction(JQueryFancyBox.CLOSE));
-    } else {
-      authDialog.setCustomCloseFunction(null);
-    }
     final BrightspaceConnectorEditorModel model = getModel(context);
     final ConnectorEditingBean connector = session.getBean();
 
@@ -190,6 +174,8 @@ public class BrightspaceConnectorEditor
         ajax.getAjaxUpdateDomFunction(
             tree, this, events.getEventHandler("testApp"), getAjaxDivId()));
     authDialog.setOkCallback(events.getSubmitValuesFunction("adminSignIn"));
+    // Use mockCloseDialog function to correctly close the fancy dialog in BrightSpace.
+    authDialog.setIsUseMockCloseDialog(true);
   }
 
   @EventHandlerMethod

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/brightspace/editor/BrightspaceConnectorEditor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/brightspace/editor/BrightspaceConnectorEditor.java
@@ -175,7 +175,7 @@ public class BrightspaceConnectorEditor
             tree, this, events.getEventHandler("testApp"), getAjaxDivId()));
     authDialog.setOkCallback(events.getSubmitValuesFunction("adminSignIn"));
     // Use mockCloseDialog function to correctly close the fancy dialog in BrightSpace.
-    authDialog.setIsUseMockCloseDialog(true);
+    authDialog.setIsExternalAuthDialog(true);
   }
 
   @EventHandlerMethod

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
@@ -40,7 +40,6 @@ import com.tle.web.sections.events.js.BookmarkAndModify;
 import com.tle.web.sections.jquery.JQuerySelector;
 import com.tle.web.sections.jquery.JQuerySelector.Type;
 import com.tle.web.sections.jquery.JQueryStatement;
-import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.js.generic.expression.ScriptExpression;
 import com.tle.web.sections.js.generic.function.CallAndReferenceFunction;
 import com.tle.web.sections.js.generic.function.ParentFrameFunction;
@@ -142,13 +141,8 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
     closeBtn.setContextExpr(
         new ScriptExpression(
             "window.parent.document")); // The script is possible in the iframe, for example in
-                                        // BrightSpace.
+    // BrightSpace.
     return new JQueryStatement(closeBtn, new ScriptExpression("click()")); // Click the button
-  }
-
-  @Override
-  public JSCallable getCloseFunction() {
-    return super.getCloseFunction();
   }
 
   @EventHandlerMethod

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
@@ -42,6 +42,7 @@ import com.tle.web.sections.js.generic.function.ParentFrameFunction;
 import com.tle.web.sections.render.Label;
 import com.tle.web.sections.render.SectionRenderable;
 import com.tle.web.sections.standard.dialog.model.DialogModel;
+import com.tle.web.template.RenderNewTemplate;
 import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,6 +112,7 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
   @EventHandlerMethod
   public void finishedAuth(SectionInfo info) {
     LOGGER.trace("Finishing up the auth sequence.");
+    info.setAttribute(RenderNewTemplate.DisableNewUI(), true);
     closeDialog(info, parentCallback, (Object) null);
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
@@ -37,6 +37,7 @@ import com.tle.web.sections.equella.annotation.PlugKey;
 import com.tle.web.sections.equella.dialog.AbstractOkayableDialog;
 import com.tle.web.sections.events.RenderContext;
 import com.tle.web.sections.events.js.BookmarkAndModify;
+import com.tle.web.sections.js.JSCallable;
 import com.tle.web.sections.js.generic.function.CallAndReferenceFunction;
 import com.tle.web.sections.js.generic.function.ParentFrameFunction;
 import com.tle.web.sections.render.Label;
@@ -62,6 +63,11 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
 
   @ViewFactory private FreemarkerFactory view;
 
+  /*
+  In order to return the correct function to automatically close the auth dialog in new UI,
+  add this property to overwrite the close function.
+   */
+  private JSCallable customCloseFunction;
   private ParentFrameFunction parentCallback;
   @Nullable private LMSAuthUrlCallable authUrlCallable;
 
@@ -107,6 +113,22 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
   public void treeFinished(String id, SectionTree tree) {
     super.treeFinished(id, tree);
     parentCallback = new ParentFrameFunction(CallAndReferenceFunction.get(getOkCallback(), this));
+  }
+
+  public JSCallable getCustomCloseFunction() {
+    return this.customCloseFunction;
+  }
+
+  public void setCustomCloseFunction(JSCallable func) {
+    this.customCloseFunction = func;
+  }
+
+  @Override
+  public JSCallable getCloseFunction() {
+    if (customCloseFunction != null) {
+      return getCustomCloseFunction();
+    }
+    return super.getCloseFunction();
   }
 
   @EventHandlerMethod

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/dialog/LMSAuthDialog.java
@@ -71,7 +71,7 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
    This property controls whether it needs to add a new JS statement which mocks a click action on close button
    in order to correctly close the auth dialog.
   */
-  private boolean isUseMockCloseDialog;
+  private boolean isExternalAuthDialog;
   private ParentFrameFunction parentCallback;
   @Nullable private LMSAuthUrlCallable authUrlCallable;
 
@@ -119,20 +119,20 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
     parentCallback = new ParentFrameFunction(CallAndReferenceFunction.get(getOkCallback(), this));
   }
 
-  public boolean isUseMockCloseDialog() {
-    return this.isUseMockCloseDialog;
+  public boolean isExternalAuthDialog() {
+    return this.isExternalAuthDialog;
   }
 
-  public void setIsUseMockCloseDialog(boolean value) {
-    this.isUseMockCloseDialog = value;
+  public void setIsExternalAuthDialog(boolean value) {
+    this.isExternalAuthDialog = value;
   }
 
   /**
-   * Js statement for closing the dialog by clicking the close button. Because the script could be
-   * existing inside the iframe so the close function should have window.parent.ducoment prefix.
-   * Otherwise, it won't be able to close the auth dialog where outside the iframe.
+   * JS statement for closing the dialog by clicking the close button. Because the script could be
+   * existing inside the iframe the close function should have window.parent.document prefix.
+   * Otherwise, it won't be able to close the auth dialog when outside the iframe.
    */
-  private JQueryStatement mockCloseDialog(SectionInfo info) {
+  private JQueryStatement closeExternalAuthDialog(SectionInfo info) {
     JQuerySelector closeBtn =
         new JQuerySelector(
             Type.ID,
@@ -148,12 +148,12 @@ public class LMSAuthDialog extends AbstractOkayableDialog<LMSAuthDialog.Model> {
   @EventHandlerMethod
   public void finishedAuth(SectionInfo info) {
     LOGGER.trace("Finishing up the auth sequence.");
-    // Keep in old new to avoid 500 error in new UI.
+    // Return old ui in order to avoid 500 error in BrightSpace.
     info.setAttribute(RenderNewTemplate.DisableNewUI(), true);
     closeDialog(
         info,
         new FunctionCallStatement(parentCallback),
-        this.isUseMockCloseDialog ? this.mockCloseDialog(info) : null);
+        this.isExternalAuthDialog ? this.closeExternalAuthDialog(info) : null);
   }
 
   @EventHandlerMethod


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Force return old UI to resolve the 500 error.
Provide a custom close function to close the Dialog in the new UI.

This PR fixes two problems.

The first one is that the LMS auth dialog in the new UI will trigger a 500 error. This 500 error happens after the finishedAuth event is triggered. Since the cause of this error is difficult to trace, we force the new UI to be closed in finishedAuth Event.

The second problem was that after fixing the 500 error, the LMS auth dialog didn't close properly in the new UI. In fact, it didn't close properly even in the old UI (it disappeared because the whole brightspace connector page was redirected). The reason is the returned script `$.fancybox.close` is in the iframe, and it does not have a `self.parent` prefix or context, so this script won't close the dialog outside the iframe. And the solution was to add a correct close JS statement to the returned script.

https://user-images.githubusercontent.com/92769668/160061668-39e86656-79f4-4400-9372-0ff4e15cf1ac.mp4

~~The only issue is now the new UI will send a redundant request at the end.~~ fixed
![image](https://user-images.githubusercontent.com/92769668/160061898-ffbc66fe-2a2d-4e46-8dd8-cd13b277b439.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
