### PR TITLE
fix: update swagger ui annotations for info and status params

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/item/interfaces/ItemResource.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/item/interfaces/ItemResource.java
@@ -57,7 +57,9 @@ public interface ItemResource {
   static final String APIDOC_FILEID = "The id of a file area to use";
 
   static final String ALL_ALLOWABLE_INFOS =
-      "basic,metadata,attachment,detail,navigation,drm,display,all";
+      "basic, metadata, attachment, detail, navigation, drm, display, all";
+  static final String ALL_ALLOWABLE_STATUSES =
+      "draft, live, rejected, moderating, archived, suspended, deleted, review, personal";
 
   @GET
   @Path("/{uuid}/{version}")

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
@@ -131,7 +131,7 @@ public interface EquellaSearchResource extends SearchResource {
               value =
                   "Filter by item status"
                       + "\nAvailable values: "
-                      + "DRAFT,LIVE,REJECTED,MODERATING,ARCHIVED,SUSPENDED,DELETED,REVIEW,PERSONAL",
+                      + ItemResource.ALL_ALLOWABLE_STATUSES,
               required = false)
           @QueryParam("status")
           CsvList status,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
@@ -20,7 +20,6 @@ package com.tle.web.api.search;
 
 import com.tle.common.interfaces.CsvList;
 import com.tle.web.api.interfaces.beans.SearchBean;
-import com.tle.web.api.item.interfaces.ItemResource;
 import com.tle.web.api.item.interfaces.beans.ItemBean;
 import com.tle.web.api.search.interfaces.SearchResource;
 import io.swagger.annotations.Api;
@@ -109,11 +108,7 @@ public interface EquellaSearchResource extends SearchResource {
               required = false)
           @QueryParam("where")
           String where,
-      @ApiParam(
-              value = "How much information to return for the results",
-              required = false,
-              allowableValues = ItemResource.ALL_ALLOWABLE_INFOS,
-              allowMultiple = true)
+      @ApiParam(value = "How much information to return for the results", required = false)
           @QueryParam("info")
           CsvList info,
       @ApiParam(
@@ -126,13 +121,7 @@ public interface EquellaSearchResource extends SearchResource {
       @ApiParam(value = "single dynamic collection uuid (:virtualized value)", required = false)
           @QueryParam("dynacollection")
           String dynaCollectionCompound,
-      @ApiParam(
-              value = "Filter by item status",
-              required = false,
-              allowableValues =
-                  "DRAFT,LIVE,REJECTED,MODERATING,ARCHIVED,SUSPENDED,DELETED,REVIEW,PERSONAL",
-              allowMultiple = true)
-          @QueryParam("status")
+      @ApiParam(value = "Filter by item status", required = false) @QueryParam("status")
           CsvList status,
       @ApiParam(value = "An ISO date format (yyyy-MM-dd)", required = false)
           @QueryParam("modifiedAfter")

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
@@ -20,6 +20,7 @@ package com.tle.web.api.search;
 
 import com.tle.common.interfaces.CsvList;
 import com.tle.web.api.interfaces.beans.SearchBean;
+import com.tle.web.api.item.interfaces.ItemResource;
 import com.tle.web.api.item.interfaces.beans.ItemBean;
 import com.tle.web.api.search.interfaces.SearchResource;
 import io.swagger.annotations.Api;
@@ -108,7 +109,12 @@ public interface EquellaSearchResource extends SearchResource {
               required = false)
           @QueryParam("where")
           String where,
-      @ApiParam(value = "How much information to return for the results", required = false)
+      @ApiParam(
+              value =
+                  "How much information to return for the results"
+                      + "\nAvailable values: "
+                      + ItemResource.ALL_ALLOWABLE_INFOS,
+              required = false)
           @QueryParam("info")
           CsvList info,
       @ApiParam(
@@ -121,7 +127,13 @@ public interface EquellaSearchResource extends SearchResource {
       @ApiParam(value = "single dynamic collection uuid (:virtualized value)", required = false)
           @QueryParam("dynacollection")
           String dynaCollectionCompound,
-      @ApiParam(value = "Filter by item status", required = false) @QueryParam("status")
+      @ApiParam(
+              value =
+                  "Filter by item status"
+                      + "\nAvailable values: "
+                      + "DRAFT,LIVE,REJECTED,MODERATING,ARCHIVED,SUSPENDED,DELETED,REVIEW,PERSONAL",
+              required = false)
+          @QueryParam("status")
           CsvList status,
       @ApiParam(value = "An ISO date format (yyyy-MM-dd)", required = false)
           @QueryParam("modifiedAfter")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Update annotations for api `search`.
Including status and info params.
Before:
![image](https://user-images.githubusercontent.com/92769668/160333786-4fe78887-989e-41ab-adfc-9823af53ecfa.png)

After:
![image](https://user-images.githubusercontent.com/92769668/160333599-d05870dc-b116-458b-a350-6f6744bf1053.png)

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
