### PR TITLE
fix: escape the reserved word 'count' for Oracle

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/viewcount/AbstractViewcount.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/viewcount/AbstractViewcount.java
@@ -19,11 +19,14 @@
 package com.tle.beans.viewcount;
 
 import java.time.Instant;
+import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
 @MappedSuperclass
 public abstract class AbstractViewcount {
+  @Column(name = "`count`")
   private int count;
+
   private Instant lastViewed;
 
   public int getCount() {

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/viewcount/AbstractViewcount.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/viewcount/AbstractViewcount.java
@@ -19,12 +19,10 @@
 package com.tle.beans.viewcount;
 
 import java.time.Instant;
-import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
 @MappedSuperclass
 public abstract class AbstractViewcount {
-  @Column(name = "`count`")
   private int count;
 
   private Instant lastViewed;

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -6049,6 +6049,11 @@
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20202.AddIndexingErrorColumnMigration"/>
     <parameter id="date" value="2020-11-18"/>
   </extension>
+  <extension plugin-id="com.tle.core.migration" point-id="migration" id="RenameViewCount">
+    <parameter id="id" value="com.tle.core.institution.migration.v20221.RenameViewCount"/>
+    <parameter id="bean" value="bean:com.tle.core.institution.migration.v20221.RenameViewCount"/>
+    <parameter id="date" value="2022-04-07"/>
+  </extension>
   <extension plugin-id="com.tle.core.migration" point-id="migration" id="EnableDefaultViewerMigration">
     <parameter id="id" value="com.tle.core.institution.migration.v20211.EnableDefaultViewerMigration"/>
     <parameter id="bean" value="bean:com.tle.core.institution.migration.v20211.EnableDefaultViewerMigration"/>

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -85,6 +85,7 @@
 /com.tle.core.entity.services.migration.v20202.removelastknownuserconstraint=Remove last known user composite constraint (username and institution ID)
 /com.tle.core.entity.services.migration.v20202.indexing.errored=Add column to attachment table to allow indexer to skip individual attachments that have failed.
 /com.tle.core.entity.services.migration.v20211.enable.default.viewer=Ensure configured default viewers are also enabled
+/com.tle.core.entity.services.migration.v20221.rename.view.count=rename view count table column 'count' to COUNT
 /com.tle.core.entity.services.query.contains={0} is {1}
 /com.tle.core.entity.services.query.date.after={0} after {1}
 /com.tle.core.entity.services.query.date.before={0} before {1}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20221/RenameViewCount.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20221/RenameViewCount.java
@@ -28,6 +28,11 @@ import java.util.List;
 import org.hibernate.Session;
 import org.hibernate.dialect.Oracle9iDialect;
 
+/**
+ * This migration renames the 'count' column in the viewcount_* tables on Oracle. This was required
+ * due to some odd naming which resulted from the original implementation with SimpleDBA. The new
+ * naming aligns with conventional Oracle usage as well as Hibernate defaults.
+ */
 @Bind
 @Singleton
 public class RenameViewCount extends AbstractHibernateSchemaMigration {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20221/RenameViewCount.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v20221/RenameViewCount.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.institution.migration.v20221;
+
+import com.google.inject.Singleton;
+import com.tle.core.guice.Bind;
+import com.tle.core.hibernate.impl.HibernateMigrationHelper;
+import com.tle.core.migration.AbstractHibernateSchemaMigration;
+import com.tle.core.migration.MigrationInfo;
+import com.tle.core.migration.MigrationResult;
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.dialect.Oracle9iDialect;
+
+@Bind
+@Singleton
+public class RenameViewCount extends AbstractHibernateSchemaMigration {
+
+  @Override
+  protected void executeDataMigration(
+      HibernateMigrationHelper helper, MigrationResult result, Session session) throws Exception {
+    // Only rename the column for when using ExtendedOracle10gDialect or ExtendedOracle9iDialect.
+    if (helper.getExtDialect() instanceof Oracle9iDialect) {
+      session
+          .createNativeQuery("alter table viewcount_item rename column \"count\" to COUNT")
+          .executeUpdate();
+      session
+          .createNativeQuery("alter table viewcount_attachment rename column \"count\" to COUNT")
+          .executeUpdate();
+    }
+  }
+
+  @Override
+  protected int countDataMigrations(HibernateMigrationHelper helper, Session session) {
+    return 1;
+  }
+
+  @Override
+  protected List<String> getDropModifySql(HibernateMigrationHelper helper) {
+    return null;
+  }
+
+  @Override
+  protected List<String> getAddSql(HibernateMigrationHelper helper) {
+    return null;
+  }
+
+  @Override
+  protected Class<?>[] getDomainClasses() {
+    return new Class<?>[] {};
+  }
+
+  @Override
+  public MigrationInfo createMigrationInfo() {
+    return new MigrationInfo("com.tle.core.entity.services.migration.v20221.rename.view.count");
+  }
+}


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

The two View Count tables have columns named `count` which is a reserved word in Oracle. So we need to escape the reserved word.