### PR TITLE
fix: blackboard 500 error from manage external resources

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -889,6 +889,7 @@ blackboardrest.editor.label.apikey=REST API Key
 blackboardrest.editor.label.apisecret=REST API Secret
 blackboardrest.editor.help.apikey=The REST API Key is specific to the Blackboard site
 blackboardrest.editor.help.apisecret=The REST API Secret is specific to the Blackboard site
+blackboardrest.error.notsupported=Feature not supported by Blackboard REST
 connector.description=Blackboard
 connector.editor.label.description=Connector description
 connector.editor.label.title=Connector name

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -411,8 +411,8 @@ public class BlackboardRESTConnectorServiceImpl extends AbstractIntegrationConne
       int count,
       ConnectorRepositoryService.ExternalContentSortType sortType,
       boolean reverseSort)
-      throws LmsUserNotFoundException {
-    return null;
+      throws LmsUserNotFoundException, UnsupportedOperationException {
+    throw new UnsupportedOperationException("Feature not supported by Blackboard Rest");
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -54,6 +54,7 @@ import com.tle.core.connectors.service.ConnectorService;
 import com.tle.core.connectors.utils.ConnectorEntityUtils;
 import com.tle.core.encryption.EncryptionService;
 import com.tle.core.guice.Bind;
+import com.tle.core.i18n.CoreStrings;
 import com.tle.core.institution.InstitutionService;
 import com.tle.core.plugins.AbstractPluginService;
 import com.tle.core.replicatedcache.ReplicatedCacheService;
@@ -412,7 +413,7 @@ public class BlackboardRESTConnectorServiceImpl extends AbstractIntegrationConne
       ConnectorRepositoryService.ExternalContentSortType sortType,
       boolean reverseSort)
       throws LmsUserNotFoundException, UnsupportedOperationException {
-    throw new UnsupportedOperationException("Feature not supported by Blackboard Rest");
+    throw new UnsupportedOperationException(CoreStrings.text("blackboardrest.error.notsupported"));
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/manage/ConnectorManagementResultsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/manage/ConnectorManagementResultsSection.java
@@ -222,8 +222,7 @@ public class ConnectorManagementResultsSection
 
   @Override
   protected ConnectorManagmentSearchResultEvent createResultsEvent(
-      SectionInfo info, ConnectorManagementSearchEvent connectorSearchEvent)
-      throws RuntimeException {
+      SectionInfo info, ConnectorManagementSearchEvent connectorSearchEvent) {
     try {
       Connector connector = connectorSearchEvent.getConnector();
       List<ConnectorContent> allUsage = new ArrayList<ConnectorContent>();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/manage/ConnectorManagementResultsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/manage/ConnectorManagementResultsSection.java
@@ -222,7 +222,8 @@ public class ConnectorManagementResultsSection
 
   @Override
   protected ConnectorManagmentSearchResultEvent createResultsEvent(
-      SectionInfo info, ConnectorManagementSearchEvent connectorSearchEvent) {
+      SectionInfo info, ConnectorManagementSearchEvent connectorSearchEvent)
+      throws RuntimeException {
     try {
       Connector connector = connectorSearchEvent.getConnector();
       List<ConnectorContent> allUsage = new ArrayList<ConnectorContent>();
@@ -300,6 +301,13 @@ public class ConnectorManagementResultsSection
 
     } catch (LmsUserNotFoundException e) {
       throw new RuntimeException(e);
+    } catch (UnsupportedOperationException e) {
+      ConnectorManagmentSearchResultEvent erroredSearchResultEvent =
+          new ConnectorManagmentSearchResultEvent(
+              null, null, null, 0, connectorSearchEvent.getConnector());
+      erroredSearchResultEvent.setErrored(true);
+      erroredSearchResultEvent.setErrorMessage(e.getMessage());
+      return erroredSearchResultEvent;
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Change func `findAllUsages` to throw UnsupportedOperationException.
Add catch statement to set error message.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
![image](https://user-images.githubusercontent.com/92769668/163289324-1cc6112c-e809-4ab1-9561-a675c3bbf206.png)
![image](https://user-images.githubusercontent.com/92769668/163289345-e57478db-68d6-4a95-8bc8-7b0bb5322963.png)

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
