### PR TITLE
chore: update the output directory of `npm run dev`

### DIFF
--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "config": {
     "buildlang": "target/resources/lang",
-    "devjs": "../Source/Plugins/Core/com.equella.core/target/scala-2.12/classes/web/reactjs",
-    "devlang": "../Source/Plugins/Core/com.equella.core/target/scala-2.12/classes/lang",
+    "devjs": "../Source/Plugins/Core/com.equella.core/target/scala-2.13/classes/web/reactjs",
+    "devlang": "../Source/Plugins/Core/com.equella.core/target/scala-2.13/classes/lang",
     "dist": "target/resources/web/reactjs",
     "languageBundle": "target/compile-language-bundle",
     "jest": {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Since we have updated Scala to 2.13, the output of `npm run dev` should be saved in `com.equella.core/target/scala-2.13/classes` now.