### PR TITLE
fix: add missing target attribute to menu link

### DIFF
--- a/react-front-end/tsrc/mainui/MainMenu.tsx
+++ b/react-front-end/tsrc/mainui/MainMenu.tsx
@@ -54,6 +54,7 @@ const MainMenu = ({ menuGroups, onClickNavItem }: MainMenuProps) => {
     <ListItem
       component="a"
       href={item.href}
+      target={item.newWindow ? "_blank" : ""}
       onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
         onClickNavItem();
         if (item.route) {

--- a/react-front-end/tsrc/mainui/MainMenu.tsx
+++ b/react-front-end/tsrc/mainui/MainMenu.tsx
@@ -54,7 +54,7 @@ const MainMenu = ({ menuGroups, onClickNavItem }: MainMenuProps) => {
     <ListItem
       component="a"
       href={item.href}
-      target={item.newWindow ? "_blank" : ""}
+      target={item.newWindow ? "_blank" : "_self"}
       onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
         onClickNavItem();
         if (item.route) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Add missing `target` attribute to menu link.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
