### PR TITLE
refactor: use versions.json determine latest version

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/js/versioncheck.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/js/versioncheck.js
@@ -1,7 +1,6 @@
 function checkVersion(currentVersion, callback) {
-  const releaseCheckUrl =
-    "https://api.github.com/repos/openequella/openEQUELLA/releases";
-  $.ajax(releaseCheckUrl).done(function(data) {
+  const releaseCheckUrl = "https://openequella.github.io/versions.json";
+  $.ajax(releaseCheckUrl).done(function (data) {
     const checkResult = createCheckResult(currentVersion, data);
     callback(checkResult.newer, JSON.stringify(checkResult.newerReleases));
   });
@@ -35,7 +34,7 @@ function createCheckResult(currentVersion, data) {
     newerReleases = {
       majorUpdate: latestMajorRelease,
       minorUpdate: latestMinorRelease,
-      patchUpdate: latestPatchRelease
+      patchUpdate: latestPatchRelease,
     };
   } else {
     console.log(
@@ -47,8 +46,8 @@ function createCheckResult(currentVersion, data) {
 
 function getReleaseList(data) {
   const releaseList = [];
-  data.forEach(function(value) {
-    const releaseVersion = value.name;
+  data.forEach(function (value) {
+    const releaseVersion = value.version;
     const releaseUrl = value.html_url;
     const parsedVersion = parseVersion(releaseVersion);
     // We only want releases which support the semantic version
@@ -57,7 +56,7 @@ function getReleaseList(data) {
         major: parsedVersion.major,
         minor: parsedVersion.minor,
         patch: parsedVersion.patch,
-        url: releaseUrl
+        url: releaseUrl,
       });
     }
   });
@@ -66,7 +65,7 @@ function getReleaseList(data) {
 
 function getLatestMajorRelease(releaseList, parsedVersion) {
   // Find out all major releases published after current version
-  const majorReleaseList = releaseList.filter(function(release) {
+  const majorReleaseList = releaseList.filter(function (release) {
     return release.major > parsedVersion.major;
   });
 
@@ -94,7 +93,7 @@ function getLatestMajorRelease(releaseList, parsedVersion) {
 
 function getLatestMinorRelease(releaseList, parsedVersion) {
   // Find out all minor releases published after current version
-  const minorReleaseList = releaseList.filter(function(release) {
+  const minorReleaseList = releaseList.filter(function (release) {
     return (
       release.major === parsedVersion.major &&
       release.minor > parsedVersion.minor
@@ -120,7 +119,7 @@ function getLatestMinorRelease(releaseList, parsedVersion) {
 
 function getLatestPatchRelease(releaseList, parsedVersion) {
   // Find out all patch releases published after current version
-  const patchReleaseList = releaseList.filter(function(release) {
+  const patchReleaseList = releaseList.filter(function (release) {
     return (
       release.major === parsedVersion.major &&
       release.minor === parsedVersion.minor &&
@@ -154,7 +153,7 @@ function parseVersion(version) {
     result = {
       major: parsedVersion[1],
       minor: parsedVersion[2],
-      patch: parsedVersion[3]
+      patch: parsedVersion[3],
     };
   }
   return result;

--- a/Source/Plugins/Core/com.equella.core/test/javascript/__mocks__/versioncheck_mock_data.js
+++ b/Source/Plugins/Core/com.equella.core/test/javascript/__mocks__/versioncheck_mock_data.js
@@ -269,14 +269,14 @@ exports.mockReleases = [
     ref: "0b94c18552b10696d21327a53c9233bc8d3ea44e",
   },
   {
-    version: "2019.1.0",
+    version: "2019.1",
     html_url:
       "https://github.com/openequella/openEQUELLA/releases/tag/2019.1-Stable",
     release_date: "2019-07-31",
     ref: "ad37d9a4da99bc5ba74eef7e3d2baf96cf08b56b",
   },
   {
-    version: "2018.2.0",
+    version: "2018.2",
     html_url:
       "https://github.com/openequella/openEQUELLA/releases/tag/2018.2-Stable",
     release_date: "2018-12-21",

--- a/Source/Plugins/Core/com.equella.core/test/javascript/__mocks__/versioncheck_mock_data.js
+++ b/Source/Plugins/Core/com.equella.core/test/javascript/__mocks__/versioncheck_mock_data.js
@@ -17,1060 +17,269 @@
  */
 exports.mockReleases = [
   {
-    url: "https://api.github.com/repos/openequella/openEQUELLA/releases/20197179",
-    assets_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/releases/20197179/assets",
-    upload_url:
-      "https://uploads.github.com/repos/openequella/openEQUELLA/releases/20197179/assets{?name,label}",
+    version: "2022.1.0",
     html_url:
-      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.1",
-    id: 20197199,
-    node_id: "MDc6UmVsZWFzZTIwMTk3MTc5",
-    tag_name: "2019.1.1",
-    target_commitish: "develop",
-    name: "2019.2.1",
-    draft: false,
-    author: {
-      login: "edalex-ian",
-      id: 43919233,
-      node_id: "MDQ6VXNlcjQzOTE5MjMz",
-      avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-      gravatar_id: "",
-      url: "https://api.github.com/users/edalex-ian",
-      html_url: "https://github.com/edalex-ian",
-      followers_url: "https://api.github.com/users/edalex-ian/followers",
-      following_url:
-        "https://api.github.com/users/edalex-ian/following{/other_user}",
-      gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-      starred_url:
-        "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-      subscriptions_url:
-        "https://api.github.com/users/edalex-ian/subscriptions",
-      organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-      repos_url: "https://api.github.com/users/edalex-ian/repos",
-      events_url: "https://api.github.com/users/edalex-ian/events{/privacy}",
-      received_events_url:
-        "https://api.github.com/users/edalex-ian/received_events",
-      type: "User",
-      site_admin: false,
-    },
-    prerelease: false,
-    created_at: "2019-09-20T06:05:01Z",
-    published_at: "2019-09-24T01:06:14Z",
-    assets: [
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083635",
-        id: 15083635,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM1",
-        name: "equella-installer-2019.1.1.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 311597191,
-        download_count: 8,
-        created_at: "2019-09-24T01:07:56Z",
-        updated_at: "2019-09-24T01:09:28Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/equella-installer-2019.1.1.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083636",
-        id: 15083636,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM2",
-        name: "reference-language-pack.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 131816,
-        download_count: 12,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:09:29Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/reference-language-pack.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083637",
-        id: 15083637,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM3",
-        name: "scriptingapi-javadoc-2019.1.1-Stable.OSE-g3a1c903.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 220033,
-        download_count: 2,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:09:29Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/scriptingapi-javadoc-2019.1.1-Stable.OSE-g3a1c903.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083638",
-        id: 15083638,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM4",
-        name: "tle-upgrade-2019.1.r20190920.2019.1.1-Stable.OSE.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 295780946,
-        download_count: 4,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:11:03Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/tle-upgrade-2019.1.r20190920.2019.1.1-Stable.OSE.zip",
-      },
-    ],
-    tarball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/tarball/2019.1.1",
-    zipball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/zipball/2019.1.1",
-    body: "This is the first hotfix for 2019.1. It includes the following fixes:\r\n\r\n* [List of GitHub Issues](https://github.com/openequella/openEQUELLA/issues?q=is%3Aissue+label%3A2019.1.1+is%3Aclosed)\r\n\r\nOtherwise it also includes that found in [2019.1](https://github.com/openequella/openEQUELLA/releases/tag/2019.1-Stable).",
+      "https://github.com/openequella/openEQUELLA/releases/tag/2022.1.0",
+    release_date: "2022-04-12",
+    ref: "814b313c9cc7c9b36abd75b057fa39a552f16d0d",
   },
   {
-    url: "https://api.github.com/repos/openequella/openEQUELLA/releases/20197179",
-    assets_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/releases/20197179/assets",
-    upload_url:
-      "https://uploads.github.com/repos/openequella/openEQUELLA/releases/20197179/assets{?name,label}",
+    version: "2021.2.3",
     html_url:
-      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.1",
-    id: 20197189,
-    node_id: "MDc6UmVsZWFzZTIwMTk3MTc5",
-    tag_name: "2019.2.1",
-    target_commitish: "develop",
-    name: "2019.2.0",
-    draft: false,
-    author: {
-      login: "edalex-ian",
-      id: 43919233,
-      node_id: "MDQ6VXNlcjQzOTE5MjMz",
-      avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-      gravatar_id: "",
-      url: "https://api.github.com/users/edalex-ian",
-      html_url: "https://github.com/edalex-ian",
-      followers_url: "https://api.github.com/users/edalex-ian/followers",
-      following_url:
-        "https://api.github.com/users/edalex-ian/following{/other_user}",
-      gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-      starred_url:
-        "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-      subscriptions_url:
-        "https://api.github.com/users/edalex-ian/subscriptions",
-      organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-      repos_url: "https://api.github.com/users/edalex-ian/repos",
-      events_url: "https://api.github.com/users/edalex-ian/events{/privacy}",
-      received_events_url:
-        "https://api.github.com/users/edalex-ian/received_events",
-      type: "User",
-      site_admin: false,
-    },
-    prerelease: false,
-    created_at: "2019-09-20T06:05:01Z",
-    published_at: "2019-09-24T01:06:14Z",
-    assets: [
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083635",
-        id: 15083635,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM1",
-        name: "equella-installer-2019.1.1.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 311597191,
-        download_count: 8,
-        created_at: "2019-09-24T01:07:56Z",
-        updated_at: "2019-09-24T01:09:28Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/equella-installer-2019.1.1.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083636",
-        id: 15083636,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM2",
-        name: "reference-language-pack.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 131816,
-        download_count: 12,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:09:29Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/reference-language-pack.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083637",
-        id: 15083637,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM3",
-        name: "scriptingapi-javadoc-2019.1.1-Stable.OSE-g3a1c903.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 220033,
-        download_count: 2,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:09:29Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/scriptingapi-javadoc-2019.1.1-Stable.OSE-g3a1c903.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083638",
-        id: 15083638,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM4",
-        name: "tle-upgrade-2019.1.r20190920.2019.1.1-Stable.OSE.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 295780946,
-        download_count: 4,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:11:03Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/tle-upgrade-2019.1.r20190920.2019.1.1-Stable.OSE.zip",
-      },
-    ],
-    tarball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/tarball/2019.1.1",
-    zipball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/zipball/2019.1.1",
-    body: "This is the first hotfix for 2019.1. It includes the following fixes:\r\n\r\n* [List of GitHub Issues](https://github.com/openequella/openEQUELLA/issues?q=is%3Aissue+label%3A2019.1.1+is%3Aclosed)\r\n\r\nOtherwise it also includes that found in [2019.1](https://github.com/openequella/openEQUELLA/releases/tag/2019.1-Stable).",
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.2.3",
+    release_date: "2022-02-15",
+    ref: "bfbe6390410cd4c486e5bf3f2608851a0fa8acf1",
   },
   {
-    url: "https://api.github.com/repos/openequella/openEQUELLA/releases/20197179",
-    assets_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/releases/20197179/assets",
-    upload_url:
-      "https://uploads.github.com/repos/openequella/openEQUELLA/releases/20197179/assets{?name,label}",
+    version: "2021.2.2",
     html_url:
-      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.1",
-    id: 20197179,
-    node_id: "MDc6UmVsZWFzZTIwMTk3MTc5",
-    tag_name: "2019.1.1",
-    target_commitish: "develop",
-    name: "2019.1.1",
-    draft: false,
-    author: {
-      login: "edalex-ian",
-      id: 43919233,
-      node_id: "MDQ6VXNlcjQzOTE5MjMz",
-      avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-      gravatar_id: "",
-      url: "https://api.github.com/users/edalex-ian",
-      html_url: "https://github.com/edalex-ian",
-      followers_url: "https://api.github.com/users/edalex-ian/followers",
-      following_url:
-        "https://api.github.com/users/edalex-ian/following{/other_user}",
-      gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-      starred_url:
-        "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-      subscriptions_url:
-        "https://api.github.com/users/edalex-ian/subscriptions",
-      organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-      repos_url: "https://api.github.com/users/edalex-ian/repos",
-      events_url: "https://api.github.com/users/edalex-ian/events{/privacy}",
-      received_events_url:
-        "https://api.github.com/users/edalex-ian/received_events",
-      type: "User",
-      site_admin: false,
-    },
-    prerelease: false,
-    created_at: "2019-09-20T06:05:01Z",
-    published_at: "2019-09-24T01:06:14Z",
-    assets: [
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083635",
-        id: 15083635,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM1",
-        name: "equella-installer-2019.1.1.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 311597191,
-        download_count: 8,
-        created_at: "2019-09-24T01:07:56Z",
-        updated_at: "2019-09-24T01:09:28Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/equella-installer-2019.1.1.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083636",
-        id: 15083636,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM2",
-        name: "reference-language-pack.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 131816,
-        download_count: 12,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:09:29Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/reference-language-pack.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083637",
-        id: 15083637,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM3",
-        name: "scriptingapi-javadoc-2019.1.1-Stable.OSE-g3a1c903.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 220033,
-        download_count: 2,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:09:29Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/scriptingapi-javadoc-2019.1.1-Stable.OSE-g3a1c903.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/15083638",
-        id: 15083638,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE1MDgzNjM4",
-        name: "tle-upgrade-2019.1.r20190920.2019.1.1-Stable.OSE.zip",
-        label: null,
-        uploader: {
-          login: "PenghaiZhang",
-          id: 47203811,
-          node_id: "MDQ6VXNlcjQ3MjAzODEx",
-          avatar_url: "https://avatars0.githubusercontent.com/u/47203811?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/PenghaiZhang",
-          html_url: "https://github.com/PenghaiZhang",
-          followers_url: "https://api.github.com/users/PenghaiZhang/followers",
-          following_url:
-            "https://api.github.com/users/PenghaiZhang/following{/other_user}",
-          gists_url:
-            "https://api.github.com/users/PenghaiZhang/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/PenghaiZhang/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/PenghaiZhang/subscriptions",
-          organizations_url: "https://api.github.com/users/PenghaiZhang/orgs",
-          repos_url: "https://api.github.com/users/PenghaiZhang/repos",
-          events_url:
-            "https://api.github.com/users/PenghaiZhang/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/PenghaiZhang/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 295780946,
-        download_count: 4,
-        created_at: "2019-09-24T01:07:57Z",
-        updated_at: "2019-09-24T01:11:03Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1.1/tle-upgrade-2019.1.r20190920.2019.1.1-Stable.OSE.zip",
-      },
-    ],
-    tarball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/tarball/2019.1.1",
-    zipball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/zipball/2019.1.1",
-    body: "This is the first hotfix for 2019.1. It includes the following fixes:\r\n\r\n* [List of GitHub Issues](https://github.com/openequella/openEQUELLA/issues?q=is%3Aissue+label%3A2019.1.1+is%3Aclosed)\r\n\r\nOtherwise it also includes that found in [2019.1](https://github.com/openequella/openEQUELLA/releases/tag/2019.1-Stable).",
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.2.2",
+    release_date: "2022-01-28",
+    ref: "cbbf3bd453468d499becb03d9c532bc6bee013dd",
   },
   {
-    url: "https://api.github.com/repos/openequella/openEQUELLA/releases/18976802",
-    assets_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/releases/18976802/assets",
-    upload_url:
-      "https://uploads.github.com/repos/openequella/openEQUELLA/releases/18976802/assets{?name,label}",
+    version: "2021.2.1",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.2.1",
+    release_date: "2022-01-11",
+    ref: "d8fd69f49f6cb0599ccbc869d9aa739ab0b48f32",
+  },
+  {
+    version: "2021.2.0",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.2.0",
+    release_date: "2021-12-22",
+    ref: "f08bb1d3c31562c920e21693a1e3682714c029a8",
+  },
+  {
+    version: "2021.1.5",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.1.5",
+    release_date: "2022-02-15",
+    ref: "38733610b642e13925848f0c5f145b599458d302",
+  },
+  {
+    version: "2021.1.4",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.1.4",
+    release_date: "2022-01-28",
+    ref: "dad59c0a18a6d968a55546ebb7a69434dd4c14f5",
+  },
+  {
+    version: "2021.1.3",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.1.3",
+    release_date: "2022-01-11",
+    ref: "94de657060513e70fca8c7615b6f0319c90aebc0",
+  },
+  {
+    version: "2021.1.2",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.1.2",
+    release_date: "2021-11-14",
+    ref: "25b17cf60b06f84a151c0622f07895fc63090442",
+  },
+  {
+    version: "2021.1.1",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.1.1",
+    release_date: "2021-06-28",
+    ref: "28b28e9cd64455048b3e18af2453692c5229126c",
+  },
+  {
+    version: "2021.1.0",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2021.1.0",
+    release_date: "2021-04-28",
+    ref: "32861feacfd7d37db3d4bf840bfbe6874466221a",
+  },
+  {
+    version: "2020.2.2",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.2.2",
+    release_date: "2022-01-28",
+    ref: "6943299f5b9aa99650ae1dc4313b4cf919d8cbdd",
+  },
+  {
+    version: "2020.2.1",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.2.1",
+    release_date: "2022-01-11",
+    ref: "e8123657b327facd7963915bbd6b2654f5b2acf5",
+  },
+  {
+    version: "2020.2.0",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.2.0",
+    release_date: "2020-12-22",
+    ref: "753a3abb37dabc2c0615bcbdd48420d920590b41",
+  },
+  {
+    version: "2020.1.6",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.6",
+    release_date: "2020-11-05",
+    ref: "506f58bc908ec122646fa532b4694ba13d9a98c5",
+  },
+  {
+    version: "2020.1.5",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.5",
+    release_date: "2020-11-03",
+    ref: "480648f155cc9af72949051bea20ca9708cb9bef",
+  },
+  {
+    version: "2020.1.4",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.4",
+    release_date: "2020-09-10",
+    ref: "ea048fa65b920b845b878468cff29738638ba89d",
+  },
+  {
+    version: "2020.1.3",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.3",
+    release_date: "2020-07-01",
+    ref: "01ef1717e5b02ca9cb97a6d2f90c48f6bab3b5d1",
+  },
+  {
+    version: "2020.1.2",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.2",
+    release_date: "2020-05-29",
+    ref: "7723830ee188a63818ba702178e5ddc8e6102c98",
+  },
+  {
+    version: "2020.1.1",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.1",
+    release_date: "2020-04-06",
+    ref: "6caa6f44145eea1699837bf2c6210077e025b3d8",
+  },
+  {
+    version: "2020.1.0",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2020.1.0",
+    release_date: "2020-03-10",
+    ref: "a4859ee7a4d25cca6ff971b94482d778c24e87a4",
+  },
+  {
+    version: "2019.2.6",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.6",
+    release_date: "2020-11-05",
+    ref: "799d83c5a6e1acee3cda08e42480ee3bb262b06a",
+  },
+  {
+    version: "2019.2.5",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.5",
+    release_date: "2020-11-03",
+    ref: "b2a85c770080fe6e256731ded37eed17c0735fd2",
+  },
+  {
+    version: "2019.2.4",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.4",
+    release_date: "2020-07-01",
+    ref: "513742dea818214cdfa8818ae345b016581a4fed",
+  },
+  {
+    version: "2019.2.3",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.3",
+    release_date: "2020-05-29",
+    ref: "5174f998765aad1f539e6ee2e3849c234970249f",
+  },
+  {
+    version: "2019.2.2",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.2",
+    release_date: "2020-04-06",
+    ref: "dd48f401f5201e57f9c885224eb9c9b434bd8cca",
+  },
+  {
+    version: "2019.2.1",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.1",
+    release_date: "2020-02-19",
+    ref: "b8fa27d7de38841c50fe50162432c1fccd0ea33c",
+  },
+  {
+    version: "2019.2.0",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.2.0",
+    release_date: "2019-12-18",
+    ref: "2bad3ac5a3163d0cb6472d85d12ff503844265f3",
+  },
+  {
+    version: "2019.1.8",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.8",
+    release_date: "2020-11-05",
+    ref: "f57e4c79c48460d23098677b60e620fa3abcb1bf",
+  },
+  {
+    version: "2019.1.7",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.7",
+    release_date: "2020-11-03",
+    ref: "8e303d5b8b7424f8000b251e4c15777a117beca1",
+  },
+  {
+    version: "2019.1.6",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.6",
+    release_date: "2020-05-29",
+    ref: "9fca9c8d05bb1d6d738b15eac87063973533d468",
+  },
+  {
+    version: "2019.1.5",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.5",
+    release_date: "2020-04-06",
+    ref: "cef608f3ba0a37455614e0d973be308a675acae4",
+  },
+  {
+    version: "2019.1.4",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.4",
+    release_date: "2020-03-03",
+    ref: "4ffc287b13de92929ff9eb7ff7b05b56b2c0fe41",
+  },
+  {
+    version: "2019.1.3",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.3",
+    release_date: "2020-01-28",
+    ref: "03502a5824a9f75e41f51f6948aa51e520b8c8f2",
+  },
+  {
+    version: "2019.1.2",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.2",
+    release_date: "2019-11-24",
+    ref: "ac0b23f0484b7adc3b1f36fecb3ab78c8ae3486e",
+  },
+  {
+    version: "2019.1.1",
+    html_url:
+      "https://github.com/openequella/openEQUELLA/releases/tag/2019.1.1",
+    release_date: "2019-09-24",
+    ref: "0b94c18552b10696d21327a53c9233bc8d3ea44e",
+  },
+  {
+    version: "2019.1.0",
     html_url:
       "https://github.com/openequella/openEQUELLA/releases/tag/2019.1-Stable",
-    id: 18976802,
-    node_id: "MDc6UmVsZWFzZTE4OTc2ODAy",
-    tag_name: "2019.1-Stable",
-    target_commitish: "develop",
-    name: "2019.1",
-    draft: false,
-    author: {
-      login: "edalex-ian",
-      id: 43919233,
-      node_id: "MDQ6VXNlcjQzOTE5MjMz",
-      avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-      gravatar_id: "",
-      url: "https://api.github.com/users/edalex-ian",
-      html_url: "https://github.com/edalex-ian",
-      followers_url: "https://api.github.com/users/edalex-ian/followers",
-      following_url:
-        "https://api.github.com/users/edalex-ian/following{/other_user}",
-      gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-      starred_url:
-        "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-      subscriptions_url:
-        "https://api.github.com/users/edalex-ian/subscriptions",
-      organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-      repos_url: "https://api.github.com/users/edalex-ian/repos",
-      events_url: "https://api.github.com/users/edalex-ian/events{/privacy}",
-      received_events_url:
-        "https://api.github.com/users/edalex-ian/received_events",
-      type: "User",
-      site_admin: false,
-    },
-    prerelease: false,
-    created_at: "2019-07-31T00:48:12Z",
-    published_at: "2019-07-31T07:43:04Z",
-    assets: [
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/14023727",
-        id: 14023727,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE0MDIzNzI3",
-        name: "equella-installer-2019.1.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 311497140,
-        download_count: 43,
-        created_at: "2019-07-31T07:41:13Z",
-        updated_at: "2019-07-31T07:42:48Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1-Stable/equella-installer-2019.1.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/14023671",
-        id: 14023671,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE0MDIzNjcx",
-        name: "reference-language-pack.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 131827,
-        download_count: 13,
-        created_at: "2019-07-31T07:38:08Z",
-        updated_at: "2019-07-31T07:38:11Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1-Stable/reference-language-pack.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/14023670",
-        id: 14023670,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE0MDIzNjcw",
-        name: "scriptingapi-javadoc-2019.1-Stable.OSE-r2-g8cf2a6c-SNAPSHOT.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 220169,
-        download_count: 10,
-        created_at: "2019-07-31T07:38:08Z",
-        updated_at: "2019-07-31T07:38:10Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1-Stable/scriptingapi-javadoc-2019.1-Stable.OSE-r2-g8cf2a6c-SNAPSHOT.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/14023691",
-        id: 14023691,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDE0MDIzNjkx",
-        name: "tle-upgrade-2019.1.r2.2019.1-Stable.OSE.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 295682427,
-        download_count: 18,
-        created_at: "2019-07-31T07:39:15Z",
-        updated_at: "2019-07-31T07:40:54Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2019.1-Stable/tle-upgrade-2019.1.r2.2019.1-Stable.OSE.zip",
-      },
-    ],
-    tarball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/tarball/2019.1-Stable",
-    zipball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/zipball/2019.1-Stable",
-    body: "**openEQUELLA 2019.1**\r\n\r\nPlease see https://version.openequella.net/ for future upgrades and changelogs.\r\n\r\nDocumentation can be found at the openEQUELLA [documentation site](https://openequella.github.io/).\r\n\r\n**Key features:**\r\n\r\n* **Administration Console Package** – this package bundles the Java Runtime Environment (JRE) with the Administration Console and allows users to access the Administration Console on local systems. This will remove the requirement to install Java locally and this package will be the access point to the Administration Console from openEQUELLA 2019.1 forward.\r\n\r\n* **Login Notice Editor** - openEQUELLA 2019.1 introduces the ability to create content using a rich text editor (TinyMCE 5.0.2) to display as a notice on the Login page.\r\n\r\n* **Support for Languages other than English** - expanded support for languages other than English in openEQUELLA’s search capabilities (such as recognising the specified language’s stop words, stemming, etc.).\r\n\r\n* **REST API Enhancements** – including search API documentation enhancements and the editing of attachments and metadata\r\n\r\n* **Cloud providers** – ability to register openEQUELLA with Cloud providers that deliver cloud services to openEQUELLA content.\r\n\r\n* **Enhanced Blackboard Integration** - a pure LTI / REST integration has started to be developed. This integration is available in this release as a 'beta' feature with a minimal set of functionality, and will be enhanced for 2019.2.\r\n\r\nFurther details can be found in the [openEQUELLA 2019.1 Features Guide](https://openequella.github.io/guides/featureGuides/featureGuide2019.1/openEQUELLA-2019.1-FeaturesGuide.html).",
+    release_date: "2019-07-31",
+    ref: "ad37d9a4da99bc5ba74eef7e3d2baf96cf08b56b",
   },
   {
-    url: "https://api.github.com/repos/openequella/openEQUELLA/releases/14652766",
-    assets_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/releases/14652766/assets",
-    upload_url:
-      "https://uploads.github.com/repos/openequella/openEQUELLA/releases/14652766/assets{?name,label}",
+    version: "2018.2.0",
     html_url:
       "https://github.com/openequella/openEQUELLA/releases/tag/2018.2-Stable",
-    id: 14652766,
-    node_id: "MDc6UmVsZWFzZTE0NjUyNzY2",
-    tag_name: "2018.2-Stable",
-    target_commitish: "master",
-    name: "2018.2",
-    draft: false,
-    author: {
-      login: "edalex-ian",
-      id: 43919233,
-      node_id: "MDQ6VXNlcjQzOTE5MjMz",
-      avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-      gravatar_id: "",
-      url: "https://api.github.com/users/edalex-ian",
-      html_url: "https://github.com/edalex-ian",
-      followers_url: "https://api.github.com/users/edalex-ian/followers",
-      following_url:
-        "https://api.github.com/users/edalex-ian/following{/other_user}",
-      gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-      starred_url:
-        "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-      subscriptions_url:
-        "https://api.github.com/users/edalex-ian/subscriptions",
-      organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-      repos_url: "https://api.github.com/users/edalex-ian/repos",
-      events_url: "https://api.github.com/users/edalex-ian/events{/privacy}",
-      received_events_url:
-        "https://api.github.com/users/edalex-ian/received_events",
-      type: "User",
-      site_admin: false,
-    },
-    prerelease: false,
-    created_at: "2018-12-21T00:20:22Z",
-    published_at: "2018-12-21T05:52:01Z",
-    assets: [
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/10255967",
-        id: 10255967,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDEwMjU1OTY3",
-        name: "equella-installer-2018.2.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 295101809,
-        download_count: 76,
-        created_at: "2018-12-21T05:38:13Z",
-        updated_at: "2018-12-21T05:42:40Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2018.2-Stable/equella-installer-2018.2.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/10255969",
-        id: 10255969,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDEwMjU1OTY5",
-        name: "reference-language-pack.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 130400,
-        download_count: 16,
-        created_at: "2018-12-21T05:38:14Z",
-        updated_at: "2018-12-21T05:42:43Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2018.2-Stable/reference-language-pack.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/10255968",
-        id: 10255968,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDEwMjU1OTY4",
-        name: "scriptingapi-javadoc-2018.2-Stable.OSE-r1-ga5e0b20.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 220179,
-        download_count: 10,
-        created_at: "2018-12-21T05:38:14Z",
-        updated_at: "2018-12-21T05:42:42Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2018.2-Stable/scriptingapi-javadoc-2018.2-Stable.OSE-r1-ga5e0b20.zip",
-      },
-      {
-        url: "https://api.github.com/repos/openequella/openEQUELLA/releases/assets/10255966",
-        id: 10255966,
-        node_id: "MDEyOlJlbGVhc2VBc3NldDEwMjU1OTY2",
-        name: "tle-upgrade-2018.2.r1.2018.2-Stable.OSE.zip",
-        label: null,
-        uploader: {
-          login: "edalex-ian",
-          id: 43919233,
-          node_id: "MDQ6VXNlcjQzOTE5MjMz",
-          avatar_url: "https://avatars3.githubusercontent.com/u/43919233?v=4",
-          gravatar_id: "",
-          url: "https://api.github.com/users/edalex-ian",
-          html_url: "https://github.com/edalex-ian",
-          followers_url: "https://api.github.com/users/edalex-ian/followers",
-          following_url:
-            "https://api.github.com/users/edalex-ian/following{/other_user}",
-          gists_url: "https://api.github.com/users/edalex-ian/gists{/gist_id}",
-          starred_url:
-            "https://api.github.com/users/edalex-ian/starred{/owner}{/repo}",
-          subscriptions_url:
-            "https://api.github.com/users/edalex-ian/subscriptions",
-          organizations_url: "https://api.github.com/users/edalex-ian/orgs",
-          repos_url: "https://api.github.com/users/edalex-ian/repos",
-          events_url:
-            "https://api.github.com/users/edalex-ian/events{/privacy}",
-          received_events_url:
-            "https://api.github.com/users/edalex-ian/received_events",
-          type: "User",
-          site_admin: false,
-        },
-        content_type: "application/zip",
-        state: "uploaded",
-        size: 279379717,
-        download_count: 19,
-        created_at: "2018-12-21T05:38:13Z",
-        updated_at: "2018-12-21T05:40:16Z",
-        browser_download_url:
-          "https://github.com/openequella/openEQUELLA/releases/download/2018.2-Stable/tle-upgrade-2018.2.r1.2018.2-Stable.OSE.zip",
-      },
-    ],
-    tarball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/tarball/2018.2-Stable",
-    zipball_url:
-      "https://api.github.com/repos/openequella/openEQUELLA/zipball/2018.2-Stable",
-    body: "**openEQUELLA 2018.2**\r\n\r\nPlease see https://version.openequella.net/ for future upgrades and changelogs.\r\n\r\nDocumentation can be found at the openEQUELLA [documentation site](https://openequella.github.io/).\r\n\r\nKey features:\r\n\r\n* **Views counts for summary pages and attachments** – Views counts can now be displayed for summary pages and attachments.\r\n* **Streamlined process for attaching EQUELLA resources during contribution** – an option to remove a number of dialogs during the selection of EQUELLA resources during contribution has been added.\r\n* **Course selector updated across EQUELLA** – the course selector has been updated to allow searching of Title, Code and Description with a scrollable list.\r\n* **HTTP Referrers added to log** – HTTP referrers are now recorded in the audit log to enable identification of an item’s LMS usage.\r\n* **Theme Editor (for New UI)** – a new Theme Editor is available to apply colour schemes to new UI components and upload logos.\r\n",
+    release_date: "2018-12-21",
+    ref: "08beeb46e9b4f64cdc59e817fcc2bc495d0cd8f0",
   },
 ];

--- a/Source/Plugins/Core/com.equella.core/test/javascript/versioncheck.test.ts
+++ b/Source/Plugins/Core/com.equella.core/test/javascript/versioncheck.test.ts
@@ -26,7 +26,7 @@ describe("versioncheck", () => {
     it("should support major updates", () => {
       const checkResult = createCheckResult("2018.1.0", mockData.mockReleases);
       expect(checkResult.newer).toBe(true);
-      expect(checkResult.newerReleases.majorUpdate.major).toBe("2019");
+      expect(checkResult.newerReleases.majorUpdate.major).toBe("2022");
     });
 
     it("should support minor updates", () => {
@@ -45,11 +45,11 @@ describe("versioncheck", () => {
       const patchUpdateRelease = checkResult.newerReleases.patchUpdate;
       expect(patchUpdateRelease.major).toBe("2019");
       expect(patchUpdateRelease.minor).toBe("2");
-      expect(patchUpdateRelease.patch).toBe("1");
+      expect(patchUpdateRelease.patch).toBe("6");
     });
 
     it("should do nothing when there are no updates", () => {
-      const checkResult = createCheckResult("2020.1.0", mockData.mockReleases);
+      const checkResult = createCheckResult("2022.1.0", mockData.mockReleases);
       expect(checkResult.newer).toBe(false);
 
       expect(checkResult.newerReleases.majorUpdate).toBeNull();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Rework versioncheck.js to consume new versions.json from openequella.github.io.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
