### PR TITLE
fix: add missing collection query in breadcrumb

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/navigation/SearchCollectionBreadcrumbProvider.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/navigation/SearchCollectionBreadcrumbProvider.java
@@ -38,10 +38,13 @@ import com.tle.web.sections.standard.model.HtmlComponentState;
 import com.tle.web.sections.standard.model.HtmlLinkState;
 import com.tle.web.sections.standard.model.SimpleBookmark;
 import com.tle.web.settings.UISettings;
+import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** @author aholland */
 @Bind
@@ -81,7 +84,19 @@ public class SearchCollectionBreadcrumbProvider implements BreadcrumbProvider {
     collectionLink.setLabel(label);
 
     if (UISettings.getUISettings().isNewSearchActive()) {
-      collectionLink.setBookmark(new SimpleBookmark("page/search"));
+      String baseBreadcrumbUrl = "page/search";
+      String query = "";
+      try {
+        query =
+            "?searchOptions="
+                + URLEncoder.encode(
+                    String.format("{\"collections\":[{\"uuid\": \"%s\"}]}", collectionUuid),
+                    "UTF-8");
+      } catch (Exception e) {
+        Logger LOGGER = LoggerFactory.getLogger(SearchCollectionBreadcrumbProvider.class);
+        LOGGER.warn("Failed to encode url:", e);
+      }
+      collectionLink.setBookmark(new SimpleBookmark(baseBreadcrumbUrl + query));
     } else {
       // "..page=<n>.." can be misleading (when the original search which
       // rendered the item we are now viewing was an "All Resources" search),

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/navigation/SearchCollectionBreadcrumbProvider.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/searching/navigation/SearchCollectionBreadcrumbProvider.java
@@ -38,6 +38,7 @@ import com.tle.web.sections.standard.model.HtmlComponentState;
 import com.tle.web.sections.standard.model.HtmlLinkState;
 import com.tle.web.sections.standard.model.SimpleBookmark;
 import com.tle.web.settings.UISettings;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.Map;
@@ -50,6 +51,9 @@ import org.slf4j.LoggerFactory;
 @Bind
 @Singleton
 public class SearchCollectionBreadcrumbProvider implements BreadcrumbProvider {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SearchCollectionBreadcrumbProvider.class);
+
   @PlugKey("breadcrumb.collection.untitled")
   private static Label LABEL_UNTITLED;
 
@@ -92,8 +96,7 @@ public class SearchCollectionBreadcrumbProvider implements BreadcrumbProvider {
                 + URLEncoder.encode(
                     String.format("{\"collections\":[{\"uuid\": \"%s\"}]}", collectionUuid),
                     "UTF-8");
-      } catch (Exception e) {
-        Logger LOGGER = LoggerFactory.getLogger(SearchCollectionBreadcrumbProvider.class);
+      } catch (UnsupportedEncodingException e) {
         LOGGER.warn("Failed to encode url:", e);
       }
       collectionLink.setBookmark(new SimpleBookmark(baseBreadcrumbUrl + query));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Add missing collection query in breadcrumb and "Collection" button in right menu in summary page.

Before:

https://user-images.githubusercontent.com/92769668/171098413-ce5bea8b-b74a-4758-b38b-779ecd0a5eaa.mp4

Now:

https://user-images.githubusercontent.com/92769668/171099165-adb5cee2-62a9-4238-a6d1-fb8d4cf2db2b.mp4


<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
