### PR TITLE
fix: portlet display in new UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
+++ b/Source/Plugins/Core/com.equella.core/resources/web/sass/legacy.scss
@@ -19,6 +19,7 @@
 @import "render/ajaxupload.css";
 @import "settings.css";
 @import "popupbrowser.css";
+@import "portal.css";
 @import "shufflebox.css";
 @import "treenavctl.css";
 @import "moderate.css";


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [x] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Import missing `portal.css` in `legacy.css`.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
Before:

https://user-images.githubusercontent.com/24543345/112783026-1369db80-909a-11eb-94db-f4a5bcfc7477.mp4

Now:

https://user-images.githubusercontent.com/92769668/172736421-0c3bc071-1d40-4849-af23-09821b2b474a.mp4

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
