### PR TITLE
chore(deps): remove unused plugin dep axis2-jaxbri

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,7 +38,6 @@ libraryDependencies ++= Seq(
   "org.apache.axis2" % "axis2-kernel"      % axis2Version,
   "org.apache.axis2" % "axis2-java2wsdl"   % axis2Version,
   "org.apache.axis2" % "axis2-adb"         % axis2Version,
-  "org.apache.axis2" % "axis2-jaxbri"      % axis2Version,
   "org.apache.axis2" % "axis2-adb-codegen" % axis2Version,
   "org.apache.axis2" % "axis2-codegen"     % axis2Version,
   "org.apache.axis2" % "axis2-xmlbeans"    % axis2Version


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

It would appear this is not actually required, as the build appears to
work fine without it. However keeping it there, we're blocked from
upgrading to axis 1.8+ as there is no version of this in that release -
release notes say they renamed it, but they don't say what to. (Well,
they do but there seems to be a typo as they say it is renamed to the
same name.)

Will help #4217 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
