### PR TITLE
Update the com.oracle.database.jdbc ojdbc8 from 19.3.0.0 to 19.16.0.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ ThisBuild / assemblyMergeStrategy := {
     false
   }
 }
-(ThisBuild / oracleDriverMavenCoordinate) := Seq("com.oracle.database.jdbc" % "ojdbc8" % "19.3.0.0")
+(ThisBuild / oracleDriverMavenCoordinate) := Seq("com.oracle.database.jdbc" % "ojdbc8" % "19.16.0.0")
 
 (ThisBuild / buildConfig) := Common.buildConfig
 

--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,8 @@ ThisBuild / assemblyMergeStrategy := {
     false
   }
 }
-(ThisBuild / oracleDriverMavenCoordinate) := Seq("com.oracle.database.jdbc" % "ojdbc8" % "19.16.0.0")
+(ThisBuild / oracleDriverMavenCoordinate) := Seq(
+  "com.oracle.database.jdbc" % "ojdbc8" % "19.16.0.0")
 
 (ThisBuild / buildConfig) := Common.buildConfig
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]

##### Description of change
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
resolves #4299 (this didn't work in the renovate branch as it required the build.sbt file to be re-linted).
Updates the com.oracle.database.jdbc ojdbc8 from 19.3.0.0 to 19.16.0.0.

I can confirm the new driver works, I tested it with Oracle Database 19c. 
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
