### PR TITLE
chore: remove the deprecated use of 'set-output' in GHA build config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-ivy-
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo name=NVMRC::$(cat .nvmrc) >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup node
@@ -138,7 +138,7 @@ jobs:
             ${{ runner.os }}-npm.storybook-
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo name=NVMRC::$(cat .nvmrc) >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup node
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo name=NVMRC::$(cat .nvmrc) >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup node
@@ -368,7 +368,7 @@ jobs:
           java-version: 8
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo name=NVMRC::$(cat .nvmrc) >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup node


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

`set-output` is deprecated so we need to update GHA build configuration to use the new approach.