### PR TITLE
chore: pin node version and npm version

### DIFF
--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -10,7 +10,8 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": "16.18.1",
+    "npm": "8.19.2"
   },
   "scripts": {
     "start": "rollup --config --watch --bundleConfigAsCjs",

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -13,6 +13,11 @@
     "parcelEntryFiles": "entrypoint/*.html entrypoint/scripts/*.js",
     "tools": "target/tools"
   },
+  "engines": {
+    "node": "16.18.1",
+    "npm": "8.19.2"
+  }
+  ,
   "scripts": {
     "prepare": "cross-env-shell \"cd ../oeq-ts-rest-api && npm ci && npm run build\"",
     "install": "cross-env-shell \"mkdirp ${npm_package_config_devlang} ${npm_package_config_buildlang}\"",

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -16,8 +16,7 @@
   "engines": {
     "node": "16.18.1",
     "npm": "8.19.2"
-  }
-  ,
+  },
   "scripts": {
     "prepare": "cross-env-shell \"cd ../oeq-ts-rest-api && npm ci && npm run build\"",
     "install": "cross-env-shell \"mkdirp ${npm_package_config_devlang} ${npm_package_config_buildlang}\"",


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Pin Node and NPM versions so that Renovate will use the correct versions to build.

The pinned Node version matches to the one specified in `.nvmrc`.