### PR TITLE
build (github): change order or node dep install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,10 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      - name: Install node dependencies (root)
+        run: |
+          npm ci
+
       - name: Install node dependencies (core)
         working-directory: react-front-end
         run: |
@@ -66,10 +70,6 @@ jobs:
 
       - name: Install node dependencies (IntegTester)
         working-directory: autotest/IntegTester/ps
-        run: |
-          npm ci
-
-      - name: Install node dependencies (root)
         run: |
           npm ci
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Install node dependencies (root)
+        run: |
+          npm ci
+
       - name: Install node dependencies (core)
         working-directory: react-front-end
         run: |


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
~~- [ ] tests are included~~
~~- [ ] screenshots are included showing significant UI changes~~
~~- [ ] documentation is changed or added~~

##### Description of change

Need to install the root node dependencies before the others, as the new io-ts code-gen relies on ESLint being installed from the root first.

An alternative could be to try and get the oeq-ts-rest-api to install ESLint before it starts the codegen, however this is probably easier (and all is working on the internal Edalex build - due to this order difference).

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
