### PR TITLE
fix: ScalaCheck tests

### DIFF
--- a/autotest/Tests/src/test/scala/equellatests/sections/wizard/UniversalControl.scala
+++ b/autotest/Tests/src/test/scala/equellatests/sections/wizard/UniversalControl.scala
@@ -1,13 +1,24 @@
 package equellatests.sections.wizard
 
 import equellatests.domain.TestFile
-import org.openqa.selenium.By
+import org.openqa.selenium.{By, StaleElementReferenceException, WebElement}
 import org.openqa.selenium.support.pagefactory.ByChained
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions}
 
 import scala.util.Try
 
 class UniversalControl(val page: WizardPageTab, val ctrlNum: Int) extends WizardControl {
+
+  private def isElementPresent(element: WebElement): Boolean = {
+    try {
+      // try to get text attribute
+      element.getText()
+      // if no exception, the element should still in dom
+      true
+    } catch {
+      case e => false
+    }
+  }
 
   private def actionLinkBy(action: String) =
     By.xpath("div/div/div[contains(@class, 'actions')]/div/a[text()=" + quoteXPath(action) + "]")
@@ -41,7 +52,10 @@ class UniversalControl(val page: WizardPageTab, val ctrlNum: Int) extends Wizard
   def cancelUpload(actualFilename: String) = {
     rowForDescription(actualFilename, true).map { row =>
       row.findElement(cancelBtnBy).click()
-      waitFor(ExpectedConditions.stalenessOf(row))
+      // make sure the element is till in dom before monitoring its state
+      if (isElementPresent(row)) {
+        waitFor(ExpectedConditions.stalenessOf(row))
+      }
     }
   }
 

--- a/autotest/Tests/src/test/scala/equellatests/sections/wizard/UniversalControl.scala
+++ b/autotest/Tests/src/test/scala/equellatests/sections/wizard/UniversalControl.scala
@@ -9,16 +9,8 @@ import scala.util.Try
 
 class UniversalControl(val page: WizardPageTab, val ctrlNum: Int) extends WizardControl {
 
-  private def isElementPresent(element: WebElement): Boolean = {
-    try {
-      // try to get text attribute
-      element.getText()
-      // if no exception, the element should still in dom
-      true
-    } catch {
-      case e => false
-    }
-  }
+  private def isElementPresent(element: WebElement): Boolean =
+    Try(element.isDisplayed).getOrElse(false)
 
   private def actionLinkBy(action: String) =
     By.xpath("div/div/div[contains(@class, 'actions')]/div/a[text()=" + quoteXPath(action) + "]")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
In `UniversalControl`,  the exception is raised from `ExpectedConditions.stalenessOf(row)`. 

And the error message says it can't find the node with the given id.

Consider we updated the web driver and the above code will remove the `row` element from dom,
so I think it's possible the element is already been moved before we do `ExpectedConditions.stalenessOf(row)`.

Thus I add a new function to check if the element is still there before calling `ExpectedConditions.stalenessOf(row)`.


<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
