### PR TITLE
fix(selenium test): check the element before stalenessOf

### DIFF
--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/ExpectedConditions2.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/ExpectedConditions2.java
@@ -46,7 +46,7 @@ public class ExpectedConditions2 {
           try {
             realElement.isDisplayed();
             return null;
-          } catch (StaleElementReferenceException se) {
+          } catch (Exception se) {
             checkingStale = false;
           }
         }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/ExpectedConditions2.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/ExpectedConditions2.java
@@ -314,7 +314,7 @@ public class ExpectedConditions2 {
           try {
             realElement.isDisplayed();
             return null;
-          } catch (StaleElementReferenceException se) {
+          } catch (WebDriverException se) {
             checkingStale = false;
           }
         }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/searching/AbstractResultList.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/searching/AbstractResultList.java
@@ -3,6 +3,7 @@ package com.tle.webtests.pageobject.searching;
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.pageobject.AbstractPage;
 import com.tle.webtests.pageobject.ExpectWaiter;
+import com.tle.webtests.pageobject.ExpectedConditions2;
 import com.tle.webtests.pageobject.PrefixedName;
 import com.tle.webtests.pageobject.WaitingPageObject;
 import java.util.ArrayList;
@@ -11,7 +12,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.internal.WrapsElement;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public abstract class AbstractResultList<
@@ -32,33 +32,16 @@ public abstract class AbstractResultList<
     return getResultsDiv();
   }
 
-  private boolean isElementPresent(WebElement element) {
-    try {
-      return element.isDisplayed();
-    } catch (Exception e) {
-      return false;
-    }
-  }
-
   public WaitingPageObject<T> getUpdateWaiter() {
     WebElement firstChild =
         ((WrapsElement) getResultsDiv().findElement(By.xpath("*[1]"))).getWrappedElement();
-
-    ExpectedCondition<WebElement> showResult =
-        ExpectedConditions.visibilityOfElementLocated(
-            By.xpath("id('searchresults')[div[@class='itemlist'] or h3]"));
-    ExpectedCondition<Boolean> alwaysTrue = driver -> true;
-    ExpectedCondition<Boolean> staleFirstChild =
-        driver -> {
-          if (isElementPresent(firstChild)) {
-            return ExpectedConditions.stalenessOf(firstChild).apply(driver);
-          } else {
-            return alwaysTrue.apply(driver);
-          }
-        };
-
-    return ExpectWaiter.waiter(ExpectedConditions.and(staleFirstChild, showResult), this);
-  }
+    return ExpectWaiter.waiter(
+        ExpectedConditions.and(
+            ExpectedConditions2.stalenessOrNonPresenceOf(firstChild),
+            ExpectedConditions.visibilityOfElementLocated(
+                By.xpath("id('searchresults')[div[@class='itemlist'] or h3]"))),
+        this);
+  };
 
   protected static String getXPathForTitle(String title) {
     return "//div/div[contains(@class,'itemresult-wrapper') and .//h3/a[normalize-space(string())="


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Same issue with [!4700](https://github.com/openequella/openEQUELLA/pull/4700). The element has been removed before we monitor it.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
