### PR TITLE
fix: update dependency com.thoughtworks.xstream:xstream to v1…

### DIFF
--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/xml/service/impl/XmlServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/xml/service/impl/XmlServiceImpl.java
@@ -22,6 +22,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.core.util.ClassLoaderReference;
 import com.thoughtworks.xstream.core.util.CompositeClassLoader;
 import com.thoughtworks.xstream.io.xml.XppDriver;
+import com.thoughtworks.xstream.security.WildcardTypePermission;
 import com.tle.common.security.streaming.XStreamSecurityManager;
 import com.tle.core.guice.Bind;
 import com.tle.core.xml.service.XmlService;
@@ -34,9 +35,14 @@ import javax.inject.Singleton;
 @Singleton
 public final class XmlServiceImpl implements XmlService {
   private final XStream xstream;
+  private final WildcardTypePermission xstreamTypePermission;
 
   public XmlServiceImpl() {
     xstream = new ExtXStream(null);
+    /** Allow all inner classes for the DRMPage class. */
+    xstreamTypePermission =
+        new WildcardTypePermission(true, new String[] {"com.dytech.edge.wizard.beans.DRMPage**"});
+    xstream.addPermission(xstreamTypePermission);
   }
 
   @Override
@@ -50,7 +56,9 @@ public final class XmlServiceImpl implements XmlService {
 
   @Override
   public XStream createDefault(ClassLoader loader) {
-    return new ExtXStream(loader);
+    XStream xs = new ExtXStream(loader);
+    xs.addPermission(xstreamTypePermission);
+    return xs;
   }
 
   @Override

--- a/autotest/OldTests/build.sbt
+++ b/autotest/OldTests/build.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
   // The older Log4j is required by dependency "oclc-harvester2" at runtime.
   "log4j"                    % "log4j"              % "1.2.17" % Test,
   "commons-httpclient"       % "commons-httpclient" % "3.1"    % Test,
-  "com.thoughtworks.xstream" % "xstream"            % "1.4.19" % Test
+  "com.thoughtworks.xstream" % "xstream"            % "1.4.20" % Test
 )
 
 /*

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -54,7 +54,7 @@ object CommonSettings extends AutoPlugin {
     lazy val springAop     = "org.springframework" % "spring-aop" % springVersion
     lazy val springContext = "org.springframework" % "spring-context" % springVersion
 
-    lazy val xstreamVersion = "1.4.19"
+    lazy val xstreamVersion = "1.4.20"
     lazy val xstreamDep     = "com.thoughtworks.xstream" % "xstream" % xstreamVersion
 
     lazy val jacksonVersion        = "2.15.2"


### PR DESCRIPTION
To fix #4547.
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
Since version 20, `The WildcardTypePermission allows by default no longer anonymous class types`.
https://x-stream.github.io/changes.html

I have updated the xstream config.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
