### PR TITLE
fix: com.puppycrawl.tools checkstyle 10.x

### DIFF
--- a/Installer/src/com/dytech/installer/controls/GPassword.java
+++ b/Installer/src/com/dytech/installer/controls/GPassword.java
@@ -93,7 +93,7 @@ public class GPassword extends GuiControl {
     }
   }
 
-  private static class ConfirmPassword {
+  private static final class ConfirmPassword {
     private boolean confirmed = false;
 
     private ConfirmPassword(final JPasswordField fieldToConfirm) {

--- a/Platform/Infrastructure/com.tle.jpfclasspath/src/com/tle/jpfclasspath/model/JPFPluginModelManager.java
+++ b/Platform/Infrastructure/com.tle.jpfclasspath/src/com/tle/jpfclasspath/model/JPFPluginModelManager.java
@@ -22,7 +22,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 
-public class JPFPluginModelManager implements IModelProviderListener {
+public final class JPFPluginModelManager implements IModelProviderListener {
   private static JPFPluginModelManager instance;
   private WorkspaceJarModelManager jarManager;
   private WorkspacePluginModelManager projectManager;

--- a/Platform/Plugins/com.tle.platform.common/src/com/dytech/common/net/NetworkUtils.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/dytech/common/net/NetworkUtils.java
@@ -26,7 +26,7 @@ import java.net.SocketException;
 import java.util.Enumeration;
 import java.util.List;
 
-public class NetworkUtils {
+public final class NetworkUtils {
   /**
    * @return a bunch of InetAddresses that are "real", ie, not virtual, loopback, multicast and are
    *     up.

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/NamedThreadFactory.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/NamedThreadFactory.java
@@ -46,7 +46,7 @@ public class NamedThreadFactory implements ThreadFactory {
     }
   }
 
-  private static class Builder implements Callable<AtomicInteger> {
+  private static final class Builder implements Callable<AtomicInteger> {
     @Override
     public AtomicInteger call() throws Exception {
       return new AtomicInteger(1);

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/hash/Hash.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/hash/Hash.java
@@ -87,7 +87,7 @@ public class Hash {
     String getDigest(String value);
   }
 
-  private static class SHA1Digester implements HashDigester {
+  private static final class SHA1Digester implements HashDigester {
     @SuppressWarnings("nls")
     private static final String customSalt = System.getProperty("equella.salt");
 
@@ -100,7 +100,7 @@ public class Hash {
     }
   }
 
-  private static class MD5Digester implements HashDigester {
+  private static final class MD5Digester implements HashDigester {
     @Override
     public String getDigest(String value) {
       return new Md5(value).getStringDigest();

--- a/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/CachedPropertyInfo.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/tle/common/util/CachedPropertyInfo.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-public class CachedPropertyInfo {
+public final class CachedPropertyInfo {
   private static CacheHolder cache = new CacheHolder();
 
   private Map<String, PropertyDescriptor> propertyMap = Maps.newHashMap();
@@ -75,7 +75,7 @@ public class CachedPropertyInfo {
     return cache.getForClass(clazz);
   }
 
-  private static class CacheHolder extends CachedClassData<CachedPropertyInfo> {
+  private static final class CacheHolder extends CachedClassData<CachedPropertyInfo> {
     @Override
     protected CachedPropertyInfo newEntry(Class<?> clazz) {
       try {

--- a/Platform/Plugins/com.tle.platform.common/test/java/com/dytech/common/text/HTMLParserTest.java
+++ b/Platform/Plugins/com.tle.platform.common/test/java/com/dytech/common/text/HTMLParserTest.java
@@ -88,7 +88,7 @@ public class HTMLParserTest extends TestCase {
     void parse(HTMLParser parser) throws Exception;
   }
 
-  private static class DefaultParserTester implements ParserTester {
+  private static final class DefaultParserTester implements ParserTester {
     @Override
     public void parse(HTMLParser parser) throws Exception {
       // Just read through the whole stream to make sure it parses
@@ -99,7 +99,7 @@ public class HTMLParserTest extends TestCase {
     }
   }
 
-  private static class Html1Tester implements ParserTester {
+  private static final class Html1Tester implements ParserTester {
     @Override
     public void parse(HTMLParser parser) throws Exception {
       Tag tag = parser.getNextTag();

--- a/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/registry/TreeRegistry.java
+++ b/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/registry/TreeRegistry.java
@@ -225,7 +225,7 @@ public class TreeRegistry implements RegistrationController {
     }
   }
 
-  private static class SectionTreeData {
+  private static final class SectionTreeData {
     SectionTree tree;
     boolean url;
   }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/remotesqlquerying/SqlConnectionAndQueryPanel.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/remotesqlquerying/SqlConnectionAndQueryPanel.java
@@ -223,7 +223,7 @@ public class SqlConnectionAndQueryPanel extends JPanel implements Changeable {
     return CurrentLocale.get(KEY_PFX + keyEnd);
   }
 
-  private static class Editor extends JPanel implements ListWithViewInterface<QueryState> {
+  private static final class Editor extends JPanel implements ListWithViewInterface<QueryState> {
     private JLabel description;
     private JTextArea sql;
     private String originalSql;

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/taxonomy/tool/internal/TermEditor.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/taxonomy/tool/internal/TermEditor.java
@@ -166,7 +166,7 @@ public class TermEditor extends AbstractTreeNodeEditor {
     }
   }
 
-  private static class DataEditor extends JPanel implements ListWithViewInterface<DataEntry> {
+  private static final class DataEditor extends JPanel implements ListWithViewInterface<DataEntry> {
     private JTextArea data;
     private String originalData;
 

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/filesystem/FileSystemConstants.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/filesystem/FileSystemConstants.java
@@ -19,7 +19,7 @@
 package com.tle.common.filesystem;
 
 /** @author Aaron */
-public class FileSystemConstants {
+public final class FileSystemConstants {
   public static final String IMS_FOLDER = "_IMS";
 
   private FileSystemConstants() {

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/hierarchy/VirtualTopicUtils.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/hierarchy/VirtualTopicUtils.java
@@ -24,7 +24,7 @@ import com.tle.common.URLUtils;
 import java.util.Map;
 
 /** @author larry Culled form TopicUtils, moved to more widely accessible common namespace */
-public class VirtualTopicUtils {
+public final class VirtualTopicUtils {
   public static String buildTopicId(
       HierarchyTopic topic, String value, Map<String, String> parentValues) {
     // Short-cut!

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/dispatcher/ServletDispatcher.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/dispatcher/ServletDispatcher.java
@@ -40,7 +40,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.java.plugin.registry.Extension;
 import org.java.plugin.registry.Extension.Parameter;
 
-public class ServletDispatcher {
+public final class ServletDispatcher {
   private static final String DISPATCHER_KEY = "ServletDispatcher"; // $NON-NLS-1$
   private final PluginTracker<HttpServlet> servletTracker;
   private final Set<Extension> initedServlets =

--- a/Source/Plugins/Core/com.equella.base/test/java/com/tle/core/xstream/TLEXStreamTest.java
+++ b/Source/Plugins/Core/com.equella.base/test/java/com/tle/core/xstream/TLEXStreamTest.java
@@ -31,7 +31,7 @@ public class TLEXStreamTest extends TestCase {
     assertEquals("string", bean.string);
   }
 
-  private static class TestBean {
+  private static final class TestBean {
     String string;
   }
 }

--- a/Source/Plugins/Core/com.equella.base/test/java/com/tle/core/xstream/XMLDataConverterTest.java
+++ b/Source/Plugins/Core/com.equella.base/test/java/com/tle/core/xstream/XMLDataConverterTest.java
@@ -829,7 +829,7 @@ public class XMLDataConverterTest extends TestCase {
     }
   }
 
-  private static class OverideBean extends TestBean2 {
+  private static final class OverideBean extends TestBean2 {
     private static final long serialVersionUID = 1L;
     // Empty on purpose!
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/dytech/edge/ejb/helpers/metadata/mappers/XPathMapper.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/dytech/edge/ejb/helpers/metadata/mappers/XPathMapper.java
@@ -394,7 +394,7 @@ public class XPathMapper extends Mapper {
     }
   }
 
-  private static class NodeEvent {
+  private static final class NodeEvent {
     int status;
     String name;
     String text;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardConnectorServiceImpl.java
@@ -1104,7 +1104,8 @@ public class BlackboardConnectorServiceImpl extends AbstractIntegrationConnector
     }
   }
 
-  private static class CustomConfigurator extends DeploymentEngine implements AxisConfigurator {
+  private static final class CustomConfigurator extends DeploymentEngine
+      implements AxisConfigurator {
     @Override
     public void loadServices() {
       // Do we really need????

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/brightspace/service/impl/BrightspaceConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/brightspace/service/impl/BrightspaceConnectorServiceImpl.java
@@ -1135,7 +1135,7 @@ public class BrightspaceConnectorServiceImpl extends AbstractIntegrationConnecto
     }
   }
 
-  private static class CourseOfferingTransformer
+  private static final class CourseOfferingTransformer
       implements Function<CourseOffering, ConnectorCourse> {
     @Override
     public ConnectorCourse apply(CourseOffering course) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/canvas/service/CanvasConnectorService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/canvas/service/CanvasConnectorService.java
@@ -868,7 +868,8 @@ public class CanvasConnectorService extends AbstractIntegrationConnectorResposit
     return null;
   }
 
-  private static class CourseTransformer implements Function<CanvasCourseBean, ConnectorCourse> {
+  private static final class CourseTransformer
+      implements Function<CanvasCourseBean, ConnectorCourse> {
     @Override
     public ConnectorCourse apply(CanvasCourseBean canvasCourse) {
       final String state = canvasCourse.getState();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/index/ItemIndex.java
@@ -1409,7 +1409,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
     this.defaultOperator = defaultOperator;
   }
 
-  private static class CountingCollector extends Collector {
+  private static final class CountingCollector extends Collector {
     private int count = 0;
 
     public int getCount() {
@@ -1447,7 +1447,7 @@ public abstract class ItemIndex<T extends FreetextResult> extends AbstractIndexE
     }
   }
 
-  private static class BitSetCollector extends Collector {
+  private static final class BitSetCollector extends Collector {
     private int docBase;
     private final OpenBitSet bitSet = new OpenBitSet();
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/convert/TransactionThreadPool.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/convert/TransactionThreadPool.java
@@ -70,7 +70,7 @@ public class TransactionThreadPool {
     return closing;
   }
 
-  private class TransactionThread extends AuthenticatedThread {
+  private final class TransactionThread extends AuthenticatedThread {
     private Runnable runnable;
     private boolean end;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v52/ConvertNtextDatabaseMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v52/ConvertNtextDatabaseMigration.java
@@ -173,7 +173,7 @@ public class ConvertNtextDatabaseMigration extends AbstractHibernateSchemaMigrat
     return new Class[] {};
   }
 
-  private static class ColMeta {
+  private static final class ColMeta {
     public boolean nullable;
     public String name;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v52/ConvertVarcharDatabaseMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/institution/migration/v52/ConvertVarcharDatabaseMigration.java
@@ -178,7 +178,7 @@ public class ConvertVarcharDatabaseMigration extends AbstractHibernateSchemaMigr
     return new Class[] {};
   }
 
-  private static class ColMeta {
+  private static final class ColMeta {
     public boolean nullable;
     public int size;
     public String name;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/filter/UserDeletedFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/filter/UserDeletedFilter.java
@@ -25,7 +25,7 @@ import com.tle.core.item.operations.WorkflowOperation;
 /** @author jmaginnis */
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class UserDeletedFilter extends AbstractUserFilter // NOSONAR
+public final class UserDeletedFilter extends AbstractUserFilter // NOSONAR
 {
   @AssistedInject
   private UserDeletedFilter(@Assisted String userID) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ChangeUserIdOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ChangeUserIdOperation.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class ChangeUserIdOperation extends AbstractStandardWorkflowOperation // NOSONAR
+public final class ChangeUserIdOperation extends AbstractStandardWorkflowOperation // NOSONAR
 {
   private String fromUser;
   private String toUser;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ForceModificationOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ForceModificationOperation.java
@@ -22,7 +22,7 @@ import com.google.inject.assistedinject.AssistedInject;
 
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class ForceModificationOperation extends AbstractStandardWorkflowOperation // NOSONAR
+public final class ForceModificationOperation extends AbstractStandardWorkflowOperation // NOSONAR
 {
   @AssistedInject
   private ForceModificationOperation() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ModifyCollaboratorsOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ModifyCollaboratorsOperation.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class ModifyCollaboratorsOperation extends AbstractStandardWorkflowOperation // NOSONAR
+public final class ModifyCollaboratorsOperation extends AbstractStandardWorkflowOperation // NOSONAR
 {
   private boolean remove;
   private boolean bulkAdd;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ModifyNotificationsOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/ModifyNotificationsOperation.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class ModifyNotificationsOperation extends AbstractStandardWorkflowOperation // NOSONAR
+public final class ModifyNotificationsOperation extends AbstractStandardWorkflowOperation // NOSONAR
 {
   private Set<String> userIds;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/SetItemThumbnailOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/SetItemThumbnailOperation.java
@@ -22,7 +22,7 @@ import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import com.tle.beans.item.Item;
 
-public class SetItemThumbnailOperation extends AbstractStandardWorkflowOperation {
+public final class SetItemThumbnailOperation extends AbstractStandardWorkflowOperation {
   private final String thumb;
 
   @AssistedInject

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/UserDeletedOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/standard/operations/UserDeletedOperation.java
@@ -24,7 +24,7 @@ import com.google.inject.assistedinject.AssistedInject;
 /** @author jmaginnis */
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class UserDeletedOperation extends AbstractStandardWorkflowOperation // NOSONAR
+public final class UserDeletedOperation extends AbstractStandardWorkflowOperation // NOSONAR
 {
   private final String user;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/oauth/convert/OAuthTokenConverter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/oauth/convert/OAuthTokenConverter.java
@@ -149,7 +149,7 @@ public class OAuthTokenConverter extends AbstractConverter<OAuthToken> {
     return xstream;
   }
 
-  private class ClientXStreamConverter implements Converter {
+  private final class ClientXStreamConverter implements Converter {
     @SuppressWarnings("rawtypes")
     @Override
     public boolean canConvert(Class clazz) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/qti/service/impl/QtiServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/qti/service/impl/QtiServiceImpl.java
@@ -209,7 +209,7 @@ public class QtiServiceImpl implements QtiService {
     return testSessionController;
   }
 
-  private class LoggingNotificationListener implements NotificationListener {
+  private final class LoggingNotificationListener implements NotificationListener {
     @Override
     public void onNotification(Notification notification) {
       final NotificationType notificationType = notification.getNotificationType();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/remoterepo/equella/service/impl/EquellaRepoServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/remoterepo/equella/service/impl/EquellaRepoServiceImpl.java
@@ -369,7 +369,7 @@ public class EquellaRepoServiceImpl implements EquellaRepoService {
     }
   }
 
-  private static class XFireReturnTypeConfig extends AbstractServiceConfiguration {
+  private static final class XFireReturnTypeConfig extends AbstractServiceConfiguration {
     @Override
     public QName getInParameterName(OperationInfo op, Method method, int paramNumber) {
       return new QName(op.getName().getNamespaceURI(), "in" + paramNumber);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/security/convert/migration/v52/MergeOneClickSubmitAndVersionSelectionDatabaseMigration.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/security/convert/migration/v52/MergeOneClickSubmitAndVersionSelectionDatabaseMigration.java
@@ -85,7 +85,7 @@ public class MergeOneClickSubmitAndVersionSelectionDatabaseMigration
   @SuppressWarnings("unused")
   @Entity(name = "AccessEntry")
   @AccessType("field")
-  private static class FakeAccessEntry {
+  private static final class FakeAccessEntry {
     @Id public long id;
     public String targetObject;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/item/relation/RelationOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/item/relation/RelationOperation.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
 
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class RelationOperation extends AbstractWorkflowOperation // NOSONAR
+public final class RelationOperation extends AbstractWorkflowOperation // NOSONAR
 {
   @Inject private RelationService relationService;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/user/impl/UserServiceImpl.java
@@ -772,7 +772,7 @@ public class UserServiceImpl
     return loggedoutUri;
   }
 
-  private static class InstitutionState {
+  private static final class InstitutionState {
     UserDirectoryChain chain;
     Collection<UserManagementLogonFilter> filters;
     Map<?, ?> attributes;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/url/CheckURLsScheduledTask.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/url/CheckURLsScheduledTask.java
@@ -124,7 +124,7 @@ public class CheckURLsScheduledTask implements ScheduledTask {
     }
   }
 
-  private class ReferencedURLIterator extends BatchingIterator<ReferencedURL> {
+  private final class ReferencedURLIterator extends BatchingIterator<ReferencedURL> {
     private static final int BATCH_SIZE = 200;
 
     @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/ldap/MemberOfGroupSearch.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/usermanagement/standard/ldap/MemberOfGroupSearch.java
@@ -368,7 +368,7 @@ public class MemberOfGroupSearch extends GroupSearch {
     return new AndFilter(ldap.getGroupSearchFilter(query), groupsFilter);
   }
 
-  private class SubgroupResultHitsCollector
+  private final class SubgroupResultHitsCollector
       extends HitsCollector<SubgroupResultHitsCollector.SubgroupResult> {
     private String[] returnAttributes;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/util/ims/IMSUtilities.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/util/ims/IMSUtilities.java
@@ -198,7 +198,7 @@ public final class IMSUtilities {
   // ////////////////// HELPER CLASSES
   // /////////////////////////////////////////////////////////
 
-  private static class CollectionHashMap<K, V> extends HashMap<K, Collection<V>> {
+  private static final class CollectionHashMap<K, V> extends HashMap<K, Collection<V>> {
     private static final long serialVersionUID = 1L;
 
     public void add(K key, V value) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/ims/export/IMSExporter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/ims/export/IMSExporter.java
@@ -453,7 +453,7 @@ public class IMSExporter extends AbstractPrototypeSection<IMSExporterModel>
     attachmentExporters.setBeanKey("class");
   }
 
-  private static class RootItemInfo {
+  private static final class RootItemInfo {
     private boolean hasAttachments;
 
     public boolean hasAttachments() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/integration/lti/brightspace/guice/BrightspaceIntegrationModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/integration/lti/brightspace/guice/BrightspaceIntegrationModule.java
@@ -60,7 +60,7 @@ public class BrightspaceIntegrationModule extends SectionsModule {
     }
   }
 
-  private class BrightspaceLtiOptionalModule extends OptionalConfigModule {
+  private final class BrightspaceLtiOptionalModule extends OptionalConfigModule {
     @Override
     protected void configure() {
       bindProp("brightspace.parameter.username", "ext_d2l_username");

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mycontent/workflow/operations/EditMyContentOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mycontent/workflow/operations/EditMyContentOperation.java
@@ -43,7 +43,7 @@ import javax.inject.Inject;
 
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class EditMyContentOperation extends AbstractWorkflowOperation // NOSONAR
+public final class EditMyContentOperation extends AbstractWorkflowOperation // NOSONAR
 {
   private final String filename;
   private final boolean removeExistingAttachments;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/web/section/AbstractMyPagesPageActionsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/web/section/AbstractMyPagesPageActionsSection.java
@@ -235,7 +235,7 @@ public abstract class AbstractMyPagesPageActionsSection
     return pagesTable;
   }
 
-  private class MyPagesModel extends DynamicSelectionsTableModel<HtmlAttachment> {
+  private final class MyPagesModel extends DynamicSelectionsTableModel<HtmlAttachment> {
     @Override
     protected List<HtmlAttachment> getSourceList(SectionInfo info) {
       final MyPagesContributeModel contribModel = contribSection.getModel(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/workflow/operation/EditMyPagesOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/workflow/operation/EditMyPagesOperation.java
@@ -38,7 +38,7 @@ import java.util.Date;
 import java.util.Iterator;
 import javax.inject.Inject;
 
-public class EditMyPagesOperation extends AbstractWorkflowOperation {
+public final class EditMyPagesOperation extends AbstractWorkflowOperation {
   private final InputStream inputStream;
   private final String filename;
   private final boolean removeExistingAttachments;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/workflow/operation/UnusedContentCleanupOperation.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/mypages/workflow/operation/UnusedContentCleanupOperation.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 /** @author aholland */
 // Sonar maintains that 'Class cannot be instantiated and does not provide any
 // static methods or fields', but methinks thats bunkum
-public class UnusedContentCleanupOperation extends AbstractWorkflowOperation // NOSONAR
+public final class UnusedContentCleanupOperation extends AbstractWorkflowOperation // NOSONAR
 {
   private static final Logger LOGGR = LoggerFactory.getLogger(UnusedContentCleanupOperation.class);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/schema/impl/SchemaEditorImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/schema/impl/SchemaEditorImpl.java
@@ -153,7 +153,7 @@ public class SchemaEditorImpl extends AbstractBaseEntityEditor<Schema, SchemaBea
   }
 
   @Nullable
-  private List<TSchemaNode> buildNodeTree(
+  private final List<TSchemaNode> buildNodeTree(
       @Nullable TSchemaNode parent, @Nullable Map<String, SchemaNodeBean> def) {
     if (def == null) {
       return null;
@@ -186,7 +186,7 @@ public class SchemaEditorImpl extends AbstractBaseEntityEditor<Schema, SchemaBea
   }
 
   @NonNullByDefault(false)
-  private static class TSchemaNode {
+  private static final class TSchemaNode {
     private List<TSchemaNode> childNodes;
     private String name;
     private boolean attribute;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/emailselector/EmailSelectorWebControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/emailselector/EmailSelectorWebControl.java
@@ -235,7 +235,7 @@ public class EmailSelectorWebControl
     return selectedTable;
   }
 
-  private class EmailsModel extends DynamicSelectionsTableModel<String> {
+  private final class EmailsModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       return storageControl.getValues();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/groupselector/GroupSelectorWebControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/groupselector/GroupSelectorWebControl.java
@@ -224,7 +224,7 @@ public class GroupSelectorWebControl
     return groupsTable;
   }
 
-  private class GroupsModel extends DynamicSelectionsTableModel<String> {
+  private final class GroupsModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       return storageControl.getValues();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/roleselector/RoleSelectorWebControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/roleselector/RoleSelectorWebControl.java
@@ -220,7 +220,7 @@ public class RoleSelectorWebControl
     return rolesTable;
   }
 
-  private class RolesModel extends DynamicSelectionsTableModel<String> {
+  private final class RolesModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       return storageControl.getValues();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/universal/AbstractDetailsAttachmentHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/universal/AbstractDetailsAttachmentHandler.java
@@ -542,7 +542,7 @@ public abstract class AbstractDetailsAttachmentHandler<
     }
   }
 
-  private class ViewersListModel extends DynamicHtmlListModel<NameValue> {
+  private final class ViewersListModel extends DynamicHtmlListModel<NameValue> {
     @Override
     protected Iterable<NameValue> populateModel(SectionInfo info) {
       final String mimeType = getMimeType(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/userselector/UserSelectorWebControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/userselector/UserSelectorWebControl.java
@@ -229,7 +229,7 @@ public class UserSelectorWebControl
     return usersTable;
   }
 
-  private class UsersModel extends DynamicSelectionsTableModel<String> {
+  private final class UsersModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       return storageControl.getValues();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/webdav/WebDavControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/webdav/WebDavControl.java
@@ -133,7 +133,7 @@ public class WebDavControl extends AbstractWebControl<WebControlModel> {
     return filesTable;
   }
 
-  private class FilesModel extends DynamicSelectionsTableModel<FileAttachment> {
+  private final class FilesModel extends DynamicSelectionsTableModel<FileAttachment> {
     @Override
     protected List<FileAttachment> getSourceList(SectionInfo info) {
       return getFiles();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/LoggingContextFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/core/filter/LoggingContextFilter.java
@@ -105,7 +105,7 @@ public class LoggingContextFilter extends AbstractWebFilter {
 
   // This is for DEV ONLY.  Do not use in a test / staging / prod environment.
   // There is no guarantee that all sensitive information will be blanked!
-  private static class RequestLogger {
+  private static final class RequestLogger {
     private static final Logger REQUEST_LOGGER =
         LoggerFactory.getLogger(LoggingContextFilter.class.getName() + ".RequestLogger");
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/echo/section/EchoServerListSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/echo/section/EchoServerListSection.java
@@ -151,7 +151,7 @@ public class EchoServerListSection
     return ListEchoServersSectionModel.class;
   }
 
-  private class EchoServerModel extends DynamicSelectionsTableModel<BaseEntityLabel> {
+  private final class EchoServerModel extends DynamicSelectionsTableModel<BaseEntityLabel> {
     @Override
     protected List<BaseEntityLabel> getSourceList(SectionInfo info) {
       return echoService.listEditable();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/entities/section/AbstractShowEntitiesSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/entities/section/AbstractShowEntitiesSection.java
@@ -439,7 +439,7 @@ public abstract class AbstractShowEntitiesSection<
     // Nothing by default
   }
 
-  private class EntitiesListModel extends DynamicSelectionsTableModel<E> {
+  private final class EntitiesListModel extends DynamicSelectionsTableModel<E> {
     @Override
     protected List<E> getSourceList(SectionInfo info) {
       return getEntityList(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/ItemListModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/itemlist/ItemListModule.java
@@ -29,7 +29,7 @@ public class ItemListModule extends SectionsModule {
     install(new Trackers());
   }
 
-  private static class Trackers extends PluginTrackerModule {
+  private static final class Trackers extends PluginTrackerModule {
     @Override
     protected String getPluginId() {
       return "com.tle.web.itemlist";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/language/RootLanguageSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/language/RootLanguageSection.java
@@ -273,7 +273,7 @@ public class RootLanguageSection extends OneColumnLayout<OneColumnLayout.OneColu
     }
   }
 
-  private class ContributionLanguageTableModel extends DynamicSelectionsTableModel<String> {
+  private final class ContributionLanguageTableModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       List<Language> langList = langService.getLanguages();
@@ -305,7 +305,7 @@ public class RootLanguageSection extends OneColumnLayout<OneColumnLayout.OneColu
     }
   }
 
-  private class LocaleLanguageTableModel extends DynamicSelectionsTableModel<Locale> {
+  private final class LocaleLanguageTableModel extends DynamicSelectionsTableModel<Locale> {
     @Override
     protected List<Locale> getSourceList(SectionInfo info) {
       return langService.listAvailableResourceBundles();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/lti/consumers/section/LtiConsumerEditorSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/lti/consumers/section/LtiConsumerEditorSection.java
@@ -636,7 +636,7 @@ public class LtiConsumerEditorSection
     }
   }
 
-  private class CustomRoleTableModel extends DynamicSelectionsTableModel<CustomRoleMapping> {
+  private final class CustomRoleTableModel extends DynamicSelectionsTableModel<CustomRoleMapping> {
 
     @Override
     protected Collection<CustomRoleMapping> getSourceList(SectionInfo info) {
@@ -661,7 +661,7 @@ public class LtiConsumerEditorSection
     }
   }
 
-  private class GroupsTableModel extends DynamicSelectionsTableModel<SelectedGroup> {
+  private final class GroupsTableModel extends DynamicSelectionsTableModel<SelectedGroup> {
 
     @Override
     protected Collection<SelectedGroup> getSourceList(SectionInfo info) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/lti/guice/LtiModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/lti/guice/LtiModule.java
@@ -28,7 +28,7 @@ public class LtiModule extends SectionsModule {
     install(new LtiTrackerModule());
   }
 
-  private static class LtiTrackerModule extends PluginTrackerModule {
+  private static final class LtiTrackerModule extends PluginTrackerModule {
     @Override
     protected String getPluginId() {
       return "com.tle.web.lti";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/oauth/section/ShowOAuthSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/oauth/section/ShowOAuthSection.java
@@ -255,7 +255,7 @@ public class ShowOAuthSection
     return tokenTable;
   }
 
-  private class OAuthClientsModel extends DynamicSelectionsTableModel<OAuthClient> {
+  private final class OAuthClientsModel extends DynamicSelectionsTableModel<OAuthClient> {
     @Override
     protected List<OAuthClient> getSourceList(SectionInfo info) {
       return oauthService.enumerateEditable();
@@ -290,7 +290,7 @@ public class ShowOAuthSection
     }
   }
 
-  private class OAuthTokensModel extends DynamicSelectionsTableModel<OAuthToken> {
+  private final class OAuthTokensModel extends DynamicSelectionsTableModel<OAuthToken> {
     @Override
     protected List<OAuthToken> getSourceList(SectionInfo info) {
       return oauthService.listAllTokens();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/oauth/service/OAuthWebServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/oauth/service/OAuthWebServiceImpl.java
@@ -366,7 +366,7 @@ public class OAuthWebServiceImpl implements OAuthWebService, DeleteOAuthTokensEv
     }
   }
 
-  private static class CodeReg implements Serializable {
+  private static final class CodeReg implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String clientId;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/editor/tabs/ClientScriptTab.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/editor/tabs/ClientScriptTab.java
@@ -256,7 +256,7 @@ public class ClientScriptTab extends AbstractScriptingTab<ClientScriptTab.Client
     return javascriptTable;
   }
 
-  private class JavascriptTableModel extends DynamicSelectionsTableModel<String> {
+  private final class JavascriptTableModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       return javascriptFileList.getListModel().getValues(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/editor/tabs/FreemarkerTab.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/portal/standard/editor/tabs/FreemarkerTab.java
@@ -244,7 +244,7 @@ public class FreemarkerTab extends AbstractScriptingTab<FreemarkerTab.Freemarker
     return cssTable;
   }
 
-  private class CssTableModel extends DynamicSelectionsTableModel<String> {
+  private final class CssTableModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       return cssFileList.getListModel().getValues(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/raw/servlet/UserConfigurableServlet.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/raw/servlet/UserConfigurableServlet.java
@@ -81,7 +81,7 @@ public class UserConfigurableServlet extends HttpServlet {
     }
   }
 
-  private class CacheLoader implements Callable<String> {
+  private final class CacheLoader implements Callable<String> {
     private long lastMod;
     private String lastContent = NO_CONTENT;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/resources/AnnotatedResourceHelperScanner.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/resources/AnnotatedResourceHelperScanner.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AnnotatedResourceHelperScanner {
-  private static class ResourceData {
+  private static final class ResourceData {
     Field field;
     Class<?> clazz;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/guice/SectionsEquellaModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/guice/SectionsEquellaModule.java
@@ -72,7 +72,7 @@ public class SectionsEquellaModule extends SectionsModule {
     }
   }
 
-  private static class PluginModule extends PluginTrackerModule {
+  private static final class PluginModule extends PluginTrackerModule {
     @Override
     protected String getPluginId() {
       return "com.tle.web.sections.equella";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/layout/InnerLayout.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/sections/equella/layout/InnerLayout.java
@@ -116,7 +116,7 @@ public class InnerLayout implements LayoutSelector {
     getLayoutSelectorsObj(info).addLayoutSelector(selector);
   }
 
-  private static class LayoutSelectors {
+  private static final class LayoutSelectors {
     private final Set<LayoutSelector> selectors = new LinkedHashSet<LayoutSelector>();
 
     public void addLayoutSelector(LayoutSelector layoutSelector) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/selection/guice/SelectionModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/selection/guice/SelectionModule.java
@@ -60,7 +60,7 @@ public class SelectionModule extends SectionsModule {
     return node;
   }
 
-  private static class TrackerModule extends PluginTrackerModule {
+  private static final class TrackerModule extends PluginTrackerModule {
     @Override
     protected String getPluginId() {
       return "com.tle.web.selection";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/shortcuturls/RootShortcutUrlsSettingsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/shortcuturls/RootShortcutUrlsSettingsSection.java
@@ -137,7 +137,7 @@ public class RootShortcutUrlsSettingsSection extends OneColumnLayout<ShortcutUrl
     return ShortcutUrlsSettingsModel.class;
   }
 
-  private class ShortcutURLModel extends DynamicSelectionsTableModel<Pair<String, String>> {
+  private final class ShortcutURLModel extends DynamicSelectionsTableModel<Pair<String, String>> {
     @Override
     protected List<Pair<String, String>> getSourceList(SectionInfo info) {
       List<Pair<String, String>> shortcutUrls = Lists.newArrayList();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/userdetails/EditUserSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/userdetails/EditUserSection.java
@@ -291,7 +291,7 @@ public class EditUserSection extends TwoColumnLayout<EditUserSection.EditUserMod
     }
   }
 
-  private class DateFormatModel extends DynamicHtmlListModel<NameValue> {
+  private final class DateFormatModel extends DynamicHtmlListModel<NameValue> {
     @Override
     protected Iterable<NameValue> populateModel(SectionInfo info) {
       List<NameValue> values = new ArrayList<NameValue>();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/sharing/ShareWithOthersContentSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/sharing/ShareWithOthersContentSection.java
@@ -247,7 +247,7 @@ public class ShareWithOthersContentSection extends AbstractShareWithOthersSectio
     iinfo.modify(workflowFactory.modifyNotifications(new HashSet<String>(userIds)));
   }
 
-  private class OthersTableModel extends DynamicSelectionsTableModel<String> {
+  private final class OthersTableModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected Collection<String> getSourceList(SectionInfo info) {
       return ParentViewItemSectionUtils.getItemInfo(info).getItem().getNotifications();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/content/ChangeOwnershipContentSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/content/ChangeOwnershipContentSection.java
@@ -295,7 +295,7 @@ public class ChangeOwnershipContentSection
     return ChangeOwnershipModel.class;
   }
 
-  private class OwnerTableModel extends DynamicSelectionsTableModel<String> {
+  private final class OwnerTableModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       final ItemSectionInfo iinfo = ParentViewItemSectionUtils.getItemInfo(info);
@@ -320,7 +320,7 @@ public class ChangeOwnershipContentSection
     }
   }
 
-  private class CollabTableModel extends DynamicSelectionsTableModel<String> {
+  private final class CollabTableModel extends DynamicSelectionsTableModel<String> {
     @Override
     protected List<String> getSourceList(SectionInfo info) {
       final ItemSectionInfo iinfo = ParentViewItemSectionUtils.getItemInfo(info);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/module/ViewItemSummaryModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/module/ViewItemSummaryModule.java
@@ -174,7 +174,7 @@ public class ViewItemSummaryModule extends SectionsModule {
     return node;
   }
 
-  private static class TrackerModule extends PluginTrackerModule {
+  private static final class TrackerModule extends PluginTrackerModule {
     @Override
     protected String getPluginId() {
       return "com.tle.web.viewitem.summary";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/guice/WizardModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/guice/WizardModule.java
@@ -90,7 +90,7 @@ public class WizardModule extends SectionsModule {
     }
   }
 
-  private static class WizardTracker extends PluginTrackerModule {
+  private static final class WizardTracker extends PluginTrackerModule {
     @Override
     protected String getPluginId() {
       return "com.tle.web.wizard";

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/standard/controls/ShuffleList.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/standard/controls/ShuffleList.java
@@ -157,7 +157,7 @@ public class ShuffleList extends AbstractWebControl<WebControlModel> implements 
     return WebControlModel.class;
   }
 
-  private class ListModel extends StringListModel {
+  private final class ListModel extends StringListModel {
     @Override
     public List<Option<String>> getOptions(SectionInfo info) {
       List<Option<String>> opts = new ArrayList<Option<String>>();

--- a/Source/Plugins/Core/com.equella.core/test/java/com/tle/web/sections/equella/js/ObjectExpressionDeserialiserTest.java
+++ b/Source/Plugins/Core/com.equella.core/test/java/com/tle/web/sections/equella/js/ObjectExpressionDeserialiserTest.java
@@ -99,7 +99,7 @@ public class ObjectExpressionDeserialiserTest extends TestCase {
     }
   }
 
-  private static class FakePluginService implements PluginService {
+  private static final class FakePluginService implements PluginService {
 
     @Override
     public PluginBeanLocator getBeanLocator(String pluginId) {

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/ExtendedAnnotationConfiguration.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/ExtendedAnnotationConfiguration.java
@@ -51,7 +51,7 @@ public class ExtendedAnnotationConfiguration extends Configuration {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ExtendedAnnotationConfiguration.class);
 
-  private static class MetadataCapture implements Integrator {
+  private static final class MetadataCapture implements Integrator {
     private Metadata metadata;
     private final Map<String, Table> systemTables = new HashMap<>();
 

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/guice/TransactionModule.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/guice/TransactionModule.java
@@ -67,7 +67,7 @@ public class TransactionModule extends AbstractModule {
     return systemInterceptor;
   }
 
-  private static class TransactionMethodMatcher extends AbstractMatcher<Method> {
+  private static final class TransactionMethodMatcher extends AbstractMatcher<Method> {
     @Override
     public boolean matches(Method t) {
       return !t.isSynthetic() && t.isAnnotationPresent(Transactional.class);

--- a/Source/Plugins/Platform/com.tle.platform.swing/src/com/dytech/gui/flatter/FlatterSpinnerUI.java
+++ b/Source/Plugins/Platform/com.tle.platform.swing/src/com/dytech/gui/flatter/FlatterSpinnerUI.java
@@ -648,7 +648,7 @@ public class FlatterSpinnerUI extends SpinnerUI {
    * A simple layout manager for the editor and the next/previous buttons. See the BasicSpinnerUI
    * javadoc for more information about exactly how the components are arranged.
    */
-  private static class SpinnerLayout implements LayoutManager {
+  private static final class SpinnerLayout implements LayoutManager {
     private Component nextButton = null;
     private Component previousButton = null;
     private Component editor = null;
@@ -761,7 +761,7 @@ public class FlatterSpinnerUI extends SpinnerUI {
    * createPropertyChangeListener) since all of the interesting property changes are delegated to
    * protected methods.
    */
-  private static class PropertyChangeHandler implements PropertyChangeListener {
+  private static final class PropertyChangeHandler implements PropertyChangeListener {
     @Override
     public void propertyChange(PropertyChangeEvent e) {
       String propertyName = e.getPropertyName();

--- a/Source/Tools/Cacher/src/com/dytech/edge/cache/Service.java
+++ b/Source/Tools/Cacher/src/com/dytech/edge/cache/Service.java
@@ -365,7 +365,7 @@ public class Service extends Thread {
    *
    * @author Nicholas Read
    */
-  private static class NobodyCaresAboutThisOutputStream extends OutputStream {
+  private static final class NobodyCaresAboutThisOutputStream extends OutputStream {
     @Override
     public void write(int b) {
       // Nobody cares
@@ -387,7 +387,7 @@ public class Service extends Thread {
    *
    * @author Nicholas Read
    */
-  private class MyHandler implements WgetConnectionHandler {
+  private final class MyHandler implements WgetConnectionHandler {
     @Override
     public void connectionMade(URLConnection connection) {
       if (connection instanceof HttpURLConnection) {

--- a/autotest/OAuthRedirector/src/com/tle/oauthserver/OAuthRedirectorServlet.java
+++ b/autotest/OAuthRedirector/src/com/tle/oauthserver/OAuthRedirectorServlet.java
@@ -169,7 +169,7 @@ public class OAuthRedirectorServlet extends HttpServlet {
     }
   }
 
-  private static class TestInfo {
+  private static final class TestInfo {
     public String clientId;
     public String clientSecret;
     public String equellaUrl;

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/PreparingDriverPool.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/PreparingDriverPool.java
@@ -60,7 +60,7 @@ public class PreparingDriverPool implements WebDriverPool {
     driverPool.releaseDriver(checkedout);
   }
 
-  private static class PerThreadData {
+  private static final class PerThreadData {
     WebDriverCheckout checkedout;
     WebDriverCheckout preferred;
     boolean invalid;

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/MimeTypeApiTest.java
@@ -55,7 +55,7 @@ public class MimeTypeApiTest extends AbstractRestApiTest {
   }
 
   // Mirror of com.tle.web.api.settings.MimeTypeDetail
-  private static class MimeTypeDetail {
+  private static final class MimeTypeDetail {
 
     private String mimeType = null;
     private String desc = null;

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/UserQueryApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/UserQueryApiTest.java
@@ -100,7 +100,7 @@ public class UserQueryApiTest extends AbstractRestApiTest {
   }
 
   // Mirror of com.tle.web.api.users.UserDetails
-  private static class UserDetails {
+  private static final class UserDetails {
 
     private String id;
     private String username;

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/DynamicUrlPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/DynamicUrlPage.java
@@ -1,6 +1,6 @@
 package com.tle.webtests.pageobject;
 
-public class DynamicUrlPage<T extends PageObject> extends AbstractPage<T> {
+public final class DynamicUrlPage<T extends PageObject> extends AbstractPage<T> {
   private AbstractPage<? extends T> targetPage;
   private String url;
 

--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ checkJavaCodeStyle := {
     streams = streams.value
   )
   val errorNumber     = countErrorNumber
-  val thresholdNumber = 569
+  val thresholdNumber = 520
   if (errorNumber > thresholdNumber) {
     throw new MessageOnlyException(
       "Checkstyle error threshold (" + thresholdNumber + ") exceeded with error count of " + errorNumber)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -55,4 +55,4 @@ libraryDependencies ++= Seq(
   "org.slf4j"              % "slf4j-nop"             % "2.0.7",
   "com.yahoo.platform.yui" % "yuicompressor"         % "2.4.8"
 )
-dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "10.12.1"
+dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "10.12.2"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

Since checkstyle fixed bug `FinalClassCheck should report private classes without constructor` https://checkstyle.sourceforge.io/releasenotes.html

I fix all `final` errors, and I think it might make sense to decrease the threshold number to 520, because the current error number is 519.

1. Add the `final` keyword for those private classes according to the checkstyle report.
2. Also add `final` keyword for some public classes according to the checkstyle report.
3. Update threshold number.

Fix #4762.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
