### PR TITLE
fix: xalan xalan 2.7.3

### DIFF
--- a/Source/Plugins/RemoteRepositories/com.equella.z3950/build.sbt
+++ b/Source/Plugins/RemoteRepositories/com.equella.z3950/build.sbt
@@ -1,8 +1,9 @@
 lazy val Z3950         = config("z3950") describedAs ("Z3950 jars")
 lazy val CustomCompile = config("compile") extend Z3950
 
-libraryDependencies += "com.github.equella.legacy" % "z3950" % "1.1"   % Z3950
-libraryDependencies += "xalan"                     % "xalan" % "2.7.3" % Z3950
+libraryDependencies += "com.github.equella.legacy" % "z3950"      % "1.1"   % Z3950
+libraryDependencies += "xalan"                     % "xalan"      % "2.7.3" % Z3950
+libraryDependencies += "xalan"                     % "serializer" % "2.7.3" % Z3950
 
 excludeDependencies := Seq(
   "commons-collections" % "commons-collections",

--- a/Source/Plugins/RemoteRepositories/com.equella.z3950/build.sbt
+++ b/Source/Plugins/RemoteRepositories/com.equella.z3950/build.sbt
@@ -2,7 +2,7 @@ lazy val Z3950         = config("z3950") describedAs ("Z3950 jars")
 lazy val CustomCompile = config("compile") extend Z3950
 
 libraryDependencies += "com.github.equella.legacy" % "z3950" % "1.1"   % Z3950
-libraryDependencies += "xalan"                     % "xalan" % "2.7.2" % Z3950
+libraryDependencies += "xalan"                     % "xalan" % "2.7.3" % Z3950
 
 excludeDependencies := Seq(
   "commons-collections" % "commons-collections",

--- a/autotest/Tests/build.sbt
+++ b/autotest/Tests/build.sbt
@@ -27,6 +27,7 @@ libraryDependencies ++= Seq(
   "org.easytesting"           % "fest-util"                 % "1.2.5",
   "org.easytesting"           % "fest-swing"                % "1.2.1",
   "xalan"                     % "xalan"                     % "2.7.3",
+  "xalan"                     % "serializer"                % "2.7.3",
   "org.apache.cxf"            % "cxf-rt-frontend-simple"    % cxfVersion,
   "org.apache.cxf"            % "cxf-rt-databinding-aegis"  % cxfVersion,
   "org.apache.cxf"            % "cxf-rt-transports-http"    % cxfVersion,

--- a/autotest/Tests/build.sbt
+++ b/autotest/Tests/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "org.seleniumhq.selenium"   % "selenium-java"             % "3.141.59",
   "org.easytesting"           % "fest-util"                 % "1.2.5",
   "org.easytesting"           % "fest-swing"                % "1.2.1",
-  "xalan"                     % "xalan"                     % "2.7.2",
+  "xalan"                     % "xalan"                     % "2.7.3",
   "org.apache.cxf"            % "cxf-rt-frontend-simple"    % cxfVersion,
   "org.apache.cxf"            % "cxf-rt-databinding-aegis"  % cxfVersion,
   "org.apache.cxf"            % "cxf-rt-transports-http"    % cxfVersion,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
To fix #4719.

Add new dep serializer.

Found this solution from https://stackoverflow.com/questions/76555759/java-lang-classnotfoundexception-org-apache-xml-serializer-outputpropertiesfact.

But the release note didn't mention it, except this sentence is related to serializer: 

![image](https://github.com/openequella/openEQUELLA/assets/92769668/db703a16-5190-4c08-a0ca-7abef209ac6a)


https://xalan.apache.org/xalan-j/index.html#current
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
