### PR TITLE
chore(deps): update dependency typescript to v5

### DIFF
--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -29,7 +29,7 @@
         "purescript": "0.12.3",
         "shelljs": "0.8.5",
         "tar": "6.1.15",
-        "typescript": "4.9.5"
+        "typescript": "5.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11691,16 +11691,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/umd": {
@@ -21641,9 +21641,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "umd": {

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -27,7 +27,7 @@
     "parcel-bundler": "1.12.5",
     "pulp": "16.0.2",
     "purescript": "0.12.3",
-    "typescript": "4.9.5",
+    "typescript": "5.2.2",
     "follow-redirects": "1.15.2",
     "tar": "6.1.15",
     "shelljs": "0.8.5"

--- a/autotest/IntegTester/ps/tsconfig.json
+++ b/autotest/IntegTester/ps/tsconfig.json
@@ -16,7 +16,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "baseUrl": "."

--- a/oeq-ts-rest-api/gen-io-ts/package-lock.json
+++ b/oeq-ts-rest-api/gen-io-ts/package-lock.json
@@ -19,7 +19,7 @@
         "newtype-ts": "0.3.5",
         "ts-morph": "17.0.1",
         "ts-node": "10.9.1",
-        "typescript": "4.9.5",
+        "typescript": "5.2.2",
         "yargs": "17.7.2"
       }
     },
@@ -671,16 +671,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -1230,9 +1230,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "v8-compile-cache-lib": {

--- a/oeq-ts-rest-api/gen-io-ts/package.json
+++ b/oeq-ts-rest-api/gen-io-ts/package.json
@@ -12,7 +12,7 @@
     "@types/yargs": "17.0.24",
     "ts-morph": "17.0.1",
     "ts-node": "10.9.1",
-    "typescript": "4.9.5",
+    "typescript": "5.2.2",
     "yargs": "17.7.2",
     "fp-ts": "2.16.1",
     "io-ts": "2.2.20",

--- a/oeq-ts-rest-api/package-lock.json
+++ b/oeq-ts-rest-api/package-lock.json
@@ -42,7 +42,7 @@
         "rollup-plugin-typescript2": "0.35.0",
         "ts-jest": "29.1.1",
         "tslib": "2.6.2",
-        "typescript": "4.9.5"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "16.20.2",
@@ -5279,16 +5279,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {
@@ -9330,9 +9330,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "universalify": {

--- a/oeq-ts-rest-api/package.json
+++ b/oeq-ts-rest-api/package.json
@@ -62,6 +62,6 @@
     "rollup-plugin-typescript2": "0.35.0",
     "ts-jest": "29.1.1",
     "tslib": "2.6.2",
-    "typescript": "4.9.5"
+    "typescript": "5.2.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "remark-cli": "11.0.0",
         "remark-lint-no-dead-urls": "1.1.0",
         "remark-validate-links": "12.1.1",
-        "typescript": "4.9.5"
+        "typescript": "5.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -12513,16 +12513,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -22434,9 +22434,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "remark-cli": "11.0.0",
     "remark-lint-no-dead-urls": "1.1.0",
     "remark-validate-links": "12.1.1",
-    "typescript": "4.9.5"
+    "typescript": "5.2.2"
   },
   "commitlint": {
     "extends": [

--- a/react-front-end/package-lock.json
+++ b/react-front-end/package-lock.json
@@ -87,7 +87,7 @@
         "parcel-bundler": "1.12.5",
         "rewire": "6.0.0",
         "ts-jest": "29.1.1",
-        "typescript": "4.9.5"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "16.20.2",
@@ -132,7 +132,7 @@
         "rollup-plugin-typescript2": "0.35.0",
         "ts-jest": "29.1.1",
         "tslib": "2.6.2",
-        "typescript": "4.9.5"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "16.20.2",
@@ -31137,16 +31137,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {
@@ -35585,7 +35585,7 @@
         "tough-cookie": "^4.0.0",
         "ts-jest": "29.1.1",
         "tslib": "2.6.2",
-        "typescript": "4.9.5"
+        "typescript": "5.2.2"
       },
       "dependencies": {
         "@ampproject/remapping": {
@@ -54382,9 +54382,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "uglify-js": {

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -111,6 +111,6 @@
     "parcel-bundler": "1.12.5",
     "rewire": "6.0.0",
     "ts-jest": "29.1.1",
-    "typescript": "4.9.5"
+    "typescript": "5.2.2"
   }
 }

--- a/react-front-end/tsrc/mainui/Template.tsx
+++ b/react-front-end/tsrc/mainui/Template.tsx
@@ -381,18 +381,17 @@ export const Template = ({
     serverSide: boolean,
     text: string
   ) {
-    const props = serverSide
-      ? {
-          component: "a",
-          href: link as string,
-          sx: { textDecoration: "none !important" },
-        }
-      : {
-          component: Link,
-          to: link,
-        };
     return (
-      <MenuItem onClick={() => setMenuAnchorEl(undefined)} {...props}>
+      <MenuItem
+        onClick={() => setMenuAnchorEl(undefined)}
+        component={(p: React.AnchorHTMLAttributes<HTMLAnchorElement>) =>
+          serverSide ? (
+            <a {...p} href={link as string} />
+          ) : (
+            <Link {...p} to={link} />
+          )
+        }
+      >
         {text}
       </MenuItem>
     );

--- a/react-front-end/tsrc/mainui/Template.tsx
+++ b/react-front-end/tsrc/mainui/Template.tsx
@@ -381,13 +381,19 @@ export const Template = ({
     serverSide: boolean,
     text: string
   ) {
+    const props = serverSide
+      ? {
+          component: "a",
+          href: link as string,
+          sx: { textDecoration: "none !important" },
+        }
+      : {
+          component: Link,
+          to: link,
+        };
     return (
-      <MenuItem onClick={() => setMenuAnchorEl(undefined)}>
-        {serverSide ? (
-          <a href={link as string}>{text}</a>
-        ) : (
-          <Link to={link}>{text}</Link>
-        )}
+      <MenuItem onClick={() => setMenuAnchorEl(undefined)} {...props}>
+        {text}
       </MenuItem>
     );
   }

--- a/react-front-end/tsrc/mainui/Template.tsx
+++ b/react-front-end/tsrc/mainui/Template.tsx
@@ -386,7 +386,9 @@ export const Template = ({
         onClick={() => setMenuAnchorEl(undefined)}
         component={(p: React.AnchorHTMLAttributes<HTMLAnchorElement>) =>
           serverSide ? (
-            <a {...p} href={link as string} />
+            <a {...p} href={link as string}>
+              {}
+            </a>
           ) : (
             <Link {...p} to={link} />
           )

--- a/react-front-end/tsrc/mainui/Template.tsx
+++ b/react-front-end/tsrc/mainui/Template.tsx
@@ -382,19 +382,12 @@ export const Template = ({
     text: string
   ) {
     return (
-      <MenuItem
-        onClick={() => setMenuAnchorEl(undefined)}
-        component={(p) =>
-          serverSide ? (
-            <a {...p} href={link as string}>
-              {}
-            </a>
-          ) : (
-            <Link {...p} to={link} />
-          )
-        }
-      >
-        {text}
+      <MenuItem onClick={() => setMenuAnchorEl(undefined)}>
+        {serverSide ? (
+          <a href={link as string}>{text}</a>
+        ) : (
+          <Link to={link}>{text}</Link>
+        )}
       </MenuItem>
     );
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
To fix #4870.

But note it has a warning:

```
 npm run check:ts

> check:ts
> eslint ${npm_package_config_typescript_glob}

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.2.0

YOUR TYPESCRIPT VERSION: 5.2.2

Please only submit bug reports when using the officially supported version.

=============

```


<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
