### PR TITLE
chore(deps): update dependency tinymce to v6.7.0

### DIFF
--- a/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/autotest/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -67,7 +67,7 @@ case class LoginNoticePage(ctx: PageContext)
   }
 
   def setPreLoginNoticeWithImageURL(imgURL: String): Unit = {
-    clearAndPopulatePreNoticeField("Image Test: ")
+    clearAndPopulatePreNoticeField("Image Test:")
     switchFromTinyMCEIFrame()
     preNoticeAddImageButton.click()
     waitFor(ExpectedConditions.visibilityOf(preNoticeAddImagePopup))

--- a/oeq-ts-rest-api/src/Errors.ts
+++ b/oeq-ts-rest-api/src/Errors.ts
@@ -26,10 +26,7 @@ export interface ErrorResponse {
 }
 
 export class ApiError extends Error {
-  constructor(
-    message: string,
-    public status?: number
-  ) {
+  constructor(message: string, public status?: number) {
     super(message);
     this.status = status;
   }

--- a/oeq-ts-rest-api/src/Errors.ts
+++ b/oeq-ts-rest-api/src/Errors.ts
@@ -26,7 +26,10 @@ export interface ErrorResponse {
 }
 
 export class ApiError extends Error {
-  constructor(message: string, public status?: number) {
+  constructor(
+    message: string,
+    public status?: number
+  ) {
     super(message);
     this.status = status;
   }

--- a/react-front-end/package-lock.json
+++ b/react-front-end/package-lock.json
@@ -43,7 +43,7 @@
         "runtypes": "6.7.0",
         "shallow-equal-object": "1.1.1",
         "sprintf-js": "1.1.2",
-        "tinymce": "6.3.1",
+        "tinymce": "6.7.0",
         "uuid": "9.0.0",
         "wicked-good-xpath": "1.3.0"
       },
@@ -30666,8 +30666,9 @@
       }
     },
     "node_modules/tinymce": {
-      "version": "6.3.1",
-      "license": "MIT"
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.0.tgz",
+      "integrity": "sha512-Wf2RSobIXQ7XNw3/v4z1lPGiH3Pjsmc/6/7fG28aIS6uVWj/7IhvOPuwfJJDeOx0o0D3nSnoLHgR2KU8JAdE+w=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -54082,7 +54083,9 @@
       "version": "1.4.2"
     },
     "tinymce": {
-      "version": "6.3.1"
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.0.tgz",
+      "integrity": "sha512-Wf2RSobIXQ7XNw3/v4z1lPGiH3Pjsmc/6/7fG28aIS6uVWj/7IhvOPuwfJJDeOx0o0D3nSnoLHgR2KU8JAdE+w=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -66,7 +66,7 @@
     "runtypes": "6.7.0",
     "shallow-equal-object": "1.1.1",
     "sprintf-js": "1.1.2",
-    "tinymce": "6.3.1",
+    "tinymce": "6.7.0",
     "uuid": "9.0.0",
     "wicked-good-xpath": "1.3.0"
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
To fix #4839.

Looks like TinyMCE changed the encode for trailing space from `&nbsp` to `&#xFEFF`, so I just removed the last space form the text.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
