### PR TITLE
chore(deps): loading error handler from the parent instead of defining by itself

### DIFF
--- a/react-front-end/tsrc/settings/SchemaSelector.tsx
+++ b/react-front-end/tsrc/settings/SchemaSelector.tsx
@@ -23,8 +23,7 @@ import {
   Select,
 } from "@mui/material";
 import * as React from "react";
-import { ReactElement, useContext } from "react";
-import { AppContext } from "../mainui/App";
+import { ReactElement } from "react";
 import {
   schemaListSummary,
   SchemaNode,
@@ -39,6 +38,12 @@ interface SchemaSelectorProps {
    * @param node  Path of the selected node.
    */
   setSchemaNode: (node: string) => void;
+
+  /**
+   * Define how to handle error
+   * @param error  Error data.
+   */
+  handleError: (error: string | Error) => void;
 }
 
 const strings =
@@ -49,14 +54,16 @@ const strings =
  * When a schema is selected, it will display that schema within a SchemaNodeSelector.
  *
  */
-export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
+export default function SchemaSelector({
+  setSchemaNode,
+  handleError,
+}: SchemaSelectorProps) {
   const [selectedSchema, setSelectedSchema] = React.useState<
     string | undefined
   >(undefined);
   const [schema, setSchema] = React.useState<SchemaNode>();
   const [schemaList, setSchemaList] = React.useState<ReactElement[]>([]);
   const [schemaNodePath, setSchemaNodePath] = React.useState<string>("");
-  const { appErrorHandler } = useContext(AppContext);
 
   React.useEffect(() => {
     const buildSchemaList = (schemas: Map<string, string>) => {
@@ -73,18 +80,18 @@ export default function SchemaSelector({ setSchemaNode }: SchemaSelectorProps) {
       .then((schemas) => {
         setSchemaList(buildSchemaList(schemas));
       })
-      .catch(appErrorHandler);
-  }, [appErrorHandler]);
+      .catch(handleError);
+  }, [handleError]);
 
   React.useEffect(() => {
     if (selectedSchema?.trim()) {
       schemaTree(selectedSchema)
         .then((tree) => setSchema(tree))
-        .catch(appErrorHandler);
+        .catch(handleError);
     } else {
       setSchema(undefined);
     }
-  }, [selectedSchema, appErrorHandler]);
+  }, [selectedSchema, handleError]);
 
   React.useEffect(() => {
     if (schemaNodePath?.trim()) {

--- a/react-front-end/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
+++ b/react-front-end/tsrc/settings/Search/facetedsearch/FacetDialog.tsx
@@ -51,6 +51,10 @@ export interface FacetDialogProps {
     maxResults: number | undefined
   ) => void;
   /**
+   * Define how to handle error
+   */
+  handleError: (error: string | Error) => void;
+  /**
    * The facet to be edited; undefined if the action is to add a new one.
    */
   facet?: FacetedSearchClassificationWithFlags;
@@ -59,7 +63,13 @@ export interface FacetDialogProps {
 /**
  * A dialog for adding/editing a facet
  */
-const FacetDialog = ({ open, onClose, addOrEdit, facet }: FacetDialogProps) => {
+const FacetDialog = ({
+  open,
+  handleError,
+  onClose,
+  addOrEdit,
+  facet
+}: FacetDialogProps) => {
   const { facetedsearchsetting: facetedSearchSettingStrings } =
     languageStrings.settings.searching;
   const { facetfields: facetFieldStrings } = facetedSearchSettingStrings;
@@ -135,6 +145,7 @@ const FacetDialog = ({ open, onClose, addOrEdit, facet }: FacetDialogProps) => {
           variant="standard"
         />
         <SchemaSelector
+          handleError={handleError}
           setSchemaNode={(node) => {
             setSchemaNode(node.replace("/xml", ""));
           }}

--- a/react-front-end/tsrc/settings/Search/facetedsearch/FacetedSearchSettingsPage.tsx
+++ b/react-front-end/tsrc/settings/Search/facetedsearch/FacetedSearchSettingsPage.tsx
@@ -299,6 +299,7 @@ const FacetedSearchSettingsPage = ({ updateTemplate }: TemplateUpdateProps) => {
       </Card>
 
       <FacetDialog
+        handleError={appErrorHandler}
         addOrEdit={addOrEdit}
         open={showEditingDialog}
         onClose={() => setShowEditingDialog(false)}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->
This is a small enhancement. The parent component `FacetDialog` should define how to handle the error, and then its child `SchemaSelector` should call it as required. It follows: https://github.com/openequella/openEQUELLA/issues/2635

I have tested Faceted Seach Settings. There are no errors after applying this change.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
