### PR TITLE
ci(github): bump java to 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,11 +53,11 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 21
 
       - name: Install node dependencies (oeq-rest-api)
         working-directory: oeq-ts-rest-api
@@ -179,28 +179,6 @@ jobs:
           name: Storybook
           path: react-front-end/storybook.tar
 
-  build_import_export_tool:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Build
-        working-directory: import-export-tool
-        run: |
-          ./gradlew build
-
-      - name: Save primary artefacts
-        uses: actions/upload-artifact@v3.1.3
-        with:
-          name: ImportExportTools
-          path: import-export-tool/build/libs/
-
   functional_testing:
     needs: build_and_check
 
@@ -244,11 +222,11 @@ jobs:
             ffmpeg \
             libimage-exiftool-perl
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 21
 
       - uses: actions/checkout@v4
 
@@ -369,11 +347,11 @@ jobs:
             ffmpeg \
             libimage-exiftool-perl
 
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 21
 
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

With the move to Java 21 building (and running) we need to update the GitHub CI setup as well.

Included in this is to stop building the import-export tool, as that's not supported. See  import-export-tool/README.md.
<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
