### PR TITLE
OEQ-1811 - fix(selectUser test): remove findElement

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/pages/advancedsearch/NewAdvancedSearchPage.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/pages/advancedsearch/NewAdvancedSearchPage.java
@@ -150,7 +150,7 @@ public class NewAdvancedSearchPage extends NewSearchPage {
     WebElement targetUser =
         waiter.until(
             ExpectedConditions.elementToBeClickable(
-                dialog.findElement(By.xpath(".//span[text()='" + username + "']"))));
+                By.xpath("//div[@role='dialog']//span[text()='" + username + "']")));
     targetUser.click();
 
     // Confirm the selection.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

I think the issue is when you input query in the user selector dialog, the result won't be rendered in the dom immediately, which causes the `findElement` to fail. 

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
