### PR TITLE
fix: testRecentPortal

### DIFF
--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/portal/RecentContributionsSection.java
@@ -16,7 +16,6 @@ public class RecentContributionsSection extends AbstractPortalSection<RecentCont
             ".//div[normalize-space(@class)='recent-items']//a[normalize-space(text())="
                 + quoteXPath(itemName)
                 + "]");
-    waiter.until(ExpectedConditions.visibilityOfElementLocated(recentContributionXpath));
     return isPresent(recentContributionXpath);
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
I think this is flaky because when a user contributes an item, even though the front end returns a success message, the back end has not yet saved the data properly.

Therefore, the solution is to use a custom waiter to continuously load the page to determine whether the item has been successfully created.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
