### PR TITLE
fix: OAuthClientEditorTest fails with latest Chrome

### DIFF
--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/oauth/OAuthClientEditorPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/oauth/OAuthClientEditorPage.java
@@ -6,7 +6,7 @@ import com.tle.webtests.pageobject.WaitingPageObject;
 import com.tle.webtests.pageobject.generic.component.EquellaSelect;
 import com.tle.webtests.pageobject.generic.component.SelectUserDialog;
 import java.util.List;
-import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -156,10 +156,9 @@ public class OAuthClientEditorPage extends AbstractPage<OAuthClientEditorPage> {
   private boolean isControlInvalid(WebElement we, String selector) {
     List<WebElement> invalidControls =
         driver.findElements(By.xpath("//div[@class='control ctrlinvalid']"));
-
+    final String elementId = we.getAttribute("id");
     for (WebElement control : invalidControls) {
-      if (!Objects.equals(we.getAttribute("id"), "")
-          && isPresent(control, By.id(we.getAttribute("id")))) {
+      if (StringUtils.isNotEmpty(elementId) && isPresent(control, By.id(elementId))) {
         return true;
       }
       if (selector != null && isPresent(control, By.xpath(selector))) {

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/oauth/OAuthClientEditorPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/oauth/OAuthClientEditorPage.java
@@ -6,6 +6,7 @@ import com.tle.webtests.pageobject.WaitingPageObject;
 import com.tle.webtests.pageobject.generic.component.EquellaSelect;
 import com.tle.webtests.pageobject.generic.component.SelectUserDialog;
 import java.util.List;
+import java.util.Objects;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -157,7 +158,8 @@ public class OAuthClientEditorPage extends AbstractPage<OAuthClientEditorPage> {
         driver.findElements(By.xpath("//div[@class='control ctrlinvalid']"));
 
     for (WebElement control : invalidControls) {
-      if (isPresent(control, By.id(we.getAttribute("id")))) {
+      if (!Objects.equals(we.getAttribute("id"), "")
+          && isPresent(control, By.id(we.getAttribute("id")))) {
         return true;
       }
       if (selector != null && isPresent(control, By.xpath(selector))) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [x] tests are included

##### Description of change
- I've added a condition on OAuthClientEditorTest to check WebElement get attribute by id not empty based on the below condition of this test.
- The issue by when we send the empty string into the find element of Selenium Webdriver it will show an error when we send the empty string. But in the latest Chrome maybe Selenium Webdriver doesn't support the latest version.

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/node/676
[commit guidelines]: https://chris.beams.io/posts/git-commit/
