### PR TITLE
build(ci): pin ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build_and_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -129,7 +129,7 @@ jobs:
           path: artefacts.tar
 
   build_storybook:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Using v1 (rather than v2) through-out this workflow due to issue:
       # https://github.com/actions/checkout/issues/237
@@ -182,7 +182,7 @@ jobs:
   functional_testing:
     needs: build_and_check
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -314,7 +314,7 @@ jobs:
   rest-module-testing:
     needs: build_and_check
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       postgres:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

A recent upgrade of ubuntu-latest to Ubuntu 24 (https://github.com/actions/runner-images/issues/10636) caused a lot of issues in the community (due to missing tooling etc) and we also saw an increase in failures of a new type. As a result, just like we pin our other dependencies we should really do the same here.

Hopefully renovate will also manage it for us.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
