### PR TITLE
fix: FileAttachmentControlTest specialCharacters test

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/attachments/FileAttachmentControlTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/attachments/FileAttachmentControlTest.java
@@ -124,6 +124,7 @@ public class FileAttachmentControlTest extends AbstractCleanupAutoTest {
     String FILE3_NEW = "Special characters - <script> %test3+.zip";
     String FILE4 = "Special characters - #& test4.html";
 
+    // Test
     String rename = "<script>alert('fail')</script>";
 
     String itemName = context.getFullName("Special characters");

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/attachments/FileAttachmentControlTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/controls/attachments/FileAttachmentControlTest.java
@@ -124,7 +124,6 @@ public class FileAttachmentControlTest extends AbstractCleanupAutoTest {
     String FILE3_NEW = "Special characters - <script> %test3+.zip";
     String FILE4 = "Special characters - #& test4.html";
 
-    // Test
     String rename = "<script>alert('fail')</script>";
 
     String itemName = context.getFullName("Special characters");

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
@@ -557,5 +557,5 @@ public abstract class AbstractPage<T extends PageObject>
    */
   public void forceButtonClickWithJS(WebElement button) {
     ((JavascriptExecutor) driver).executeScript("arguments[0].click();", button);
-  };
+  }
 }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/AbstractPage.java
@@ -548,4 +548,14 @@ public abstract class AbstractPage<T extends PageObject>
     String tab = new ArrayList<>(driver.getWindowHandles()).get(tabIndex);
     driver.switchTo().window(tab);
   }
+
+  /**
+   * Force click on a button using JavaScript. This is useful when the button can't be clicked by
+   * calling webElement.click() function due to some unknown reasons.
+   *
+   * @param button WebElement to be clicked.
+   */
+  public void forceButtonClickWithJS(WebElement button) {
+    ((JavascriptExecutor) driver).executeScript("arguments[0].click();", button);
+  };
 }

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -94,7 +94,9 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
   }
 
   private void clickAction(By rowBy, String action) {
-    driver.findElement(getFullBy(new ByChained(rowBy, getActionLink(action)))).click();
+    WebElement button = driver.findElement(getFullBy(new ByChained(rowBy, getActionLink(action))));
+    waiter.until(ExpectedConditions.elementToBeClickable(button));
+    button.click();
   }
 
   public <P extends AttachmentEditPage, T extends AttachmentType<T, P>> P editResource(

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -9,6 +9,7 @@ import com.tle.webtests.pageobject.wizard.controls.universal.AttachmentType;
 import com.tle.webtests.pageobject.wizard.controls.universal.PickAttachmentTypeDialog;
 import java.util.List;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ByChained;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -98,7 +99,7 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
         waiter.until(
             ExpectedConditions.elementToBeClickable(
                 getFullBy(new ByChained(rowBy, getActionLink(action)))));
-    button.click();
+    ((JavascriptExecutor) driver).executeScript("arguments[0].click();", button);
   }
 
   public <P extends AttachmentEditPage, T extends AttachmentType<T, P>> P editResource(

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -9,7 +9,6 @@ import com.tle.webtests.pageobject.wizard.controls.universal.AttachmentType;
 import com.tle.webtests.pageobject.wizard.controls.universal.PickAttachmentTypeDialog;
 import java.util.List;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ByChained;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -99,7 +98,8 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
         waiter.until(
             ExpectedConditions.elementToBeClickable(
                 getFullBy(new ByChained(rowBy, getActionLink(action)))));
-    ((JavascriptExecutor) driver).executeScript("arguments[0].click();", button);
+    // button.click() will raise intercepted error in GitHub CI, use JS to click the button.
+    forceButtonClickWithJS(button);
   }
 
   public <P extends AttachmentEditPage, T extends AttachmentType<T, P>> P editResource(

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -94,8 +94,10 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
   }
 
   private void clickAction(By rowBy, String action) {
-    WebElement button = driver.findElement(getFullBy(new ByChained(rowBy, getActionLink(action))));
-    waiter.until(ExpectedConditions.elementToBeClickable(button));
+    WebElement button =
+        waiter.until(
+            ExpectedConditions.elementToBeClickable(
+                getFullBy(new ByChained(rowBy, getActionLink(action)))));
     button.click();
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker:
https://github.com/openequella/openEQUELLA/issues

Contributors guide: https://github.com/openequella/openEQUELLA/blob/develop/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change
According to the log, click of the Edit button is intercepted.

Pretty sure the button is clickable, but the error still happened, so I use JS to click the button.
<!--
Provide a description of the change below this comment. Please include a reference to the GitHub
issue here (not in the title) so as to utilise automatic linking.
-->

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
