### PR TITLE
Fix SearchResultTemplateTest

### DIFF
--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -47,7 +47,9 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
   }
 
   public <T extends AttachmentType<T, ?>> T addDefaultResource(T type) {
-    getAddResourceButton().click();
+    WebElement addResourceButton =
+        waiter.until(ExpectedConditions.elementToBeClickable(getAddResourceButton()));
+    addResourceButton.click();
     return type.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -9,7 +9,6 @@ import com.tle.webtests.pageobject.wizard.controls.universal.AttachmentType;
 import com.tle.webtests.pageobject.wizard.controls.universal.PickAttachmentTypeDialog;
 import java.util.List;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ByChained;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -50,7 +49,7 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
   public <T extends AttachmentType<T, ?>> T addDefaultResource(T type) {
     WebElement addResourceButton =
         waiter.until(ExpectedConditions.elementToBeClickable(getAddResourceButton()));
-    ((JavascriptExecutor) driver).executeScript("arguments[0].click();", addResourceButton);
+    forceButtonClickWithJS(addResourceButton);
     return type.get();
   }
 

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/controls/UniversalControl.java
@@ -9,6 +9,7 @@ import com.tle.webtests.pageobject.wizard.controls.universal.AttachmentType;
 import com.tle.webtests.pageobject.wizard.controls.universal.PickAttachmentTypeDialog;
 import java.util.List;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ByChained;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -49,7 +50,7 @@ public class UniversalControl extends NewAbstractWizardControl<UniversalControl>
   public <T extends AttachmentType<T, ?>> T addDefaultResource(T type) {
     WebElement addResourceButton =
         waiter.until(ExpectedConditions.elementToBeClickable(getAddResourceButton()));
-    addResourceButton.click();
+    ((JavascriptExecutor) driver).executeScript("arguments[0].click();", addResourceButton);
     return type.get();
   }
 


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

According to the log, click of the Add Resource button is intercepted by the ul above the button. Both are parts of the Attachment control which is a React component but used in the Legacty UI.
I guess  when the button is visible and the test is about to click it, the list is not yet. However, when the click happens, the list becomes visible and is displayed in where the button was (and the button is moved down to below the list).
So the first potential fix is to add a wait of element being clickable to the button.

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
