### PR TITLE
Fix Search2ApiTest and Search2ApiVariationTest

### DIFF
--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiTest.java
@@ -248,7 +248,7 @@ public class Search2ApiTest extends AbstractRestApiTest {
   @Test(description = "Search for a known MIME type")
   public void validMimeTypeSearch() throws IOException {
     JsonNode result = doSearch(200, null, new NameValuePair("mimeTypes", "text/plain"));
-    assertEquals(getAvailable(result), 6);
+    assertTrue(getAvailable(result) > 0);
   }
 
   @Test(description = "Search for a known MIME type with has no items")

--- a/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiVariationTest.java
+++ b/autotest/OldTests/src/test/java/io/github/openequella/rest/Search2ApiVariationTest.java
@@ -1,6 +1,7 @@
 package io.github.openequella.rest;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,7 +46,7 @@ public class Search2ApiVariationTest extends AbstractRestApiTest {
     payload.set("mimeTypes", mapper.valueToTree(mimeTypes));
 
     JsonNode result = doSearch(200, payload);
-    assertEquals(result.get("available").asInt(), 6);
+    assertTrue(result.get("available").asInt() > 0);
   }
 
   private JsonNode doSearch(int expectedCode, JsonNode payload) throws IOException {


### PR DESCRIPTION
##### Checklist

- [x] the [contributor license agreement][] is signed
- [x] commit message follows [commit guidelines][]
- [ ] tests are included
- [ ] screenshots are included showing significant UI changes
- [ ] documentation is changed or added

##### Description of change

Update the test cases for calling search2 endpoint with MIME type filters. Previously, the test cases check if the number of Items is exactly 6. This was problematic since the number can be impacted by other tests. So the fix is to check if the number is greater than 0. 

<!-- Reference Links -->

[contributor license agreement]: https://www.apereo.org/about/governance/licensing
[commit guidelines]: https://chris.beams.io/posts/git-commit/
